### PR TITLE
Add support for SARIF help URLs, text, and markdown

### DIFF
--- a/databind-metaschema/pom.xml
+++ b/databind-metaschema/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>dev.metaschema.java</groupId>
@@ -23,8 +25,8 @@
 
 	<scm>
 		<url>${scm.url}/tree/develop/databind-metaschema</url>
-	  <tag>HEAD</tag>
-  </scm>
+		<tag>HEAD</tag>
+	</scm>
 
 	<dependencies>
 		<dependency>
@@ -45,16 +47,16 @@
 			<groupId>com.github.spotbugs</groupId>
 			<artifactId>spotbugs-annotations</artifactId>
 		</dependency>
-		
+
 		<dependency>
-            <groupId>org.jmock</groupId>
-            <artifactId>jmock-junit5</artifactId>
-            <scope>test</scope>
-        </dependency>
+			<groupId>org.jmock</groupId>
+			<artifactId>jmock-junit5</artifactId>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
-		    <groupId>dev.harrel</groupId>
-		    <artifactId>json-schema</artifactId>
-		    <version>1.7.1</version>
+			<groupId>dev.harrel</groupId>
+			<artifactId>json-schema</artifactId>
+			<version>1.7.1</version>
 		</dependency>
 	</dependencies>
 
@@ -87,8 +89,7 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-checkstyle-plugin</artifactId>
 					<configuration>
-						<excludes>
-							**/gov/nist/secauto/metaschema/metaschema/model/**/*</excludes>
+						<excludes>**/gov/nist/secauto/metaschema/metaschema/model/**/*</excludes>
 					</configuration>
 				</plugin>
 				<plugin>
@@ -106,26 +107,26 @@
 				<artifactId>metaschema-maven-plugin</artifactId>
 				<version>${project.version}</version>
 				<executions>
-<!--					<execution>-->
-<!--						<id>metaschema-codegen</id>-->
-<!--						<phase>generate-sources</phase>-->
-<!--						<goals>-->
-<!--							<goal>generate-sources</goal>-->
-<!--						</goals>-->
-<!--						<configuration>-->
-<!--							<metaschemaDir>${project.basedir}/../core/metaschema/schema/metaschema</metaschemaDir>-->
-<!--							<outputDirectory>${project.build.directory}/generated-sources/metaschema</outputDirectory>-->
-<!--							<configs>-->
-<!--								<config>${project.basedir}/src/main/metaschema-bindings/metaschema-metaschema-bindings.xml</config>-->
-<!--							</configs>-->
-<!--							<includes>-->
-<!--								<include>metaschema-module-metaschema.xml</include>-->
-<!--							</includes>-->
-<!--							<constraints>-->
-<!--								<constraint>${project.basedir}/../core/metaschema/schema/metaschema/metaschema-module-constraints.xml</constraint>-->
-<!--							</constraints>-->
-<!--						</configuration>-->
-<!--					</execution>-->
+					<!--<execution>-->
+					<!--	<id>metaschema-codegen</id>-->
+					<!--	<phase>generate-sources</phase>-->
+					<!--	<goals>-->
+					<!--		<goal>generate-sources</goal>-->
+					<!--	</goals>-->
+					<!--	<configuration>-->
+					<!--		<metaschemaDir>${project.basedir}/../core/metaschema/schema/metaschema</metaschemaDir>-->
+					<!--		<outputDirectory>${project.build.directory}/generated-sources/metaschema</outputDirectory>-->
+					<!--		<configs>-->
+					<!--			<config>${project.basedir}/src/main/metaschema-bindings/metaschema-metaschema-bindings.xml</config>-->
+					<!--		</configs>-->
+					<!--		<includes>-->
+					<!--			<include>metaschema-module-metaschema.xml</include>-->
+					<!--		</includes>-->
+					<!--		<constraints>-->
+					<!--			<constraint>${project.basedir}/../core/metaschema/schema/metaschema/metaschema-module-constraints.xml</constraint>-->
+					<!--		</constraints>-->
+					<!--	</configuration>-->
+					<!--</execution>-->
 					<execution>
 						<id>metaschema-xml-schema</id>
 						<phase>generate-sources</phase>
@@ -246,6 +247,6 @@
 					</execution>
 				</executions>
 			</plugin>
-        </plugins>
+		</plugins>
 	</build>
 </project>

--- a/databind-metaschema/src/main/java/gov/nist/secauto/metaschema/modules/sarif/SarifValidationHandler.java
+++ b/databind-metaschema/src/main/java/gov/nist/secauto/metaschema/modules/sarif/SarifValidationHandler.java
@@ -6,6 +6,7 @@
 package gov.nist.secauto.metaschema.modules.sarif;
 
 import gov.nist.secauto.metaschema.core.datatype.markup.MarkupLine;
+import gov.nist.secauto.metaschema.core.model.IAttributable;
 import gov.nist.secauto.metaschema.core.model.IResourceLocation;
 import gov.nist.secauto.metaschema.core.model.constraint.ConstraintValidationFinding;
 import gov.nist.secauto.metaschema.core.model.constraint.IConstraint;
