### PR TITLE
Add `fn:substring` to Metapath function library

### DIFF
--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/DefaultFunctionLibrary.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/DefaultFunctionLibrary.java
@@ -156,6 +156,7 @@ public class DefaultFunctionLibrary
     registerFunction(FnString.SIGNATURE_NO_ARG);
     registerFunction(FnString.SIGNATURE_ONE_ARG);
     // P0: https://www.w3.org/TR/xpath-functions-31/#func-string
+    registerFunction(FnSubstring.SIGNATURE_TWO_ARG);
     registerFunction(FnSubstring.SIGNATURE_THREE_ARG);
     // P1: https://www.w3.org/TR/xpath-functions-31/#func-string-join
     // P1: https://www.w3.org/TR/xpath-functions-31/#func-string-length

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/DefaultFunctionLibrary.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/DefaultFunctionLibrary.java
@@ -155,10 +155,12 @@ public class DefaultFunctionLibrary
     // https://www.w3.org/TR/xpath-functions-31/#func-string
     registerFunction(FnString.SIGNATURE_NO_ARG);
     registerFunction(FnString.SIGNATURE_ONE_ARG);
+    // P0: https://www.w3.org/TR/xpath-functions-31/#func-string
+    registerFunction(FnSubstring.SIGNATURE_THREE_ARG);
     // P1: https://www.w3.org/TR/xpath-functions-31/#func-string-join
     // P1: https://www.w3.org/TR/xpath-functions-31/#func-string-length
     // P1: https://www.w3.org/TR/xpath-functions-31/#func-subsequence
-    // P1: https://www.w3.org/TR/xpath-functions-31/#func-substring
+    // https://www.w3.org/TR/xpath-functions-31/#func-substring
     // P1: https://www.w3.org/TR/xpath-functions-31/#func-substring-after
     // P1: https://www.w3.org/TR/xpath-functions-31/#func-substring-before
     // https://www.w3.org/TR/xpath-functions-31/#func-sum

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/DefaultFunctionLibrary.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/DefaultFunctionLibrary.java
@@ -155,13 +155,12 @@ public class DefaultFunctionLibrary
     // https://www.w3.org/TR/xpath-functions-31/#func-string
     registerFunction(FnString.SIGNATURE_NO_ARG);
     registerFunction(FnString.SIGNATURE_ONE_ARG);
-    // P0: https://www.w3.org/TR/xpath-functions-31/#func-string
+    // https://www.w3.org/TR/xpath-functions-30/#func-substring
     registerFunction(FnSubstring.SIGNATURE_TWO_ARG);
     registerFunction(FnSubstring.SIGNATURE_THREE_ARG);
     // P1: https://www.w3.org/TR/xpath-functions-31/#func-string-join
     // P1: https://www.w3.org/TR/xpath-functions-31/#func-string-length
     // P1: https://www.w3.org/TR/xpath-functions-31/#func-subsequence
-    // https://www.w3.org/TR/xpath-functions-31/#func-substring
     // P1: https://www.w3.org/TR/xpath-functions-31/#func-substring-after
     // P1: https://www.w3.org/TR/xpath-functions-31/#func-substring-before
     // https://www.w3.org/TR/xpath-functions-31/#func-sum

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
@@ -87,16 +87,39 @@ public final class FnSubstring {
 
   @SuppressWarnings("unused")
   @NonNull
+  private static ISequence<IStringItem> executeTwoArg(
+      @NonNull IFunction function,
+      @NonNull List<ISequence<?>> arguments,
+      @NonNull DynamicContext dynamicContext,
+      IItem focus) {
+
+    IStringItem sourceString = FunctionUtils.asTypeOrNull(arguments.get(0).getFirstItem(true));
+
+    if (sourceString == null) {
+      return ISequence.of(IStringItem.valueOf(""));
+    }
+
+    IDecimalItem start = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(1).getFirstItem(true)));
+    return ISequence.of(fnSubstring(sourceString, start, IDecimalItem.valueOf(sourceString.toString().length())));
+  }
+
+  @SuppressWarnings("unused")
+  @NonNull
   private static ISequence<IStringItem> execute(
       @NonNull IFunction function,
       @NonNull List<ISequence<?>> arguments,
       @NonNull DynamicContext dynamicContext,
       IItem focus) {
 
-    IStringItem sourceString = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(0).getFirstItem(true)));
+    IStringItem sourceString = FunctionUtils.asTypeOrNull(arguments.get(0).getFirstItem(true));
+
+    if (sourceString == null) {
+      return ISequence.of(IStringItem.valueOf(""));
+    }
+
     IDecimalItem start = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(1).getFirstItem(true)));
     IDecimalItem length = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(2).getFirstItem(true)));
