### PR TITLE
Adjusted UUID item type to be a child type of IStringItem to allow fa…

### DIFF
--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/IUuidItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/IUuidItem.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-public interface IUuidItem extends IAnyAtomicItem {
+public interface IUuidItem extends IStringItem {
 
   /**
    * Construct a new item using the provided {@code value}.
@@ -78,7 +78,7 @@ public interface IUuidItem extends IAnyAtomicItem {
   }
 
   @Override
-  default int compareTo(IAnyAtomicItem item) {
-    return compareTo(cast(item));
+  default int compareTo(IAnyAtomicItem other) {
+    return compareTo(other.asStringItem());
   }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/UuidItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/UuidItemImpl.java
@@ -36,6 +36,23 @@ class UuidItemImpl
     return new MapKey();
   }
 
+  @Override
+  public String asString() {
+    return asUuid().toString();
+  }
+
+  @Override
+  public int hashCode() {
+    return asString().hashCode();
+  }
+
+  @SuppressWarnings("PMD.OnlyOneReturn")
+  @Override
+  public boolean equals(Object obj) {
+    return this == obj
+        || (obj instanceof IStringItem && compareTo((IStringItem) obj) == 0);
+  }
+
   private final class MapKey implements IMapKey {
     @Override
     public IUuidItem getKey() {

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/IUUIDItemTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/IUUIDItemTest.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.item.atomic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+class IUuidItemTest {
+  private static Stream<Arguments> testCompare() { // NOPMD - false positive
+    UUID uuidRandom = UUID.randomUUID();
+    UUID uuid1 = UUID.fromString("4cfa2c52-9345-4012-8055-0bc9ac9b03fa");
+    UUID uuid2 = UUID.fromString("25a6d916-f179-4550-ad2b-7e7cd9df35d2");
+    String uuid2String = uuid2.toString();
+
+    return Stream.of(
+        Arguments.of(IUuidItem.valueOf(uuidRandom), IUuidItem.valueOf(uuidRandom), IIntegerItem.ZERO),
+        Arguments.of(IUuidItem.valueOf(uuid1), IUuidItem.valueOf(uuid2), IIntegerItem.valueOf(2)),
+        Arguments.of(IUuidItem.valueOf(uuid2), IStringItem.valueOf(uuid2String), IIntegerItem.ZERO),
+        Arguments.of(IStringItem.valueOf(uuid2String), IUuidItem.valueOf(uuid2), IIntegerItem.ZERO));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void testCompare(@NonNull IAnyAtomicItem left, @NonNull IAnyAtomicItem right, @NonNull IIntegerItem expectedResult) {
+    IIntegerItem result = IIntegerItem.valueOf(left.compareTo(right));
+    assertEquals(expectedResult, result);
+  }
+
+}


### PR DESCRIPTION
# Committer Notes

The issue identified by #101 was caused by improper comparison support for UUID item types. A UUID item should be compared as a string, but was unsupported for comparison, which resulted in an error being throw. This PR fixes that problem.

Resolves #101.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
