### PR TITLE
Implement fn:string Metapath function

### DIFF
--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/DefaultFunction.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/DefaultFunction.java
@@ -157,11 +157,11 @@ public class DefaultFunction
   @NonNull
   public static List<ISequence<?>> convertArguments(
       @NonNull IFunction function,
-      @NonNull List<ISequence<?>> parameters) {
+      @NonNull List<? extends ISequence<?>> parameters) {
     @NonNull List<ISequence<?>> retval = new ArrayList<>(parameters.size());
 
     Iterator<IArgument> argumentIterator = function.getArguments().iterator();
-    Iterator<ISequence<?>> parametersIterator = parameters.iterator();
+    Iterator<? extends ISequence<?>> parametersIterator = parameters.iterator();
 
     IArgument argument = null;
     while (parametersIterator.hasNext()) {
@@ -258,7 +258,7 @@ public class DefaultFunction
 
   @Override
   public ISequence<?> execute(
-      @NonNull List<ISequence<?>> arguments,
+      @NonNull List<? extends ISequence<?>> arguments,
       @NonNull DynamicContext dynamicContext,
       @NonNull ISequence<?> focus) {
     try {
@@ -270,7 +270,7 @@ public class DefaultFunction
       ISequence<?> result = null;
       if (isDeterministic()) {
         // check cache
-        callingContext = new CallingContext(arguments, contextItem);
+        callingContext = new CallingContext(convertedArguments, contextItem);
         // TODO: implement something like computeIfAbsent
         // attempt to get the result from the cache
         result = dynamicContext.getCachedResult(callingContext);

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/IFunction.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/IFunction.java
@@ -186,7 +186,7 @@ public interface IFunction {
    */
   @NonNull
   ISequence<?> execute(
-      @NonNull List<ISequence<?>> arguments,
+      @NonNull List<? extends ISequence<?>> arguments,
       @NonNull DynamicContext dynamicContext,
       @NonNull ISequence<?> focus);
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/InvalidTypeFunctionException.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/InvalidTypeFunctionException.java
@@ -28,6 +28,14 @@ public class InvalidTypeFunctionException
   public static final int NODE_HAS_NO_TYPED_VALUE = 12;
 
   /**
+   * <a href=
+   * "https://www.w3.org/TR/xpath-functions-31/#ERRFOTY0014">err:FOTY0014</a>:
+   * Raised by fn:string, or by implicit string conversion, if the input sequence
+   * contains a function item.
+   */
+  public static final int ARGUMENT_TO_STRING_IS_FUNCTION = 14;
+
+  /**
    * the serial version UUID.
    */
   private static final long serialVersionUID = 1L;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/DefaultFunctionLibrary.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/DefaultFunctionLibrary.java
@@ -47,7 +47,7 @@ public class DefaultFunctionLibrary
     registerFunction(FnCeiling.SIGNATURE);
     // https://www.w3.org/TR/xpath-functions-31/#func-compare
     registerFunction(FnCompare.SIGNATURE);
-    // P1: https://www.w3.org/TR/xpath-functions-31/#func-concat
+    // https://www.w3.org/TR/xpath-functions-31/#func-concat
     registerFunction(FnConcat.SIGNATURE);
     // P1: https://www.w3.org/TR/xpath-functions-31/#func-contains
     // https://www.w3.org/TR/xpath-functions-31/#func-count
@@ -79,7 +79,7 @@ public class DefaultFunctionLibrary
     registerFunction(FnExists.SIGNATURE);
     // https://www.w3.org/TR/xpath-functions-31/#func-false
     registerFunction(FnFalse.SIGNATURE);
-    // P1: https://www.w3.org/TR/xpath-functions-31/#func-floor
+    // https://www.w3.org/TR/xpath-functions-31/#func-floor
     registerFunction(NumericFunction.signature(MetapathConstants.NS_METAPATH_FUNCTIONS, "floor", INumericItem::floor));
     // P2: https://www.w3.org/TR/xpath-functions-31/#func-format-date
     // P2: https://www.w3.org/TR/xpath-functions-31/#func-format-dateTime
@@ -88,7 +88,7 @@ public class DefaultFunctionLibrary
     // P2: https://www.w3.org/TR/xpath-functions-31/#func-format-time
     // P1: https://www.w3.org/TR/xpath-functions-31/#func-generate-id
     // P2: https://www.w3.org/TR/xpath-functions-31/#func-has-children
-    // P1: https://www.w3.org/TR/xpath-functions-31/#func-head
+    // https://www.w3.org/TR/xpath-functions-31/#func-head
     registerFunction(FnHead.SIGNATURE);
     // https://www.w3.org/TR/xpath-functions-31/#func-hours-from-dateTime
     // https://www.w3.org/TR/xpath-functions-31/#func-hours-from-duration
@@ -96,7 +96,7 @@ public class DefaultFunctionLibrary
     // https://www.w3.org/TR/xpath-functions-31/#func-implicit-timezone
     // P1: https://www.w3.org/TR/xpath-functions-31/#func-index-of
     // https://www.w3.org/TR/xpath-functions-31/#func-innermost
-    // P1: https://www.w3.org/TR/xpath-functions-31/#func-insert-before
+    // https://www.w3.org/TR/xpath-functions-31/#func-insert-before
     registerFunction(FnInsertBefore.SIGNATURE);
     // https://www.w3.org/TR/xpath-functions-31/#func-iri-to-uri
     // P1: https://www.w3.org/TR/xpath-functions-31/#func-last
@@ -125,7 +125,7 @@ public class DefaultFunctionLibrary
     registerFunction(FnPath.SIGNATURE_NO_ARG);
     registerFunction(FnPath.SIGNATURE_ONE_ARG);
     // P2: https://www.w3.org/TR/xpath-functions-31/#func-position
-    // P1: https://www.w3.org/TR/xpath-functions-31/#func-remove
+    // https://www.w3.org/TR/xpath-functions-31/#func-remove
     registerFunction(FnRemove.SIGNATURE);
     // P1: https://www.w3.org/TR/xpath-functions-31/#func-replace
     // https://www.w3.org/TR/xpath-functions-31/#func-resolve-uri
@@ -157,7 +157,7 @@ public class DefaultFunctionLibrary
     // https://www.w3.org/TR/xpath-functions-31/#func-sum
     registerFunction(FnSum.SIGNATURE_ONE_ARG);
     registerFunction(FnSum.SIGNATURE_TWO_ARG);
-    // P1: https://www.w3.org/TR/xpath-functions-31/#func-tail
+    // https://www.w3.org/TR/xpath-functions-31/#func-tail
     registerFunction(FnTail.SIGNATURE);
     // https://www.w3.org/TR/xpath-functions-31/#func-timezone-from-date
     // https://www.w3.org/TR/xpath-functions-31/#func-timezone-from-dateTime

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/DefaultFunctionLibrary.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/DefaultFunctionLibrary.java
@@ -47,8 +47,8 @@ public class DefaultFunctionLibrary
     registerFunction(FnCeiling.SIGNATURE);
     // https://www.w3.org/TR/xpath-functions-31/#func-compare
     registerFunction(FnCompare.SIGNATURE);
-    registerFunction(FnConcat.SIGNATURE);
     // P1: https://www.w3.org/TR/xpath-functions-31/#func-concat
+    registerFunction(FnConcat.SIGNATURE);
     // P1: https://www.w3.org/TR/xpath-functions-31/#func-contains
     // https://www.w3.org/TR/xpath-functions-31/#func-count
     registerFunction(FnCount.SIGNATURE);
@@ -145,7 +145,9 @@ public class DefaultFunctionLibrary
     registerFunction(FnStartsWith.SIGNATURE);
     // https://www.w3.org/TR/xpath-functions-31/#func-static-base-uri
     registerFunction(FnStaticBaseUri.SIGNATURE);
-    // P0: https://www.w3.org/TR/xpath-functions-31/#func-string
+    // https://www.w3.org/TR/xpath-functions-31/#func-string
+    registerFunction(FnString.SIGNATURE_NO_ARG);
+    registerFunction(FnString.SIGNATURE_ONE_ARG);
     // P1: https://www.w3.org/TR/xpath-functions-31/#func-string-join
     // P1: https://www.w3.org/TR/xpath-functions-31/#func-string-length
     // P1: https://www.w3.org/TR/xpath-functions-31/#func-subsequence

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnString.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnString.java
@@ -25,7 +25,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Implements
- * <a href= "https://www.w3.org/TR/xpath-functions-31/#func-data">fn:data</a>.
+ * <a href= "https://www.w3.org/TR/xpath-functions-31/#func-string">fn:string</a>.
  */
 public final class FnString {
   @NonNull

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnString.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnString.java
@@ -1,0 +1,114 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.function.library;
+
+import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
+import gov.nist.secauto.metaschema.core.metapath.DynamicMetapathException;
+import gov.nist.secauto.metaschema.core.metapath.ISequence;
+import gov.nist.secauto.metaschema.core.metapath.MetapathConstants;
+import gov.nist.secauto.metaschema.core.metapath.function.FunctionUtils;
+import gov.nist.secauto.metaschema.core.metapath.function.IArgument;
+import gov.nist.secauto.metaschema.core.metapath.function.IFunction;
+import gov.nist.secauto.metaschema.core.metapath.function.InvalidTypeFunctionException;
+import gov.nist.secauto.metaschema.core.metapath.item.IItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
+import gov.nist.secauto.metaschema.core.metapath.item.node.INodeItem;
+import gov.nist.secauto.metaschema.core.util.ObjectUtils;
+
+import java.util.List;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Implements
+ * <a href= "https://www.w3.org/TR/xpath-functions-31/#func-data">fn:data</a>.
+ */
+public final class FnString {
+  @NonNull
+  static final IFunction SIGNATURE_NO_ARG = IFunction.builder()
+      .name("string")
+      .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
+      .deterministic()
+      .contextDependent()
+      .focusDependent()
+      .returnType(IStringItem.class)
+      .returnOne()
+      .functionHandler(FnString::executeNoArg)
+      .build();
+
+  @NonNull
+  static final IFunction SIGNATURE_ONE_ARG = IFunction.builder()
+      .name("string")
+      .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
+      .deterministic()
+      .contextIndependent()
+      .focusIndependent()
+      .argument(IArgument.builder()
+          .name("arg1")
+          .type(IItem.class)
+          .zeroOrOne()
+          .build())
+      .returnType(IStringItem.class)
+      .returnOne()
+      .functionHandler(FnString::executeOneArg)
+      .build();
+
+  private FnString() {
+    // disable construction
+  }
+
+  @SuppressWarnings("unused")
+  @NonNull
+  private static ISequence<IStringItem> executeNoArg(@NonNull IFunction function,
+      @NonNull List<ISequence<?>> arguments,
+      @NonNull DynamicContext dynamicContext,
+      IItem focus) {
+
+    ISequence<IAnyAtomicItem> retval;
+    if (focus == null) {
+      throw new DynamicMetapathException(DynamicMetapathException.DYNAMIC_CONTEXT_ABSENT, "The context is empty");
+    }
+
+    return ISequence.of(fnStringItem(focus));
+  }
+
+  @SuppressWarnings("unused")
+  @NonNull
+  private static ISequence<IStringItem> executeOneArg(
+      @NonNull IFunction function,
+      @NonNull List<ISequence<?>> arguments,
+      @NonNull DynamicContext dynamicContext,
+      IItem focus) {
+
+    ISequence<?> sequence = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(0)));
+
+    IItem first = sequence.getFirstItem(true);
+
+    return first == null ? ISequence.empty() : ISequence.of(fnStringItem(first));
+  }
+
+  /**
+   * An implementation of <a href=
+   * "https://www.w3.org/TR/xpath-functions-31/#func-string">fn::string</a>.
+   *
+   * @param item
+   *          the item to get the string value for
+   * @return the string value
+   */
+  @NonNull
+  public static IStringItem fnStringItem(@NonNull IItem item) {
+    IStringItem retval;
+    if (item instanceof INodeItem) {
+      retval = IStringItem.valueOf(((INodeItem) item).stringValue());
+    } else if (item instanceof IAnyAtomicItem) {
+      retval = ((IAnyAtomicItem) item).asStringItem();
+    } else {
+      throw new InvalidTypeFunctionException(InvalidTypeFunctionException.ARGUMENT_TO_STRING_IS_FUNCTION, item);
+    }
+    return retval;
+  }
+}

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/impl/AbstractArrayItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/impl/AbstractArrayItem.java
@@ -58,7 +58,7 @@ public abstract class AbstractArrayItem<ITEM extends ICollectionValue>
   }
 
   @Override
-  public ISequence<?> execute(List<ISequence<?>> arguments, DynamicContext dynamicContext,
+  public ISequence<?> execute(List<? extends ISequence<?>> arguments, DynamicContext dynamicContext,
       ISequence<?> focus) {
     ISequence<? extends IIntegerItem> arg = FunctionUtils.asType(
         ObjectUtils.notNull(arguments.get(0)));

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/impl/AbstractMapItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/impl/AbstractMapItem.java
@@ -60,7 +60,7 @@ public abstract class AbstractMapItem<VALUE extends ICollectionValue>
   }
 
   @Override
-  public ISequence<?> execute(List<ISequence<?>> arguments, DynamicContext dynamicContext,
+  public ISequence<?> execute(List<? extends ISequence<?>> arguments, DynamicContext dynamicContext,
       ISequence<?> focus) {
     ISequence<? extends IIntegerItem> arg = FunctionUtils.asType(
         ObjectUtils.notNull(arguments.get(0)));

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/IArrayItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/IArrayItem.java
@@ -104,7 +104,7 @@ public interface IArrayItem<ITEM extends ICollectionValue> extends IFunction, II
   }
 
   @Override
-  ISequence<?> execute(List<ISequence<?>> arguments, DynamicContext dynamicContext, ISequence<?> focus);
+  ISequence<?> execute(List<? extends ISequence<?>> arguments, DynamicContext dynamicContext, ISequence<?> focus);
 
   @Override
   default String toSignature() {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/IMapItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/IMapItem.java
@@ -94,7 +94,7 @@ public interface IMapItem<VALUE extends ICollectionValue>
   }
 
   @Override
-  ISequence<?> execute(List<ISequence<?>> arguments, DynamicContext dynamicContext, ISequence<?> focus);
+  ISequence<?> execute(List<? extends ISequence<?>> arguments, DynamicContext dynamicContext, ISequence<?> focus);
 
   @Override
   default String toSignature() {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AssemblyGlobalDefinitionNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AssemblyGlobalDefinitionNodeItemImpl.java
@@ -30,4 +30,9 @@ class AssemblyGlobalDefinitionNodeItemImpl
   public ModelContainer getModel() {
     return model.get();
   }
+
+  @Override
+  public String stringValue() {
+    return "";
+  }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AssemblyInstanceNoValueNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AssemblyInstanceNoValueNodeItemImpl.java
@@ -36,4 +36,9 @@ class AssemblyInstanceNoValueNodeItemImpl
   public int getPosition() {
     return 1;
   }
+
+  @Override
+  public String stringValue() {
+    return "";
+  }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AssemblyInstanceNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AssemblyInstanceNodeItemImpl.java
@@ -5,6 +5,8 @@ import gov.nist.secauto.metaschema.core.model.IAssemblyDefinition;
 import gov.nist.secauto.metaschema.core.model.IAssemblyInstance;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
+import java.util.stream.Collectors;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 import nl.talsmasoftware.lazy4j.Lazy;
 
@@ -50,5 +52,12 @@ class AssemblyInstanceNodeItemImpl
   @Override
   public Object getValue() {
     return value;
+  }
+
+  @Override
+  public String stringValue() {
+    return ObjectUtils.notNull(modelItems()
+        .map(INodeItem::stringValue)
+        .collect(Collectors.joining()));
   }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AssemblyOrphanedDefinitionDataNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AssemblyOrphanedDefinitionDataNodeItemImpl.java
@@ -6,6 +6,7 @@ import gov.nist.secauto.metaschema.core.model.IAssemblyInstance;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
 import java.net.URI;
+import java.util.stream.Collectors;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -41,5 +42,12 @@ class AssemblyOrphanedDefinitionDataNodeItemImpl
   @Override
   public Object getValue() {
     return value;
+  }
+
+  @Override
+  public String stringValue() {
+    return ObjectUtils.notNull(modelItems()
+        .map(INodeItem::stringValue)
+        .collect(Collectors.joining()));
   }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AssemblyOrphanedDefinitionNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AssemblyOrphanedDefinitionNodeItemImpl.java
@@ -33,4 +33,8 @@ class AssemblyOrphanedDefinitionNodeItemImpl
     return model.get();
   }
 
+  @Override
+  public String stringValue() {
+    return "";
+  }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/CycledAssemblyInstanceNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/CycledAssemblyInstanceNodeItemImpl.java
@@ -67,4 +67,9 @@ class CycledAssemblyInstanceNodeItemImpl
     // always a singleton as a non-valued item
     return 1;
   }
+
+  @Override
+  public String stringValue() {
+    return "";
+  }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/DocumentNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/DocumentNodeItemImpl.java
@@ -75,4 +75,10 @@ class DocumentNodeItemImpl
   public StaticContext getStaticContext() {
     return staticContext;
   }
+
+  @Override
+  public String stringValue() {
+    return getRootAssemblyNodeItem().stringValue();
+  }
+
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/FieldGlobalDefinitionNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/FieldGlobalDefinitionNodeItemImpl.java
@@ -29,4 +29,9 @@ class FieldGlobalDefinitionNodeItemImpl
   public FlagContainer getModel() {
     return model.get();
   }
+
+  @Override
+  public String stringValue() {
+    return "";
+  }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/FieldInstanceNoValueNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/FieldInstanceNoValueNodeItemImpl.java
@@ -36,4 +36,9 @@ class FieldInstanceNoValueNodeItemImpl
   public int getPosition() {
     return 1;
   }
+
+  @Override
+  public String stringValue() {
+    return "";
+  }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/FieldInstanceNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/FieldInstanceNodeItemImpl.java
@@ -72,4 +72,9 @@ class FieldInstanceNodeItemImpl
   public IAnyAtomicItem toAtomicItem() {
     return atomicItem.get();
   }
+
+  @Override
+  public String stringValue() {
+    return toAtomicItem().asString();
+  }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/FieldOrphanedDefinitionNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/FieldOrphanedDefinitionNodeItemImpl.java
@@ -36,4 +36,8 @@ class FieldOrphanedDefinitionNodeItemImpl
     return model.get();
   }
 
+  @Override
+  public String stringValue() {
+    return "";
+  }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/FlagGlobalDefinitionNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/FlagGlobalDefinitionNodeItemImpl.java
@@ -33,4 +33,9 @@ class FlagGlobalDefinitionNodeItemImpl
   public IFlagInstance getInstance() {
     return null;
   }
+
+  @Override
+  public String stringValue() {
+    return "";
+  }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/FlagInstanceNoValueNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/FlagInstanceNoValueNodeItemImpl.java
@@ -14,4 +14,9 @@ class FlagInstanceNoValueNodeItemImpl
       @NonNull IModelNodeItem<?, ?> parent) {
     super(instance, parent);
   }
+
+  @Override
+  public String stringValue() {
+    return "";
+  }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/FlagInstanceNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/FlagInstanceNodeItemImpl.java
@@ -50,4 +50,9 @@ class FlagInstanceNodeItemImpl
   public IAnyAtomicItem toAtomicItem() {
     return atomicItem.get();
   }
+
+  @Override
+  public String stringValue() {
+    return toAtomicItem().asString();
+  }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/INodeItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/INodeItem.java
@@ -280,6 +280,14 @@ public interface INodeItem extends IItem, IPathSegment, INodeItemVisitable {
   IResourceLocation getLocation();
 
   /**
+   * Get the string value of the node.
+   *
+   * @return the string value of the node or an empty string if it has no value.
+   */
+  @NonNull
+  String stringValue();
+
+  /**
    * Get the static context to use to query this node item.
    *
    * @return the static context

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/ModuleNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/ModuleNodeItemImpl.java
@@ -46,4 +46,9 @@ class ModuleNodeItemImpl
     // no location
     return null;
   }
+
+  @Override
+  public String stringValue() {
+    return "";
+  }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/RootAssemblyValuedNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/RootAssemblyValuedNodeItemImpl.java
@@ -4,6 +4,8 @@ package gov.nist.secauto.metaschema.core.metapath.item.node;
 import gov.nist.secauto.metaschema.core.model.IAssemblyDefinition;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
+import java.util.stream.Collectors;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 import nl.talsmasoftware.lazy4j.Lazy;
 
@@ -56,5 +58,12 @@ class RootAssemblyValuedNodeItemImpl
   @Override
   public ModelContainer getModel() {
     return model.get();
+  }
+
+  @Override
+  public String stringValue() {
+    return ObjectUtils.notNull(modelItems()
+        .map(INodeItem::stringValue)
+        .collect(Collectors.joining()));
   }
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnStringTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnStringTest.java
@@ -1,0 +1,88 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.function.library;
+
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.array;
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.integer;
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.sequence;
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.string;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import gov.nist.secauto.metaschema.core.metapath.ExpressionTestBase;
+import gov.nist.secauto.metaschema.core.metapath.ISequence;
+import gov.nist.secauto.metaschema.core.metapath.InvalidTypeMetapathException;
+import gov.nist.secauto.metaschema.core.metapath.MetapathException;
+import gov.nist.secauto.metaschema.core.metapath.MetapathExpression;
+import gov.nist.secauto.metaschema.core.metapath.function.InvalidTypeFunctionException;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+class FnStringTest
+    extends ExpressionTestBase {
+  private static Stream<Arguments> provideValues() { // NOPMD - false positive
+    return Stream.of(
+        Arguments.of(
+            string("23"),
+            "string(23)"),
+        Arguments.of(
+            string("false"),
+            "string(false())"),
+        Arguments.of(
+            string("Paris"),
+            "string(\"Paris\")"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideValues")
+  void testExpression(@NonNull IStringItem expected, @NonNull String metapath) {
+    IStringItem result = MetapathExpression.compile(metapath)
+        .evaluateAs(null, MetapathExpression.ResultType.NODE, newDynamicContext());
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void testInvalidArgument() {
+    InvalidTypeMetapathException throwable = assertThrows(InvalidTypeMetapathException.class,
+        () -> {
+          try {
+            ISequence<IStringItem> result = FunctionTestBase.executeFunction(
+                FnString.SIGNATURE_ONE_ARG,
+                newDynamicContext(),
+                ISequence.empty(),
+                List.of(sequence(integer(1), integer(2))));
+          } catch (MetapathException ex) {
+            throw ex.getCause();
+          }
+        });
+  }
+
+  @Test
+  void testInvalidArgumentType() {
+    InvalidTypeFunctionException throwable = assertThrows(InvalidTypeFunctionException.class,
+        () -> {
+          try {
+            ISequence<IStringItem> result = FunctionTestBase.executeFunction(
+                FnString.SIGNATURE_ONE_ARG,
+                newDynamicContext(),
+                ISequence.empty(),
+                List.of(sequence(array(array(integer(1), integer(2)), array(integer(3), integer(4))))));
+          } catch (MetapathException ex) {
+            throw ex.getCause();
+          }
+        });
+    assertEquals(InvalidTypeFunctionException.ARGUMENT_TO_STRING_IS_FUNCTION, throwable.getCode());
+  }
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FunctionTestBase.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FunctionTestBase.java
@@ -97,11 +97,11 @@ public class FunctionTestBase
   }
 
   @SuppressWarnings("unchecked")
-  private static <R extends IItem> ISequence<R> executeFunction(
+  public static <R extends IItem> ISequence<R> executeFunction(
       @NonNull IFunction function,
       @Nullable DynamicContext dynamicContext,
       @Nullable ISequence<?> focus,
-      List<ISequence<?>> arguments) {
+      List<? extends ISequence<?>> arguments) {
 
     DynamicContext context = dynamicContext == null ? new DynamicContext() : dynamicContext;
     ISequence<?> focusSeqence = function.isFocusDepenent()


### PR DESCRIPTION
# Committer Notes

Added support for the [fn:string](https://www.w3.org/TR/xpath-functions-31/#func-string) Metapath functions.

In support of this, added a stringValue method to INodeItem implementations to get the string value of it's contents. 

Resolves #122

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
