### PR TITLE
Added a CLI command to list Metapath functions

### DIFF
--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/FunctionLibrary.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/FunctionLibrary.java
@@ -89,7 +89,7 @@ public class FunctionLibrary implements IFunctionLibrary {
   }
 
   @Override
-  public Stream<IFunction> getFunctionsAsStream() {
+  public Stream<IFunction> stream() {
     synchronized (this) {
       return ObjectUtils.notNull(libraryByQName.values().stream().flatMap(NamedFunctionSet::getFunctionsAsStream));
     }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/FunctionService.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/FunctionService.java
@@ -31,6 +31,7 @@ import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
 import java.util.ServiceLoader;
 import java.util.ServiceLoader.Provider;
+import java.util.stream.Stream;
 
 import javax.xml.namespace.QName;
 
@@ -64,7 +65,7 @@ public final class FunctionService {
     FunctionLibrary functionLibrary = new FunctionLibrary();
     loader.stream()
         .map(Provider<IFunctionLibrary>::get)
-        .flatMap(IFunctionLibrary::getFunctionsAsStream)
+        .flatMap(IFunctionLibrary::stream)
         .forEachOrdered(function -> functionLibrary.registerFunction(ObjectUtils.notNull(function)));
     this.library = functionLibrary;
   }
@@ -77,6 +78,10 @@ public final class FunctionService {
   @NonNull
   private ServiceLoader<IFunctionLibrary> getLoader() {
     return loader;
+  }
+
+  public Stream<IFunction> stream() {
+    return this.library.stream();
   }
 
   /**

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/IFunction.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/IFunction.java
@@ -231,7 +231,7 @@ public interface IFunction {
     return ObjectUtils.notNull(String.format("Q{%s}%s(%s) as %s",
         getNamespace(),
         getName(),
-        getArguments().isEmpty() ? "()"
+        getArguments().isEmpty() ? ""
             : getArguments().stream().map(IArgument::toSignature).collect(Collectors.joining(","))
                 + (isArityUnbounded() ? ", ..." : ""),
         getResult().toSignature()));

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/IFunctionLibrary.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/IFunctionLibrary.java
@@ -40,7 +40,7 @@ public interface IFunctionLibrary {
    * @return a stream of function signatures
    */
   @NonNull
-  Stream<IFunction> getFunctionsAsStream();
+  Stream<IFunction> stream();
 
   /**
    * Determine if there is a function with the provided name that supports the

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/IBoundLoader.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/IBoundLoader.java
@@ -523,4 +523,72 @@ public interface IBoundLoader extends IDocumentLoader, IMutableConfiguration<Des
     ISerializer<CLASS> serializer = getBindingContext().newSerializer(toFormat, rootClass);
     serializer.serialize(object, os);
   }
+
+  /**
+   * Auto convert the provided {@code source} to the provided {@code toFormat}.
+   * Write the converted content to the provided {@code destination}.
+   * <p>
+   * The format of the source is expected to be auto detected using
+   * {@link #detectFormat(Path)}.
+   *
+   * @param <CLASS>
+   *          the Java type to load data into
+   * @param source
+   *          the resource to convert
+   * @param destination
+   *          the resource to write converted content to
+   * @param toFormat
+   *          the format to convert to
+   * @param rootClass
+   *          the class for the Java type to load data into
+   * @throws FileNotFoundException
+   *           the the provided source file was not found
+   * @throws IOException
+   *           if an error occurred while loading the data from the specified
+   *           resource or writing the converted data to the specified destination
+   */
+  default <CLASS> void convert(
+      @NonNull URI source,
+      @NonNull Path destination,
+      @NonNull Format toFormat,
+      @NonNull Class<CLASS> rootClass) throws FileNotFoundException, IOException {
+    CLASS object = load(rootClass, source);
+
+    ISerializer<CLASS> serializer = getBindingContext().newSerializer(toFormat, rootClass);
+    serializer.serialize(object, destination);
+  }
+
+  /**
+   * Auto convert the provided {@code source} to the provided {@code toFormat}.
+   * Write the converted content to the provided {@code destination}.
+   * <p>
+   * The format of the source is expected to be auto detected using
+   * {@link #detectFormat(Path)}.
+   *
+   * @param <CLASS>
+   *          the Java type to load data into
+   * @param source
+   *          the resource to convert
+   * @param os
+   *          the output stream to write converted content to
+   * @param toFormat
+   *          the format to convert to
+   * @param rootClass
+   *          the class for the Java type to load data into
+   * @throws FileNotFoundException
+   *           the the provided source file was not found
+   * @throws IOException
+   *           if an error occurred while loading the data from the specified
+   *           resource or writing the converted data to the specified destination
+   */
+  default <CLASS> void convert(
+      @NonNull URI source,
+      @NonNull OutputStream os,
+      @NonNull Format toFormat,
+      @NonNull Class<CLASS> rootClass) throws FileNotFoundException, IOException {
+    CLASS object = load(rootClass, source);
+
+    ISerializer<CLASS> serializer = getBindingContext().newSerializer(toFormat, rootClass);
+    serializer.serialize(object, os);
+  }
 }

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/CLI.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/CLI.java
@@ -29,6 +29,7 @@ package gov.nist.secauto.metaschema.cli;
 import gov.nist.secauto.metaschema.cli.commands.GenerateSchemaCommand;
 import gov.nist.secauto.metaschema.cli.commands.ValidateContentUsingModuleCommand;
 import gov.nist.secauto.metaschema.cli.commands.ValidateModuleCommand;
+import gov.nist.secauto.metaschema.cli.commands.metapath.MetapathCommand;
 import gov.nist.secauto.metaschema.cli.processor.CLIProcessor;
 import gov.nist.secauto.metaschema.cli.processor.ExitStatus;
 import gov.nist.secauto.metaschema.cli.processor.command.CommandService;
@@ -59,6 +60,7 @@ public final class CLI {
     processor.addCommandHandler(new ValidateModuleCommand());
     processor.addCommandHandler(new GenerateSchemaCommand());
     processor.addCommandHandler(new ValidateContentUsingModuleCommand());
+    processor.addCommandHandler(new MetapathCommand());
 
     CommandService.getInstance().getCommands().stream().forEach(command -> {
       assert command != null;

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractValidateContentCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractValidateContentCommand.java
@@ -80,7 +80,7 @@ public abstract class AbstractValidateContentCommand
   private static final String COMMAND = "validate";
   @NonNull
   private static final List<ExtraArgument> EXTRA_ARGUMENTS = ObjectUtils.notNull(List.of(
-      new DefaultExtraArgument("file to validate", true)));
+      new DefaultExtraArgument("file-or-URI-to-validate", true)));
 
   @NonNull
   private static final Option AS_OPTION = ObjectUtils.notNull(
@@ -189,7 +189,7 @@ public abstract class AbstractValidateContentCommand
       IBoundLoader loader = bindingContext.newBoundLoader();
 
       List<String> extraArgs = cmdLine.getArgList();
-      // @SuppressWarnings("null")
+
       String sourceName = extraArgs.get(0);
       URI source;
 

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/GenerateSchemaCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/GenerateSchemaCommand.java
@@ -99,7 +99,7 @@ public class GenerateSchemaCommand
 
   static {
     EXTRA_ARGUMENTS = ObjectUtils.notNull(List.of(
-        new DefaultExtraArgument("metaschema-module-file", true),
+        new DefaultExtraArgument("metaschema-module-file-or-URL", true),
         new DefaultExtraArgument("destination-schema-file", false)));
   }
 
@@ -166,7 +166,6 @@ public class GenerateSchemaCommand
       @NonNull CallingContext callingContext,
       @NonNull CommandLine cmdLine) {
     List<String> extraArgs = cmdLine.getArgList();
-    URI cwd = Paths.get("").toAbsolutePath().toUri();
 
     Path destination = null;
     if (extraArgs.size() > 1) {
@@ -212,6 +211,7 @@ public class GenerateSchemaCommand
 
     URI input;
     String inputName = extraArgs.get(0);
+    URI cwd = Paths.get("").toAbsolutePath().toUri();
 
     try {
       input = UriUtils.toUri(extraArgs.get(0), cwd);

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/MetaschemaCommands.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/MetaschemaCommands.java
@@ -24,46 +24,21 @@
  * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
  */
 
-package gov.nist.secauto.metaschema.cli;
+package gov.nist.secauto.metaschema.cli.commands;
 
-import gov.nist.secauto.metaschema.cli.commands.MetaschemaCommands;
-import gov.nist.secauto.metaschema.cli.processor.CLIProcessor;
-import gov.nist.secauto.metaschema.cli.processor.ExitStatus;
-import gov.nist.secauto.metaschema.cli.processor.command.CommandService;
-import gov.nist.secauto.metaschema.core.MetaschemaJavaVersion;
-import gov.nist.secauto.metaschema.core.model.MetaschemaVersion;
-import gov.nist.secauto.metaschema.core.util.IVersionInfo;
-import gov.nist.secauto.metaschema.core.util.ObjectUtils;
+import gov.nist.secauto.metaschema.cli.commands.metapath.MetapathCommand;
+import gov.nist.secauto.metaschema.cli.processor.command.ICommand;
 
 import java.util.List;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
+public class MetaschemaCommands {
+  public static final List<ICommand> COMMANDS = List.of(
+      new ValidateModuleCommand(),
+      new GenerateSchemaCommand(),
+      new ValidateContentUsingModuleCommand(),
+      new MetapathCommand());
 
-@SuppressWarnings("PMD.ShortClassName")
-public final class CLI {
-  public static void main(String[] args) {
-    System.exit(runCli(args).getExitCode().getStatusCode());
-  }
-
-  @NonNull
-  public static ExitStatus runCli(String... args) {
-    System.setProperty("java.util.logging.manager", "org.apache.logging.log4j.jul.LogManager");
-
-    List<IVersionInfo> versions = ObjectUtils.notNull(
-        List.of(
-            new MetaschemaJavaVersion(),
-            new MetaschemaVersion()));
-    CLIProcessor processor = new CLIProcessor("metaschema-cli", versions);
-    MetaschemaCommands.COMMANDS.forEach(processor::addCommandHandler);
-
-    CommandService.getInstance().getCommands().stream().forEach(command -> {
-      assert command != null;
-      processor.addCommandHandler(command);
-    });
-    return processor.process(args);
-  }
-
-  private CLI() {
+  private MetaschemaCommands() {
     // disable construction
   }
 }

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/MetaschemaCommands.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/MetaschemaCommands.java
@@ -31,7 +31,7 @@ import gov.nist.secauto.metaschema.cli.processor.command.ICommand;
 
 import java.util.List;
 
-public class MetaschemaCommands {
+public final class MetaschemaCommands {
   public static final List<ICommand> COMMANDS = List.of(
       new ValidateModuleCommand(),
       new GenerateSchemaCommand(),

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/metapath/ListFunctionsSubcommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/metapath/ListFunctionsSubcommand.java
@@ -1,0 +1,132 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.cli.commands.metapath;
+
+import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
+import gov.nist.secauto.metaschema.cli.processor.ExitCode;
+import gov.nist.secauto.metaschema.cli.processor.ExitStatus;
+import gov.nist.secauto.metaschema.cli.processor.command.AbstractTerminalCommand;
+import gov.nist.secauto.metaschema.cli.processor.command.ICommandExecutor;
+import gov.nist.secauto.metaschema.core.metapath.StaticContext;
+import gov.nist.secauto.metaschema.core.metapath.function.FunctionService;
+import gov.nist.secauto.metaschema.core.metapath.function.IArgument;
+import gov.nist.secauto.metaschema.core.metapath.function.IFunction;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public class ListFunctionsSubcommand
+    extends AbstractTerminalCommand {
+  private static final Logger LOGGER = LogManager.getLogger(ListFunctionsSubcommand.class);
+
+  @NonNull
+  private static final String COMMAND = "list-functions";
+
+  @Override
+  public String getName() {
+    return COMMAND;
+  }
+
+  @Override
+  public String getDescription() {
+    return "Get a listing of supported Metapath functions";
+  }
+
+  @Override
+  public ICommandExecutor newExecutor(CallingContext callingContext, CommandLine cmdLine) {
+    return ICommandExecutor.using(callingContext, cmdLine, this::executeCommand);
+  }
+
+  @SuppressWarnings({
+      "PMD.OnlyOneReturn", // readability
+      "unused"
+  })
+  protected ExitStatus executeCommand(
+      @NonNull CallingContext callingContext,
+      @NonNull CommandLine cmdLine) {
+
+    Map<String, Map<String, List<IFunction>>> namespaceToNameToFunctionMap = FunctionService.getInstance().stream()
+        .collect(Collectors.groupingBy(
+            IFunction::getNamespace,
+            Collectors.groupingBy(
+                IFunction::getName,
+                Collectors.toList())));
+
+    Map<String, String> namespaceToPrefixMap = StaticContext.getWellKnownNamespaces().entrySet().stream()
+        .collect(Collectors.toMap(entry -> entry.getValue().toASCIIString(), Map.Entry::getKey));
+
+    List<String> namespaces = new ArrayList<>(namespaceToNameToFunctionMap.keySet());
+
+    Collections.sort(namespaces);
+
+    for (String namespace : namespaces) {
+      String prefix = namespaceToPrefixMap.get(namespace);
+
+      if (prefix == null) {
+        LOGGER.atInfo().log("In namespace '{}':", namespace);
+      } else {
+        LOGGER.atInfo().log("In namespace '{}' as '{}':", namespace, prefix);
+      }
+
+      Map<String, List<IFunction>> namespacedFunctions = namespaceToNameToFunctionMap.get(namespace);
+
+      List<String> names = new ArrayList<>(namespacedFunctions.keySet());
+      Collections.sort(names);
+
+      for (String name : names) {
+        List<IFunction> functions = namespacedFunctions.get(name);
+        Collections.sort(functions, Comparator.comparing(IFunction::arity));
+
+        for (IFunction function : functions) {
+          String functionRef = prefix == null
+              ? String.format("Q{%s}%s", function.getNamespace(), function.getName())
+              : String.format("%s:%s", prefix, function.getName());
+
+          LOGGER.atInfo().log(String.format("%s(%s) as %s",
+              functionRef,
+              function.getArguments().isEmpty()
+                  ? ""
+                  : function.getArguments().stream().map(IArgument::toSignature)
+                      .collect(Collectors.joining(","))
+                      + (function.isArityUnbounded() ? ", ..." : ""),
+              function.getResult().toSignature()));
+        }
+      }
+    }
+    return ExitCode.OK.exit();
+  }
+}

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/metapath/MetapathCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/metapath/MetapathCommand.java
@@ -1,0 +1,49 @@
+/*
+ * Portions of this software was developed by employees of the National Institute
+ * of Standards and Technology (NIST), an agency of the Federal Government and is
+ * being made available as a public service. Pursuant to title 17 United States
+ * Code Section 105, works of NIST employees are not subject to copyright
+ * protection in the United States. This software may be subject to foreign
+ * copyright. Permission in the United States and in foreign countries, to the
+ * extent that NIST may hold copyright, to use, copy, modify, create derivative
+ * works, and distribute this software and its documentation without fee is hereby
+ * granted on a non-exclusive basis, provided that this notice and disclaimer
+ * of warranty appears in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
+ * EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTY
+ * THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM FROM
+ * INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO THE
+ * SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE.  IN NO EVENT
+ * SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT,
+ * INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM,
+ * OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+ * CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY PERSONS OR
+ * PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED FROM, OR AROSE OUT
+ * OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR SERVICES PROVIDED HEREUNDER.
+ */
+
+package gov.nist.secauto.metaschema.cli.commands.metapath;
+
+import gov.nist.secauto.metaschema.cli.processor.command.AbstractParentCommand;
+
+public class MetapathCommand
+    extends AbstractParentCommand {
+  private static final String COMMAND = "metapath";
+
+  public MetapathCommand() {
+    super(true);
+    addCommandHandler(new ListFunctionsSubcommand());
+  }
+
+  @Override
+  public String getName() {
+    return COMMAND;
+  }
+
+  @Override
+  public String getDescription() {
+    return "Perform a Metapath operation.";
+  }
+}

--- a/metaschema-cli/src/test/java/gov/nist/secauto/metaschema/cli/CLITest.java
+++ b/metaschema-cli/src/test/java/gov/nist/secauto/metaschema/cli/CLITest.java
@@ -141,6 +141,9 @@ public class CLITest {
                 "--as=xml"
             },
             ExitCode.IO_ERROR, java.io.FileNotFoundException.class));
+        add(Arguments.of(
+            new String[] { "metapath", "list-functions" },
+            ExitCode.OK, NO_EXCEPTION_CLASS));
       }
     };
 


### PR DESCRIPTION
# Committer Notes

This adds a new CLI command `metaschema-cli metapath list-functions` that lists all supported functions and their signature.

Example output:

```
In namespace 'http://csrc.nist.gov/ns/metaschema':
Q{http://csrc.nist.gov/ns/metaschema}model(node as gov.nist.secauto.metaschema.core.metapath.item.node.INodeItem) as gov.nist.secauto.metaschema.core.metapath.item.node.INodeItem?
In namespace 'http://csrc.nist.gov/ns/metaschema/metapath':
Q{http://csrc.nist.gov/ns/metaschema/metapath}boolean(arg1 as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IBooleanItem?
Q{http://csrc.nist.gov/ns/metaschema/metapath}date(arg1 as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IDateItem?
Q{http://csrc.nist.gov/ns/metaschema/metapath}date-time(arg1 as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IDateTimeItem?
Q{http://csrc.nist.gov/ns/metaschema/metapath}decimal(arg1 as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IDecimalItem?
Q{http://csrc.nist.gov/ns/metaschema/metapath}duration(arg1 as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IDurationItem?
Q{http://csrc.nist.gov/ns/metaschema/metapath}integer(arg1 as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IIntegerItem?
Q{http://csrc.nist.gov/ns/metaschema/metapath}ncname(arg1 as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.INcNameItem?
Q{http://csrc.nist.gov/ns/metaschema/metapath}non-negative-integer(arg1 as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.INonNegativeIntegerItem?
Q{http://csrc.nist.gov/ns/metaschema/metapath}positive-integer(arg1 as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IPositiveIntegerItem?
Q{http://csrc.nist.gov/ns/metaschema/metapath}recurse-depth(recursePath as gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem) as gov.nist.secauto.metaschema.core.metapath.item.node.INodeItem*
Q{http://csrc.nist.gov/ns/metaschema/metapath}recurse-depth(context as gov.nist.secauto.metaschema.core.metapath.item.node.INodeItem*,recursePath as gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem) as gov.nist.secauto.metaschema.core.metapath.item.node.INodeItem*
Q{http://csrc.nist.gov/ns/metaschema/metapath}string(arg1 as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem?
In namespace 'http://csrc.nist.gov/ns/metaschema/metapath-functions' as 'mp':
mp:abs(arg as gov.nist.secauto.metaschema.core.metapath.item.atomic.INumericItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.INumericItem?
mp:avg(arg as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem*) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem?
mp:base-uri() as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyUriItem
mp:base-uri(arg1 as gov.nist.secauto.metaschema.core.metapath.item.node.INodeItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyUriItem
mp:boolean(arg as gov.nist.secauto.metaschema.core.metapath.item.IItem*) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IBooleanItem
mp:ceiling(arg as gov.nist.secauto.metaschema.core.metapath.item.atomic.INumericItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.INumericItem?
mp:compare(comparand1 as gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem?,comparand2 as gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IIntegerItem?
mp:concat(arg1 as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem?,arg2 as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem?, ...) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem
mp:count(arg as gov.nist.secauto.metaschema.core.metapath.item.IItem*) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IIntegerItem
mp:data() as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem
mp:data(arg1 as gov.nist.secauto.metaschema.core.metapath.item.IItem*) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem
mp:doc(arg1 as gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem?) as gov.nist.secauto.metaschema.core.metapath.item.node.IDocumentNodeItem
mp:document-uri() as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyUriItem
mp:document-uri(arg1 as gov.nist.secauto.metaschema.core.metapath.item.node.IDocumentNodeItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyUriItem
mp:empty(arg as gov.nist.secauto.metaschema.core.metapath.item.IItem*) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IBooleanItem
mp:exists(arg as gov.nist.secauto.metaschema.core.metapath.item.IItem*) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IBooleanItem
mp:false() as gov.nist.secauto.metaschema.core.metapath.item.atomic.IBooleanItem
mp:floor(arg1 as gov.nist.secauto.metaschema.core.metapath.item.atomic.INumericItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.INumericItem?
mp:head(arg as gov.nist.secauto.metaschema.core.metapath.item.IItem*) as gov.nist.secauto.metaschema.core.metapath.item.IItem?
mp:insert-before(target as gov.nist.secauto.metaschema.core.metapath.item.IItem*,position as gov.nist.secauto.metaschema.core.metapath.item.atomic.IIntegerItem,inserts as gov.nist.secauto.metaschema.core.metapath.item.IItem*) as gov.nist.secauto.metaschema.core.metapath.item.IItem*
mp:max(arg as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem*) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem?
mp:min(arg as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem*) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem?
mp:not(arg as gov.nist.secauto.metaschema.core.metapath.item.IItem*) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IBooleanItem
mp:path() as gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem?
mp:path(arg1 as gov.nist.secauto.metaschema.core.metapath.item.node.INodeItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem?
mp:remove(target as gov.nist.secauto.metaschema.core.metapath.item.IItem*,position as gov.nist.secauto.metaschema.core.metapath.item.atomic.IIntegerItem) as gov.nist.secauto.metaschema.core.metapath.item.IItem*
mp:resolve-uri(relative as gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyUriItem?
mp:resolve-uri(relative as gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem?,base as gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyUriItem?
mp:reverse(target as gov.nist.secauto.metaschema.core.metapath.item.IItem*) as gov.nist.secauto.metaschema.core.metapath.item.IItem*
mp:round(arg as gov.nist.secauto.metaschema.core.metapath.item.atomic.INumericItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.INumericItem?
mp:round(arg1 as gov.nist.secauto.metaschema.core.metapath.item.atomic.INumericItem?,precision as gov.nist.secauto.metaschema.core.metapath.item.atomic.IIntegerItem) as gov.nist.secauto.metaschema.core.metapath.item.atomic.INumericItem?
mp:starts-with(arg1 as gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem?,arg2 as gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IBooleanItem
mp:static-base-uri(arg1 as gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyUriItem
mp:sum(arg as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem*) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem
mp:sum(arg as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem*,zero as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem?
mp:tail(arg as gov.nist.secauto.metaschema.core.metapath.item.IItem*) as gov.nist.secauto.metaschema.core.metapath.item.IItem*
mp:true() as gov.nist.secauto.metaschema.core.metapath.item.atomic.IBooleanItem
In namespace 'http://csrc.nist.gov/ns/metaschema/metapath-functions/array' as 'array':
array:append(array as gov.nist.secauto.metaschema.core.metapath.item.function.IArrayItem,appendage as gov.nist.secauto.metaschema.core.metapath.item.IItem*) as gov.nist.secauto.metaschema.core.metapath.item.function.IArrayItem
array:flatten(input as gov.nist.secauto.metaschema.core.metapath.item.IItem*) as gov.nist.secauto.metaschema.core.metapath.item.IItem*
array:get(array as gov.nist.secauto.metaschema.core.metapath.item.function.IArrayItem,position as gov.nist.secauto.metaschema.core.metapath.item.atomic.IIntegerItem) as gov.nist.secauto.metaschema.core.metapath.item.IItem?
array:head(array as gov.nist.secauto.metaschema.core.metapath.item.function.IArrayItem) as gov.nist.secauto.metaschema.core.metapath.item.IItem?
array:insert-before(array as gov.nist.secauto.metaschema.core.metapath.item.function.IArrayItem,position as gov.nist.secauto.metaschema.core.metapath.item.atomic.IIntegerItem,member as gov.nist.secauto.metaschema.core.metapath.item.IItem*) as gov.nist.secauto.metaschema.core.metapath.item.function.IArrayItem
array:join(array as gov.nist.secauto.metaschema.core.metapath.item.function.IArrayItem*) as gov.nist.secauto.metaschema.core.metapath.item.IItem?
array:put(array as gov.nist.secauto.metaschema.core.metapath.item.function.IArrayItem,position as gov.nist.secauto.metaschema.core.metapath.item.atomic.IIntegerItem,member as gov.nist.secauto.metaschema.core.metapath.item.IItem*) as gov.nist.secauto.metaschema.core.metapath.item.function.IArrayItem
array:remove(array as gov.nist.secauto.metaschema.core.metapath.item.function.IArrayItem,positions as gov.nist.secauto.metaschema.core.metapath.item.atomic.IIntegerItem*) as gov.nist.secauto.metaschema.core.metapath.item.function.IArrayItem
array:reverse(array as gov.nist.secauto.metaschema.core.metapath.item.function.IArrayItem) as gov.nist.secauto.metaschema.core.metapath.item.function.IArrayItem
array:size(array as gov.nist.secauto.metaschema.core.metapath.item.function.IArrayItem) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IIntegerItem
array:subarray(array as gov.nist.secauto.metaschema.core.metapath.item.function.IArrayItem,start as gov.nist.secauto.metaschema.core.metapath.item.atomic.IIntegerItem) as gov.nist.secauto.metaschema.core.metapath.item.function.IArrayItem
array:subarray(array as gov.nist.secauto.metaschema.core.metapath.item.function.IArrayItem,start as gov.nist.secauto.metaschema.core.metapath.item.atomic.IIntegerItem,length as gov.nist.secauto.metaschema.core.metapath.item.atomic.IIntegerItem) as gov.nist.secauto.metaschema.core.metapath.item.function.IArrayItem
array:tail(array as gov.nist.secauto.metaschema.core.metapath.item.function.IArrayItem) as gov.nist.secauto.metaschema.core.metapath.item.IItem?
In namespace 'http://www.w3.org/2001/XMLSchema' as 'xs':
xs:NCName(arg1 as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.INcNameItem?
xs:boolean(arg1 as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IBooleanItem?
xs:date(arg1 as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IDateItem?
xs:dateTime(arg1 as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IDateTimeItem?
xs:decimal(arg1 as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IDecimalItem?
xs:duration(arg1 as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IDurationItem?
xs:integer(arg1 as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IIntegerItem?
xs:nonNegativeInteger(arg1 as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.INonNegativeIntegerItem?
xs:positiveInteger(arg1 as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IPositiveIntegerItem?
xs:string(arg1 as gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem?) as gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem?
```

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added methods for auto-converting resources to specified formats and writing content to a `Path` or `OutputStream`.
  - Introduced commands for Metapath operations and listing Metapath functions in the CLI.
  - Enhanced CLI with a comprehensive set of Metaschema commands for various operations, including validation and schema generation.

- **Improvements**
  - Updated CLI command handling to streamline command imports and execution.
  - Improved argument handling and descriptions for better clarity and usability.

- **Bug Fixes**
  - Refined method names and argument representations for consistency and readability.
  
- **Tests**
  - Added new test cases to ensure functionality for listing functions is robust and reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->