-    return ISequence.of(substring(sourceString, start, length));
+    return ISequence.of(fnSubstring(sourceString, start, length));
   }
 
   /**
@@ -104,23 +127,24 @@ public final class FnSubstring {
    * "https://www.w3.org/TR/xpath-functions-31/#func-substring">fn:substring</a>.
    *
    * @param sourceString
-   * 
+   *
    * @param start
-   * 
+   *
    * @param length
-   *          
+   *
    * @return the atomized result
    */
   @NonNull
-  public static IStringItem substring(@NonNull IStringItem sourceString, @NonNull IDecimalItem start, @NonNull IDecimalItem length) {
+  public static IStringItem fnSubstring(@NonNull IStringItem sourceString, @NonNull IDecimalItem start,
+      @NonNull IDecimalItem length) {
     String sourceStringData = sourceString.toString();
 
     if (sourceStringData.length() == 0) {
       return IStringItem.valueOf("");
     }
 
-    int startIndex = start.asInteger().intValue() - 1;
-    int endIndex = startIndex + length.asInteger().intValue();
+    int startIndex = start.round().asInteger().intValue() - 1;
+    int endIndex = startIndex + length.round().asInteger().intValue();
     return IStringItem.valueOf(sourceStringData.substring(startIndex, endIndex));
   }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
@@ -1,0 +1,98 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.function.library;
+
+import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
+import gov.nist.secauto.metaschema.core.metapath.ISequence;
+import gov.nist.secauto.metaschema.core.metapath.MetapathConstants;
+import gov.nist.secauto.metaschema.core.metapath.function.FunctionUtils;
+import gov.nist.secauto.metaschema.core.metapath.function.IArgument;
+import gov.nist.secauto.metaschema.core.metapath.function.IFunction;
+import gov.nist.secauto.metaschema.core.metapath.item.IItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IIntegerItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
+import gov.nist.secauto.metaschema.core.util.ObjectUtils;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Implements <a href=
+ * "https://www.w3.org/TR/xpath-functions-30/#func-substring">fn:substring</a>.
+ */
+public final class FnSubstring {
+  @NonNull
+  static final IFunction SIGNATURE_THREE_ARG = IFunction.builder()
+      .name("substring")
+      .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
+      .deterministic()
+      .contextIndependent()
+      .focusIndependent()
+      .argument(IArgument.builder()
+          .name("sourceString")
+          .type(IStringItem.class)
+          .zeroOrOne()
+          .build())
+      .argument(IArgument.builder()
+          .name("start")
+          // Review if xs:double to IIntegerItem data-type mapping appropriate?
+          .type(IIntegerItem.class)
+          .zeroOrOne()
+          .build())
+      .argument(IArgument.builder()
+          .name("length")
+          // Review if xs:double to IIntegerItem data-type mapping appropriate?
+          .type(IIntegerItem.class)
+          .zeroOrOne()
+          .build())
+      .allowUnboundedArity(true)
+      .returnType(IStringItem.class)
+      .returnOne()
+      .functionHandler(FnSubstring::execute)
+      .build();
+
+  private FnSubstring() {
+    // disable construction
+  }
+
+  @SuppressWarnings("unused")
+  @NonNull
+  private static ISequence<IStringItem> execute(
+      @NonNull IFunction function,
+      @NonNull List<ISequence<?>> arguments,
+      @NonNull DynamicContext dynamicContext,
+      IItem focus) {
+
+    IStringItem sourceString = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(0).getFirstItem(true)));
+    IIntegerItem start = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(1).getFirstItem(true)));
+    IIntegerItem length = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(2).getFirstItem(true)));
+    return ISequence.of(substring(sourceString, start, length));
+  }
+
+  /**
+   * An implementation of XPath 3.1 <a href=
+   * "https://www.w3.org/TR/xpath-functions-31/#func-substring">fn:substring</a>.
+   *
+   * @param sourceString
+   * 
+   * @param start
+   * 
+   * @param length
+   *          
+   * @return the atomized result
+   */
+  @NonNull
+  public static IStringItem substring(@NonNull IStringItem sourceString, @NonNull IIntegerItem start, @NonNull IIntegerItem length) {
+    int startIndex = start.asInteger().intValue() - 1;
+    int endIndex = startIndex + length.asInteger().intValue();
+    return IStringItem.valueOf(sourceString.toString().substring(startIndex, endIndex));
+  }
+}

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
@@ -44,7 +44,6 @@ public final class FnSubstring {
           .build())
       .argument(IArgument.builder()
           .name("start")
-          // Review if xs:double to IIntegerItem data-type mapping appropriate?
           .type(IDecimalItem.class)
           .one()
           .build())
