### PR TITLE
Ensure document node returns the root value

### DIFF
--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/DocumentNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/DocumentNodeItemImpl.java
@@ -75,4 +75,9 @@ class DocumentNodeItemImpl
   public ModelContainer getModel() {
     return model.get();
   }
+
+  @Override
+  public Object getValue() {
+    return getRootAssemblyNodeItem().getValue();
+  }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/IDocumentNodeItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/IDocumentNodeItem.java
@@ -38,7 +38,7 @@ import javax.xml.namespace.QName;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
-public interface IDocumentNodeItem extends INodeItem, IFeatureNoDataItem {
+public interface IDocumentNodeItem extends INodeItem {
   @Override
   default NodeItemType getNodeItemType() {
     return NodeItemType.DOCUMENT;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/IModuleNodeItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/IModuleNodeItem.java
@@ -41,7 +41,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * All definitions in the {@link ModuleScopeEnum#INHERITED} scope. This allows
  * the exported structure of the Metaschema module to be queried.
  */
-public interface IModuleNodeItem extends IDocumentNodeItem {
+public interface IModuleNodeItem extends IDocumentNodeItem, IFeatureNoDataItem {
 
   /**
    * The Metaschema module this item is based on.


### PR DESCRIPTION
# Committer Notes

This fixes usnistgov/oscal-cli#216 by ensuring that the document node returns the root node when getValue is called.

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a method to retrieve the value of the root assembly node item.

- **Refactor**
  - Modified inheritance structure to streamline interface implementations, potentially impacting behavior of document and module node items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->