### PR TITLE
Indicate a format's default and other extensions

### DIFF
--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/Format.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/Format.java
@@ -27,9 +27,9 @@
 package gov.nist.secauto.metaschema.databind.io;
 
 import gov.nist.secauto.metaschema.core.util.CollectionUtil;
-import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -45,20 +45,22 @@ public enum Format {
   /**
    * The <a href="https://www.w3.org/XML/">Extensible Markup Language</a> format.
    */
-  XML(Set.of(".xml")),
+  XML(".xml", Set.of()),
   /**
    * The <a href="https://www.json.org/">JavaScript Object Notation</a> format.
    */
-  JSON(Set.of(".json")),
+  JSON(".json", Set.of()),
   /**
    * The <a href="https://yaml.org/">YAML Ain't Markup Language</a> format.
    */
-  YAML(Set.of(".yml", ".yaml"));
+  YAML(".yaml", Set.of(".yml"));
 
   private static final List<String> NAMES;
 
   @NonNull
-  private final Set<String> defaultExtensions;
+  private final String defaultExtension;
+  @NonNull
+  private final Set<String> recognizedExtensions;
 
   static {
     NAMES = Arrays.stream(values())
@@ -76,8 +78,14 @@ public enum Format {
     return NAMES;
   }
 
-  Format(Set<String> defaultExtensions) {
-    this.defaultExtensions = CollectionUtil.unmodifiableSet(ObjectUtils.requireNonNull(defaultExtensions));
+  Format(@NonNull String defaultExtension, Set<String> otherExtensions) {
+    this.defaultExtension = defaultExtension;
+
+    Set<String> recognizedExtensions = new HashSet<>();
+    recognizedExtensions.add(defaultExtension);
+    recognizedExtensions.addAll(otherExtensions);
+
+    this.recognizedExtensions = CollectionUtil.unmodifiableSet(recognizedExtensions);
   }
 
   /**
@@ -86,7 +94,17 @@ public enum Format {
    * @return the default extension
    */
   @NonNull
-  public Set<String> getDefaultExtension() {
-    return defaultExtensions;
+  public Set<String> getRecognizedExtensions() {
+    return recognizedExtensions;
+  }
+
+  /**
+   * Get the default extension to use for the format.
+   *
+   * @return the default extension
+   */
+  @NonNull
+  public String getDefaultExtension() {
+    return defaultExtension;
   }
 }


### PR DESCRIPTION
# Committer Notes

Differentiate between default and other recognized extensions.

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved handling of file extensions in the `Format` module, making it easier to manage default and recognized extensions. 

- **Enhancements**
  - The `Format` enum now supports a single default extension and a set of recognized extensions, providing more flexibility and clarity in extension management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->