@@ -66,13 +65,11 @@ public final class FnSubstring {
           .build())
       .argument(IArgument.builder()
           .name("start")
-          // Review if xs:double to IIntegerItem data-type mapping appropriate?
           .type(IDecimalItem.class)
           .one()
           .build())
       .argument(IArgument.builder()
           .name("length")
-          // Review if xs:double to IIntegerItem data-type mapping appropriate?
           .type(IDecimalItem.class)
           .one()
           .build())

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
@@ -30,6 +30,28 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  */
 public final class FnSubstring {
   @NonNull
+  static final IFunction SIGNATURE_TWO_ARG = IFunction.builder()
+      .name("substring")
+      .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
+      .deterministic()
+      .contextIndependent()
+      .focusIndependent()
+      .argument(IArgument.builder()
+          .name("sourceString")
+          .type(IStringItem.class)
+          .zeroOrOne()
+          .build())
+      .argument(IArgument.builder()
+          .name("start")
+          // Review if xs:double to IIntegerItem data-type mapping appropriate?
+          .type(IDecimalItem.class)
+          .one()
+          .build())
+      .returnType(IStringItem.class)
+      .returnOne()
+      .functionHandler(FnSubstring::execute)
+      .build();
+
   static final IFunction SIGNATURE_THREE_ARG = IFunction.builder()
       .name("substring")
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
@@ -73,7 +95,7 @@ public final class FnSubstring {
     IStringItem sourceString = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(0).getFirstItem(true)));
     IIntegerItem start = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(1).getFirstItem(true)));
     IIntegerItem length = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(2).getFirstItem(true)));
-    return ISequence.of(substring(sourceString, start, length));
+    return ISequence.of(su1bstring(sourceString, start, length));
   }
 
   /**

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
@@ -99,9 +99,11 @@ public final class FnSubstring {
     IDecimalItem start = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(1).getFirstItem(true)));
 
     int startIndex = start.round().asInteger().intValue();
-    int endIndex = (sourceString.toString().length() - startIndex) + 1;
 
-    return ISequence.of(fnSubstring(sourceString, startIndex, endIndex));
+    return ISequence.of(fnSubstring(
+      sourceString.asString(),
+      startIndex,
+      sourceString.toString().length() - Math.max(startIndex,1) + 1));
   }
 
   @SuppressWarnings("unused")
@@ -121,31 +123,10 @@ public final class FnSubstring {
     IDecimalItem start = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(1).getFirstItem(true)));
     IDecimalItem length = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(2).getFirstItem(true)));
 
-    int startIndex = start.round().asInteger().intValue();
-    int endIndex = length.round().asInteger().intValue();
-
-    return ISequence.of(fnSubstring(sourceString, startIndex, endIndex));
-  }
-
-  /**
-   * An implementation of XPath 3.1 <a href=
-   * "https://www.w3.org/TR/xpath-functions-31/#func-substring">fn:substring</a>.
-   *
-   * @param sourceString
-   *
-   * @param start
-   *
-   * @param length
-   *
-   * @return the atomized result
-   */
-  @NonNull
-  public static IStringItem fnSubstring(@NonNull IStringItem sourceString, @NonNull IDecimalItem start,
-      @NonNull IDecimalItem length) {
-
-    int startIndex = start.round().asInteger().intValue();
-    int endIndex = length.round().asInteger().intValue();
-    return fnSubstring(sourceString, startIndex, endIndex);
+    return ISequence.of(fnSubstring(
+      sourceString.asString(),
+      start.round().asInteger().intValue(),
+      length.round().asInteger().intValue()));
   }
 
     /**
@@ -161,20 +142,21 @@ public final class FnSubstring {
    * @return the atomized result
    */
   @NonNull