@@ -46,6 +47,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -92,6 +94,12 @@ public final class SarifValidationHandler {
       return label;
     }
   }
+
+  @NonNull
+  public static final String SARIF_NS = "https://docs.oasis-open.org/sarif/sarif/v2.1.0";
+  @NonNull
+  public static final IAttributable.Key SARIF_HELP_URL_KEY
+      = IAttributable.key("help-url", SarifValidationHandler.SARIF_NS);
 
   @NonNull
   private final URI source;
@@ -464,7 +472,6 @@ public final class SarifValidationHandler {
       retval.setId(getId());
       retval.setGuid(getGuid());
       return retval;
-
     }
 
     public String getId() {
@@ -512,6 +519,11 @@ public final class SarifValidationHandler {
         text.setText(description.toText());
         text.setMarkdown(description.toMarkdown());
         retval.setFullDescription(text);
+      }
+
+      Set<String> helpUrls = constraint.getPropertyValues(IAttributable.key("help-url", SARIF_NS));
+      if (!helpUrls.isEmpty()) {
+        retval.setHelpUri(URI.create(helpUrls.stream().findFirst().get()));
       }
 
       return retval;

--- a/databind-metaschema/src/main/java/gov/nist/secauto/metaschema/modules/sarif/SarifValidationHandler.java
+++ b/databind-metaschema/src/main/java/gov/nist/secauto/metaschema/modules/sarif/SarifValidationHandler.java
@@ -513,6 +513,7 @@ public final class SarifValidationHandler {
         text.setMarkdown(description.toMarkdown());
         retval.setFullDescription(text);
       }
+
       return retval;
     }
 

--- a/databind-metaschema/src/test/java/gov/nist/secauto/metaschema/modules/sarif/SarifValidationHandlerTest.java
+++ b/databind-metaschema/src/test/java/gov/nist/secauto/metaschema/modules/sarif/SarifValidationHandlerTest.java
@@ -52,6 +52,7 @@ class SarifValidationHandlerTest {
     Path sourceFile = Paths.get(".", "source.json").toAbsolutePath();
 
     Set<String> helpUrls = Set.of("https://example.com/test");
+    Set<String> helpMarkdown = Set.of("**help text**");
 
     context.checking(new Expectations() {
       { // NOPMD - intentional
@@ -69,9 +70,16 @@ class SarifValidationHandlerTest {
         allowing(constraintA).getDescription();
         will(returnValue(MarkupLine.fromMarkdown("a description")));
         allowing(constraintA).getProperties();
-        will(returnValue(Map.of(SarifValidationHandler.SARIF_HELP_URL_KEY, helpUrls)));
+        will(returnValue(
+            Map.ofEntries(
+                Map.entry(SarifValidationHandler.SARIF_HELP_URL_KEY, helpUrls),
+                Map.entry(SarifValidationHandler.SARIF_HELP_MARKDOWN_KEY, helpMarkdown))));
         allowing(constraintA).getPropertyValues(SarifValidationHandler.SARIF_HELP_URL_KEY);
         will(returnValue(helpUrls));
+        allowing(constraintA).getPropertyValues(SarifValidationHandler.SARIF_HELP_TEXT_KEY);
+        will(returnValue(Set.of()));
+        allowing(constraintA).getPropertyValues(SarifValidationHandler.SARIF_HELP_MARKDOWN_KEY);
+        will(returnValue(helpMarkdown));
 
         allowing(node).getLocation();
         will(returnValue(location));

--- a/databind-metaschema/src/test/java/gov/nist/secauto/metaschema/modules/sarif/SarifValidationHandlerTest.java
+++ b/databind-metaschema/src/test/java/gov/nist/secauto/metaschema/modules/sarif/SarifValidationHandlerTest.java
@@ -28,6 +28,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Set;
 
 import dev.harrel.jsonschema.Dialects;
 import dev.harrel.jsonschema.JsonNode;
@@ -49,6 +51,8 @@ class SarifValidationHandlerTest {
 
     Path sourceFile = Paths.get(".", "source.json").toAbsolutePath();
 
+    Set<String> helpUrls = Set.of("https://example.com/test");
+
     context.checking(new Expectations() {
       { // NOPMD - intentional
         allowing(versionInfo).getName();
@@ -64,6 +68,10 @@ class SarifValidationHandlerTest {
         will(returnValue("a formal name"));
         allowing(constraintA).getDescription();
         will(returnValue(MarkupLine.fromMarkdown("a description")));
+        allowing(constraintA).getProperties();
+        will(returnValue(Map.of(SarifValidationHandler.SARIF_HELP_URL_KEY, helpUrls)));
+        allowing(constraintA).getPropertyValues(SarifValidationHandler.SARIF_HELP_URL_KEY);
+        will(returnValue(helpUrls));
 
         allowing(node).getLocation();
         will(returnValue(location));


### PR DESCRIPTION
# Committer Notes

This PR adds support for SARIF help-url, help-text, and help-markdown for rule entries.

This PR also relocates use of the SARIF module to its new location in https://github.com/metaschema-framework/metaschema-modules/tree/main/sarif.

Resolves #131

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