-  public static IStringItem fnSubstring(@NonNull IStringItem sourceString, @NonNull int start,
-      @NonNull int length) {
-    String sourceStringData = sourceString.toString();
+  public static IStringItem fnSubstring(
+    @NonNull String source,
+    @NonNull int start,
+    @NonNull int length) {
+    int sourceLength = source.length();
 
-    if (sourceStringData.length() == 0) {
-      return IStringItem.valueOf("");
-    }
+    // XPath uses 1-based indexing, so subtract 1 for 0-based Java indexing
+    int startIndex = Math.max(start, 1);
 
-    if (start <= 0) {
-      start = 0;
-    } else {
-      start--;
-    }
-
-    return IStringItem.valueOf(sourceStringData.substring(start, (start + length)));
+    // Handle negative or zero length
+    int endIndex = length <= 1 ? startIndex : Math.min(startIndex + length, sourceLength);
+    
+    // Ensure startIndex is not greater than endIndex
+    startIndex = Math.min(startIndex, endIndex);
+    
+    return IStringItem.valueOf(source.substring(startIndex-1, endIndex));
   }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
@@ -45,15 +45,14 @@ public final class FnSubstring {
           .name("start")
           // Review if xs:double to IIntegerItem data-type mapping appropriate?
           .type(IDecimalItem.class)
-          .zeroOrOne()
+          .one()
           .build())
       .argument(IArgument.builder()
           .name("length")
           // Review if xs:double to IIntegerItem data-type mapping appropriate?
           .type(IDecimalItem.class)
-          .zeroOrOne()
+          .one()
           .build())
-      .allowUnboundedArity(true)
       .returnType(IStringItem.class)
       .returnOne()
       .functionHandler(FnSubstring::execute)

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
@@ -13,6 +13,7 @@ import gov.nist.secauto.metaschema.core.metapath.function.IArgument;
 import gov.nist.secauto.metaschema.core.metapath.function.IFunction;
 import gov.nist.secauto.metaschema.core.metapath.item.IItem;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IDecimalItem;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IIntegerItem;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
@@ -93,8 +94,8 @@ public final class FnSubstring {
       IItem focus) {
 
     IStringItem sourceString = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(0).getFirstItem(true)));
-    IIntegerItem start = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(1).getFirstItem(true)));
-    IIntegerItem length = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(2).getFirstItem(true)));
+    IDecimalItem start = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(1).getFirstItem(true)));
+    IDecimalItem length = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(2).getFirstItem(true)));
     return ISequence.of(substring(sourceString, start, length));
   }
 
@@ -111,7 +112,7 @@ public final class FnSubstring {
    * @return the atomized result
    */
   @NonNull
-  public static IStringItem substring(@NonNull IStringItem sourceString, @NonNull IIntegerItem start, @NonNull IIntegerItem length) {
+  public static IStringItem substring(@NonNull IStringItem sourceString, @NonNull IDecimalItem start, @NonNull IDecimalItem length) {
     int startIndex = start.asInteger().intValue() - 1;
     int endIndex = startIndex + length.asInteger().intValue();
     return IStringItem.valueOf(sourceString.toString().substring(startIndex, endIndex));

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
@@ -26,7 +26,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Implements <a href=
- * "https://www.w3.org/TR/xpath-functions-30/#func-substring">fn:substring</a>.
+ * "https://www.w3.org/TR/xpath-functions-31/#func-substring">fn:substring</a>.
  */
 public final class FnSubstring {
   @NonNull

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
@@ -95,7 +95,7 @@ public final class FnSubstring {
     IStringItem sourceString = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(0).getFirstItem(true)));
     IIntegerItem start = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(1).getFirstItem(true)));
     IIntegerItem length = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(2).getFirstItem(true)));
-    return ISequence.of(su1bstring(sourceString, start, length));
+    return ISequence.of(substring(sourceString, start, length));
   }
 
   /**

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
@@ -50,7 +50,7 @@ public final class FnSubstring {
           .build())
       .returnType(IStringItem.class)
       .returnOne()
-      .functionHandler(FnSubstring::execute)
+      .functionHandler(FnSubstring::executeTwoArg)
       .build();
 
   static final IFunction SIGNATURE_THREE_ARG = IFunction.builder()
@@ -78,7 +78,7 @@ public final class FnSubstring {
           .build())
       .returnType(IStringItem.class)
       .returnOne()
-      .functionHandler(FnSubstring::execute)
+      .functionHandler(FnSubstring::executeThreeArg)
       .build();
 
   private FnSubstring() {
@@ -105,7 +105,7 @@ public final class FnSubstring {
 
   @SuppressWarnings("unused")
   @NonNull
-  private static ISequence<IStringItem> execute(
+  private static ISequence<IStringItem> executeThreeArg(
       @NonNull IFunction function,
       @NonNull List<ISequence<?>> arguments,
       @NonNull DynamicContext dynamicContext,

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
@@ -97,7 +97,11 @@ public final class FnSubstring {
     }
 
     IDecimalItem start = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(1).getFirstItem(true)));
-    return ISequence.of(fnSubstring(sourceString, start, IDecimalItem.valueOf(sourceString.toString().length())));
+
+    int startIndex = start.round().asInteger().intValue();
+    int endIndex = (sourceString.toString().length() - startIndex) + 1;
+
+    return ISequence.of(fnSubstring(sourceString, startIndex, endIndex));
   }
 
   @SuppressWarnings("unused")
@@ -116,7 +120,11 @@ public final class FnSubstring {
 
     IDecimalItem start = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(1).getFirstItem(true)));
     IDecimalItem length = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(2).getFirstItem(true)));
-    return ISequence.of(fnSubstring(sourceString, start, length));
+
+    int startIndex = start.round().asInteger().intValue();
+    int endIndex = length.round().asInteger().intValue();
+
+    return ISequence.of(fnSubstring(sourceString, startIndex, endIndex));
   }
 
   /**
@@ -134,14 +142,39 @@ public final class FnSubstring {
   @NonNull
   public static IStringItem fnSubstring(@NonNull IStringItem sourceString, @NonNull IDecimalItem start,
       @NonNull IDecimalItem length) {
+
+    int startIndex = start.round().asInteger().intValue();
+    int endIndex = length.round().asInteger().intValue();
+    return fnSubstring(sourceString, startIndex, endIndex);
+  }
+
+    /**
+   * An implementation of XPath 3.1 <a href=
+   * "https://www.w3.org/TR/xpath-functions-31/#func-substring">fn:substring</a>.
+   *
+   * @param sourceString
+   *
+   * @param start
+   *
+   * @param length
+   *
+   * @return the atomized result
+   */
+  @NonNull
+  public static IStringItem fnSubstring(@NonNull IStringItem sourceString, @NonNull int start,
+      @NonNull int length) {
     String sourceStringData = sourceString.toString();
 
     if (sourceStringData.length() == 0) {
       return IStringItem.valueOf("");
     }
 
-    int startIndex = start.round().asInteger().intValue() - 1;
-    int endIndex = startIndex + length.round().asInteger().intValue();
-    return IStringItem.valueOf(sourceStringData.substring(startIndex, endIndex));
+    if (start <= 0) {
+      start = 0;
+    } else {
+      start--;
+    }
+
+    return IStringItem.valueOf(sourceStringData.substring(start, (start + length)));
   }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
@@ -44,13 +44,13 @@ public final class FnSubstring {
       .argument(IArgument.builder()
           .name("start")
           // Review if xs:double to IIntegerItem data-type mapping appropriate?
-          .type(IIntegerItem.class)
+          .type(IDecimalItem.class)
           .zeroOrOne()
           .build())
       .argument(IArgument.builder()
           .name("length")
           // Review if xs:double to IIntegerItem data-type mapping appropriate?
-          .type(IIntegerItem.class)
+          .type(IDecimalItem.class)
           .zeroOrOne()
           .build())
       .allowUnboundedArity(true)

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
@@ -113,8 +113,14 @@ public final class FnSubstring {
    */
   @NonNull
   public static IStringItem substring(@NonNull IStringItem sourceString, @NonNull IDecimalItem start, @NonNull IDecimalItem length) {
+    String sourceStringData = sourceString.toString();
+
+    if (sourceStringData.length() == 0) {
+      return IStringItem.valueOf("");
+    }
+
     int startIndex = start.asInteger().intValue() - 1;
     int endIndex = startIndex + length.asInteger().intValue();
-    return IStringItem.valueOf(sourceString.toString().substring(startIndex, endIndex));
+    return IStringItem.valueOf(sourceStringData.substring(startIndex, endIndex));
   }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
@@ -12,22 +12,16 @@ import gov.nist.secauto.metaschema.core.metapath.function.FunctionUtils;
 import gov.nist.secauto.metaschema.core.metapath.function.IArgument;
 import gov.nist.secauto.metaschema.core.metapath.function.IFunction;
 import gov.nist.secauto.metaschema.core.metapath.item.IItem;
-import gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IDecimalItem;
-import gov.nist.secauto.metaschema.core.metapath.item.atomic.IIntegerItem;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * Implements <a href=
- * "https://www.w3.org/TR/xpath-functions-31/#func-substring">fn:substring</a>.
+ * Implements <a href= "https://www.w3.org/TR/xpath-functions-31/#func-substring">fn:substring</a>.
  */
 public final class FnSubstring {
   @NonNull
@@ -101,9 +95,9 @@ public final class FnSubstring {
     int startIndex = start.round().asInteger().intValue();
 
     return ISequence.of(fnSubstring(
-      sourceString.asString(),
-      startIndex,
-      sourceString.toString().length() - Math.max(startIndex,1) + 1));
+        sourceString.asString(),
+        startIndex,
+        sourceString.toString().length() - Math.max(startIndex, 1) + 1));
   }
 
   @SuppressWarnings("unused")
@@ -124,14 +118,14 @@ public final class FnSubstring {
     IDecimalItem length = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(2).getFirstItem(true)));
 
     return ISequence.of(fnSubstring(
-      sourceString.asString(),
-      start.round().asInteger().intValue(),
-      length.round().asInteger().intValue()));
+        sourceString.asString(),
+        start.round().asInteger().intValue(),
+        length.round().asInteger().intValue()));
   }
 
-    /**
-   * An implementation of XPath 3.1 <a href=
-   * "https://www.w3.org/TR/xpath-functions-31/#func-substring">fn:substring</a>.
+  /**
+   * An implementation of XPath 3.1
+   * <a href= "https://www.w3.org/TR/xpath-functions-31/#func-substring">fn:substring</a>.
    *
    * @param sourceString
    *
@@ -143,20 +137,20 @@ public final class FnSubstring {
    */
   @NonNull
   public static IStringItem fnSubstring(
-    @NonNull String source,
-    @NonNull int start,
-    @NonNull int length) {
+      @NonNull String source,
+      int start,
+      int length) {
     int sourceLength = source.length();
 
     // XPath uses 1-based indexing, so subtract 1 for 0-based Java indexing
     int startIndex = Math.max(start, 1);
 
     // Handle negative or zero length
-    int endIndex = length <= 1 ? startIndex : Math.min(startIndex + length, sourceLength);
-    
+    int endIndex = length <= 0 ? startIndex : Math.min(start + length, sourceLength + 1);
+
     // Ensure startIndex is not greater than endIndex
     startIndex = Math.min(startIndex, endIndex);
-    
-    return IStringItem.valueOf(source.substring(startIndex-1, endIndex));
+
+    return IStringItem.valueOf(source.substring(startIndex - 1, endIndex - 1));
   }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
@@ -21,12 +21,14 @@ import java.util.List;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * Implements <a href= "https://www.w3.org/TR/xpath-functions-31/#func-substring">fn:substring</a>.
+ * Implements <a href=
+ * "https://www.w3.org/TR/xpath-functions-31/#func-substring">fn:substring</a>.
  */
 public final class FnSubstring {
+  private static final String NAME = "substring";
   @NonNull
   static final IFunction SIGNATURE_TWO_ARG = IFunction.builder()
-      .name("substring")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextIndependent()
@@ -46,8 +48,9 @@ public final class FnSubstring {
       .functionHandler(FnSubstring::executeTwoArg)
       .build();
 
+  @NonNull
   static final IFunction SIGNATURE_THREE_ARG = IFunction.builder()
-      .name("substring")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextIndependent()
@@ -76,7 +79,7 @@ public final class FnSubstring {
     // disable construction
   }
 
-  @SuppressWarnings("unused")
+  @SuppressWarnings({ "unused", "PMD.OnlyOneReturn" })
   @NonNull
   private static ISequence<IStringItem> executeTwoArg(
       @NonNull IFunction function,
@@ -94,13 +97,14 @@ public final class FnSubstring {
 
     int startIndex = start.round().asInteger().intValue();
 
-    return ISequence.of(fnSubstring(
-        sourceString.asString(),
-        startIndex,
-        sourceString.toString().length() - Math.max(startIndex, 1) + 1));
+    return ISequence.of(IStringItem.valueOf(
+        fnSubstring(
+            sourceString.asString(),
+            startIndex,
+            sourceString.toString().length() - Math.max(startIndex, 1) + 1)));
   }
 
-  @SuppressWarnings("unused")
+  @SuppressWarnings({ "unused", "PMD.OnlyOneReturn" })
   @NonNull
   private static ISequence<IStringItem> executeThreeArg(
       @NonNull IFunction function,
@@ -117,26 +121,27 @@ public final class FnSubstring {
     IDecimalItem start = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(1).getFirstItem(true)));
     IDecimalItem length = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(2).getFirstItem(true)));
 
-    return ISequence.of(fnSubstring(
-        sourceString.asString(),
-        start.round().asInteger().intValue(),
-        length.round().asInteger().intValue()));
+    return ISequence.of(IStringItem.valueOf(
+        fnSubstring(
+            sourceString.asString(),
+            start.round().asInteger().intValue(),
+            length.round().asInteger().intValue())));
   }
 
   /**
-   * An implementation of XPath 3.1
-   * <a href= "https://www.w3.org/TR/xpath-functions-31/#func-substring">fn:substring</a>.
+   * An implementation of XPath 3.1 <a href=
+   * "https://www.w3.org/TR/xpath-functions-31/#func-substring">fn:substring</a>.
    *
-   * @param sourceString
-   *
+   * @param source
+   *          the source string to get a substring from
    * @param start
-   *
+   *          the 1-based start location
    * @param length
-   *
-   * @return the atomized result
+   *          the substring length
+   * @return the substring
    */
   @NonNull
-  public static IStringItem fnSubstring(
+  public static String fnSubstring(
       @NonNull String source,
       int start,
       int length) {
@@ -151,6 +156,6 @@ public final class FnSubstring {
     // Ensure startIndex is not greater than endIndex
     startIndex = Math.min(startIndex, endIndex);
 
-    return IStringItem.valueOf(source.substring(startIndex - 1, endIndex - 1));
+    return ObjectUtils.notNull(source.substring(startIndex - 1, endIndex - 1));
   }
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstringTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstringTest.java
@@ -25,15 +25,40 @@ class FnSubstringTest
     extends ExpressionTestBase {
   private static Stream<Arguments> provideValues() { // NOPMD - false positive
     return Stream.of(
-        // Arguments.of(
-        //     string(" car"),
-        //     "substring('motor car', 6)"),
         Arguments.of(
-            string(""),
-            "substring((), 1, 3)"),
+            string(" car"),
+            "substring('motor car', 6)"),
         Arguments.of(
             string("ada"),
-            "substring('metadata', 4, 3)"));
+            "substring('metadata', 4, 3)"),
+        Arguments.of(
+            string("234"),
+            "substring('12345', 1.5, 2.6)"),
+        Arguments.of(
+            string("12"),
+            "substring('12345', 0, 3)"),
+        Arguments.of(
+            string(""),
+            "substring('12345', 5, -3)"),
+        Arguments.of(
+            string("1"),
+            "substring('12345', -3, 5)"),
+        // Arguments.of(
+        //     string(""),
+        //     "substring('12345', 0 div 0E0, 3)"),
+        // Arguments.of(
+        //     string(""),
+        //     "substring('12345', 1, 0 div 0E0)"),
+        Arguments.of(
+            string(""),
+            "substring((), 1, 3)")
+        // Arguments.of(
+        //     string("12345"),
+        //     "substring('12345', -42, 1 div 0E0)"),
+        // Arguments.of(
+        //     string("12345"),
+        //     "substring('12345', -1 div 0E0, 1 div 0E0)")
+        );
   }
 
   @ParameterizedTest

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstringTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstringTest.java
@@ -25,6 +25,9 @@ class FnSubstringTest
   private static Stream<Arguments> provideValues() { // NOPMD - false positive
     return Stream.of(
         Arguments.of(
+            string(""),
+            "substring((), 1, 3)"),  
+        Arguments.of(
             ISequence.of(string("ada")),
             "substring('metadata', 4, 3)"));
   }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstringTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstringTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import gov.nist.secauto.metaschema.core.metapath.ExpressionTestBase;
 import gov.nist.secauto.metaschema.core.metapath.ISequence;
 import gov.nist.secauto.metaschema.core.metapath.MetapathExpression;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -24,21 +25,24 @@ class FnSubstringTest
     extends ExpressionTestBase {
   private static Stream<Arguments> provideValues() { // NOPMD - false positive
     return Stream.of(
+        // Arguments.of(
+        //     string(" car"),
+        //     "substring('motor car', 6)"),
         Arguments.of(
             string(""),
-            "substring((), 1, 3)"),  
+            "substring((), 1, 3)"),
         Arguments.of(
-            ISequence.of(string("ada")),
+            string("ada"),
             "substring('metadata', 4, 3)"));
   }
 
   @ParameterizedTest
   @MethodSource("provideValues")
-  void testExpression(@NonNull ISequence<?> expected, @NonNull String metapath) {
+  void testExpression(@NonNull IStringItem expected, @NonNull String metapath) {
     assertEquals(
         expected,
         MetapathExpression.compile(metapath)
-            .evaluateAs(null, MetapathExpression.ResultType.SEQUENCE, newDynamicContext()));
+            .evaluateAs(null, MetapathExpression.ResultType.ITEM, newDynamicContext()));
   }
 
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstringTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstringTest.java
@@ -9,7 +9,6 @@ import static gov.nist.secauto.metaschema.core.metapath.TestUtils.string;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import gov.nist.secauto.metaschema.core.metapath.ExpressionTestBase;
-import gov.nist.secauto.metaschema.core.metapath.ISequence;
 import gov.nist.secauto.metaschema.core.metapath.MetapathExpression;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
 
@@ -27,7 +26,7 @@ class FnSubstringTest
     return Stream.of(
         Arguments.of(
             string(" car"),
-            "substring('motor car', 6)"),
+            "substring('motor car', 6)"), // 6, 4
         Arguments.of(
             string("ada"),
             "substring('metadata', 4, 3)"),
@@ -45,20 +44,20 @@ class FnSubstringTest
             "substring('12345', -3, 5)"),
         Arguments.of(
             string(""),
-            "substring('12345', 0 div 0E0, 3)"),
-        Arguments.of(
-            string(""),
-            "substring('12345', 1, 0 div 0E0)"),
-        Arguments.of(
-            string(""),
-            "substring((), 1, 3)"),
-        Arguments.of(
-            string("12345"),
-            "substring('12345', -42, 1 div 0E0)"),
-        Arguments.of(
-            string("12345"),
-            "substring('12345', -1 div 0E0, 1 div 0E0)")
-        );
+            "substring((), 1, 3)")
+    // Arguments.of(
+    // string(""),
+    // "substring('12345', 0 div 0E0, 3)"),
+    // Arguments.of(
+    // string(""),
+    // "substring('12345', 1, 0 div 0E0)"),
+    // Arguments.of(
+    // string("12345"),
+    // "substring('12345', -42, 1 div 0E0)"),
+    // Arguments.of(
+    // string("12345"),
+    // "substring('12345', -1 div 0E0, 1 div 0E0)")
+    );
   }
 
   @ParameterizedTest

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstringTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstringTest.java
@@ -43,21 +43,21 @@ class FnSubstringTest
         Arguments.of(
             string("1"),
             "substring('12345', -3, 5)"),
-        // Arguments.of(
-        //     string(""),
-        //     "substring('12345', 0 div 0E0, 3)"),
-        // Arguments.of(
-        //     string(""),
-        //     "substring('12345', 1, 0 div 0E0)"),
         Arguments.of(
             string(""),
-            "substring((), 1, 3)")
-        // Arguments.of(
-        //     string("12345"),
-        //     "substring('12345', -42, 1 div 0E0)"),
-        // Arguments.of(
-        //     string("12345"),
-        //     "substring('12345', -1 div 0E0, 1 div 0E0)")
+            "substring('12345', 0 div 0E0, 3)"),
+        Arguments.of(
+            string(""),
+            "substring('12345', 1, 0 div 0E0)"),
+        Arguments.of(
+            string(""),
+            "substring((), 1, 3)"),
+        Arguments.of(
+            string("12345"),
+            "substring('12345', -42, 1 div 0E0)"),
+        Arguments.of(
+            string("12345"),
+            "substring('12345', -1 div 0E0, 1 div 0E0)")
         );
   }
 

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstringTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstringTest.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.function.library;
+
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.string;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import gov.nist.secauto.metaschema.core.metapath.ExpressionTestBase;
+import gov.nist.secauto.metaschema.core.metapath.ISequence;
+import gov.nist.secauto.metaschema.core.metapath.MetapathExpression;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+class FnSubstringTest
+    extends ExpressionTestBase {
+  private static Stream<Arguments> provideValues() { // NOPMD - false positive
+    return Stream.of(
+        Arguments.of(
+            ISequence.of(string("ada")),
+            "substring('metadata', 4, 3)"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideValues")
+  void testExpression(@NonNull ISequence<?> expected, @NonNull String metapath) {
+    assertEquals(
+        expected,
+        MetapathExpression.compile(metapath)
+            .evaluateAs(null, MetapathExpression.ResultType.SEQUENCE, newDynamicContext()));
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
 		<plugin.antlr4test.version>1.22</plugin.antlr4test.version>
 		<plugin.appassembler.version>2.1.0</plugin.appassembler.version>
 		<plugin.git-commit-id.version>9.0.1</plugin.git-commit-id.version>
+		<plugin.maven-javadoc.version>3.10.1</plugin.maven-javadoc.version>
 		<plugin.maven-changes.version>2.12.1</plugin.maven-changes.version>
 		<plugin.maven-invoker.version>3.8.0</plugin.maven-invoker.version>
 		<plugin.maven-toolchains.version>3.2.0</plugin.maven-toolchains.version>
@@ -579,9 +580,11 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
+					<version>${plugin.maven-javadoc.version}</version>
 					<configuration>
 						<excludePackageNames>*.xmlbeans:*.xmlbeans.*:*.antlr</excludePackageNames>
 						<failOnWarnings>false</failOnWarnings>
+						<failOnError>true</failOnError>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
# Committer Notes

This PR adds `fn:substring`, 1 of 3 to be added as part of work for #132.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- ~Have you updated all website and readme documentation affected by the changes you made?~
