### PR TITLE
Support the normalize-space Metapath function

### DIFF
--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/DynamicContext.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/DynamicContext.java
@@ -285,7 +285,7 @@ public class DynamicContext { // NOPMD - intentional data class
     letVariableMap.put(name, boundValue);
     return this;
   }
-
+  
   private class CachingLoader implements IDocumentLoader {
     @NonNull
     private final IDocumentLoader proxy;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/StringLiteral.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/StringLiteral.java
@@ -23,7 +23,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public class StringLiteral
     extends AbstractLiteralExpression<IStringItem, String> {
 
-  private static final Pattern QUOTE_PATTERN = Pattern.compile("^'(.*)'$|^\"(.*)\"$");
+  private static final Pattern QUOTE_PATTERN = Pattern.compile("(?:^'(.*)'$)|(?:^\"(.*)\"$)");
 
   /**
    * Construct a new expression that always returns the same string value.
@@ -43,17 +43,7 @@ public class StringLiteral
   @SuppressWarnings("null")
   @NonNull
   private static String removeQuotes(@NonNull String value) {
-    Matcher matcher = QUOTE_PATTERN.matcher(value);
-
-    String retval = value;
-    if (matcher.matches()) {
-      if (matcher.group(1) != null) {
-        retval = matcher.group(1);
-      } else if (matcher.group(2) != null) {
-        retval = matcher.group(2);
-      }
-    }
-    return retval;
+    return value.substring(1, value.length() - 1);
   }
 
   @Override

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/DefaultFunction.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/DefaultFunction.java
@@ -6,6 +6,7 @@
 package gov.nist.secauto.metaschema.core.metapath.function;
 
 import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
+import gov.nist.secauto.metaschema.core.metapath.DynamicMetapathException;
 import gov.nist.secauto.metaschema.core.metapath.ISequence;
 import gov.nist.secauto.metaschema.core.metapath.InvalidTypeMetapathException;
 import gov.nist.secauto.metaschema.core.metapath.MetapathException;
@@ -262,9 +263,17 @@ public class DefaultFunction
       @NonNull DynamicContext dynamicContext,
       @NonNull ISequence<?> focus) {
     try {
-      List<ISequence<?>> convertedArguments = convertArguments(this, arguments);
 
-      IItem contextItem = isFocusDepenent() ? ObjectUtils.requireNonNull(focus.getFirstItem(true)) : null;
+      IItem contextItem = null;
+      
+      if (isFocusDepenent()) {
+        contextItem = focus.getFirstItem(true);
+        if (contextItem == null) {
+          throw new DynamicMetapathException(DynamicMetapathException.DYNAMIC_CONTEXT_ABSENT, "The context is empty");
+        }
+      }
+
+      List<ISequence<?>> convertedArguments = convertArguments(this, arguments);
 
       CallingContext callingContext = null;
       ISequence<?> result = null;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/DefaultFunctionLibrary.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/DefaultFunctionLibrary.java
@@ -116,6 +116,8 @@ public class DefaultFunctionLibrary
     // https://www.w3.org/TR/xpath-functions-31/#func-months-from-duration
     // https://www.w3.org/TR/xpath-functions-31/#func-node-name
     // https://www.w3.org/TR/xpath-functions-31/#func-normalize-space
+    registerFunction(FnNormalizeSpace.SIGNATURE_NO_ARG);
+    registerFunction(FnNormalizeSpace.SIGNATURE_ONE_ARG);
     // https://www.w3.org/TR/xpath-functions-31/#func-normalize-unicode
     // https://www.w3.org/TR/xpath-functions-31/#func-not
     registerFunction(FnNot.SIGNATURE);

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnNormalizeSpace.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnNormalizeSpace.java
@@ -68,6 +68,8 @@ public final class FnNormalizeSpace {
 
     ISequence<IAnyAtomicItem> retval;
     if (focus == null) {
+      // Per the specification:
+      // If no argument is supplied and the context item is absent]then a dynamic error is raised: [[err:XPDY0002].
       throw new DynamicMetapathException(DynamicMetapathException.DYNAMIC_CONTEXT_ABSENT, "The context is empty");
     }
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnNormalizeSpace.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnNormalizeSpace.java
@@ -65,14 +65,9 @@ public final class FnNormalizeSpace {
       @NonNull List<ISequence<?>> arguments,
       @NonNull DynamicContext dynamicContext,
       IItem focus) {
-
-    ISequence<IAnyAtomicItem> retval;
-    if (focus == null) {
-      // Per the specification:
-      // If no argument is supplied and the context item is absent]then a dynamic error is raised: [[err:XPDY0002].
-      throw new DynamicMetapathException(DynamicMetapathException.DYNAMIC_CONTEXT_ABSENT, "The context is empty");
-    }
-
+    // the Focus should always be non-null, since the function if focus-dependent
+    assert focus != null;
+    
     return ISequence.of(FnString.fnStringItem(focus).normalizeSpace());
   }
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnNormalizeSpace.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnNormalizeSpace.java
@@ -1,0 +1,89 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.function.library;
+
+import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
+import gov.nist.secauto.metaschema.core.metapath.DynamicMetapathException;
+import gov.nist.secauto.metaschema.core.metapath.ISequence;
+import gov.nist.secauto.metaschema.core.metapath.MetapathConstants;
+import gov.nist.secauto.metaschema.core.metapath.function.FunctionUtils;
+import gov.nist.secauto.metaschema.core.metapath.function.IArgument;
+import gov.nist.secauto.metaschema.core.metapath.function.IFunction;
+import gov.nist.secauto.metaschema.core.metapath.item.IItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
+import gov.nist.secauto.metaschema.core.util.ObjectUtils;
+
+import java.util.List;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Implements <a href=
+ * "https://www.w3.org/TR/xpath-functions-31/#func-normalize-space">fn:normalize-space</a>.
+ */
+public final class FnNormalizeSpace {
+  @NonNull
+  static final IFunction SIGNATURE_NO_ARG = IFunction.builder()
+      .name("normalize-space")
+      .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
+      .deterministic()
+      .contextDependent()
+      .focusDependent()
+      .returnType(IStringItem.class)
+      .returnOne()
+      .functionHandler(FnNormalizeSpace::executeNoArg)
+      .build();
+
+  @NonNull
+  static final IFunction SIGNATURE_ONE_ARG = IFunction.builder()
+      .name("normalize-space")
+      .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
+      .deterministic()
+      .contextIndependent()
+      .focusIndependent()
+      .argument(IArgument.builder()
+          .name("arg")
+          .type(IStringItem.class)
+          .zeroOrOne()
+          .build())
+      .returnType(IStringItem.class)
+      .returnOne()
+      .functionHandler(FnNormalizeSpace::executeOneArg)
+      .build();
+
+  private FnNormalizeSpace() {
+    // disable construction
+  }
+
+  @SuppressWarnings("unused")
+  @NonNull
+  private static ISequence<IStringItem> executeNoArg(@NonNull IFunction function,
+      @NonNull List<ISequence<?>> arguments,
+      @NonNull DynamicContext dynamicContext,
+      IItem focus) {
+
+    ISequence<IAnyAtomicItem> retval;
+    if (focus == null) {
+      throw new DynamicMetapathException(DynamicMetapathException.DYNAMIC_CONTEXT_ABSENT, "The context is empty");
+    }
+
+    return ISequence.of(FnString.fnStringItem(focus).normalizeSpace());
+  }
+
+  @SuppressWarnings("unused")
+  @NonNull
+  private static ISequence<IStringItem> executeOneArg(
+      @NonNull IFunction function,
+      @NonNull List<ISequence<?>> arguments,
+      @NonNull DynamicContext dynamicContext,
+      IItem focus) {
+
+    IStringItem value = FunctionUtils.asTypeOrNull(ObjectUtils.requireNonNull(arguments.get(0)).getFirstItem(true));
+
+    return value == null ? ISequence.empty() : ISequence.of(value.normalizeSpace());
+  }
+}

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnString.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnString.java
@@ -6,7 +6,6 @@
 package gov.nist.secauto.metaschema.core.metapath.function.library;
 
 import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
-import gov.nist.secauto.metaschema.core.metapath.DynamicMetapathException;
 import gov.nist.secauto.metaschema.core.metapath.ISequence;
 import gov.nist.secauto.metaschema.core.metapath.MetapathConstants;
 import gov.nist.secauto.metaschema.core.metapath.function.FunctionUtils;
@@ -67,11 +66,8 @@ public final class FnString {
       @NonNull List<ISequence<?>> arguments,
       @NonNull DynamicContext dynamicContext,
       IItem focus) {
-
-    ISequence<IAnyAtomicItem> retval;
-    if (focus == null) {
-      throw new DynamicMetapathException(DynamicMetapathException.DYNAMIC_CONTEXT_ABSENT, "The context is empty");
-    }
+    // the Focus should always be non-null, since the function if focus-dependent
+    assert focus != null;
 
     return ISequence.of(fnStringItem(focus));
   }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/AbstractStringItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/AbstractStringItem.java
@@ -17,7 +17,7 @@ public abstract class AbstractStringItem
     implements IStringItem {
   private static final String WHITESPACE_SEGMENT = "[ \t\r\n]";
   private static final Pattern TRIM_END = Pattern.compile(WHITESPACE_SEGMENT + "++$");
-  private static final Pattern TRIM_START = Pattern.compile("^" + WHITESPACE_SEGMENT + "++");
+  private static final Pattern TRIM_START = Pattern.compile("^" + WHITESPACE_SEGMENT + "+");
   private static final Pattern TRIM_MIDDLE = Pattern.compile(WHITESPACE_SEGMENT + "{2,}");
 
   /**

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/IStringItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/IStringItem.java
@@ -65,6 +65,12 @@ public interface IStringItem extends IAnyAtomicItem {
     return compareTo(other.asStringItem());
   }
 
+  /**
+   * An implementation of <a href=
+   * "https://www.w3.org/TR/xpath-functions-31/#func-normalize-space">fn::normalize-space</a>.
+   *
+   * @return the normalized string value for this string
+   */
   @NonNull
   IStringItem normalizeSpace();
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/ExpressionTestBase.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/ExpressionTestBase.java
@@ -23,7 +23,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public class ExpressionTestBase {
   @NonNull
   @RegisterExtension
-  final Mockery context = new JUnit5Mockery();
+  public final Mockery context = new JUnit5Mockery();
 
   /**
    * Get the mocking context.

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/ExpressionTestBase.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/ExpressionTestBase.java
@@ -23,7 +23,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public class ExpressionTestBase {
   @NonNull
   @RegisterExtension
-  private final Mockery context = new JUnit5Mockery();
+  final Mockery context = new JUnit5Mockery();
 
   /**
    * Get the mocking context.

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnFalseTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnFalseTest.java
@@ -7,6 +7,7 @@ package gov.nist.secauto.metaschema.core.metapath.function.library;
 
 import gov.nist.secauto.metaschema.core.metapath.ISequence;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IBooleanItem;
+import gov.nist.secauto.metaschema.core.util.CollectionUtil;
 
 import org.junit.jupiter.api.Test;
 
@@ -18,6 +19,6 @@ class FnFalseTest
     assertFunctionResult(
         FnFalse.SIGNATURE,
         ISequence.of(IBooleanItem.FALSE),
-        null);
+        CollectionUtil.emptyList());
   }
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnNormalizeSpaceTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnNormalizeSpaceTest.java
@@ -5,19 +5,15 @@
 
 package gov.nist.secauto.metaschema.core.metapath.function.library;
 
-import static gov.nist.secauto.metaschema.core.metapath.TestUtils.array;
-import static gov.nist.secauto.metaschema.core.metapath.TestUtils.integer;
 import static gov.nist.secauto.metaschema.core.metapath.TestUtils.sequence;
 import static gov.nist.secauto.metaschema.core.metapath.TestUtils.string;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import gov.nist.secauto.metaschema.core.metapath.DynamicMetapathException;
 import gov.nist.secauto.metaschema.core.metapath.ExpressionTestBase;
-import gov.nist.secauto.metaschema.core.metapath.ISequence;
-import gov.nist.secauto.metaschema.core.metapath.InvalidTypeMetapathException;
 import gov.nist.secauto.metaschema.core.metapath.MetapathException;
 import gov.nist.secauto.metaschema.core.metapath.MetapathExpression;
-import gov.nist.secauto.metaschema.core.metapath.function.InvalidTypeFunctionException;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
 
 import org.junit.jupiter.api.Test;
@@ -36,7 +32,8 @@ class FnNormalizeSpaceTest
     return Stream.of(
         Arguments.of(
             string("The wealthy curled darlings of our nation."),
-            "fn:normalize-space(\" The    wealthy curled darlings \n\r       \t                                 of    our    nation. \")"));
+            "fn:normalize-space(\" The    wealthy curled darlings \n\r       \t" +
+            "                                 of    our    nation. \")"));
   }
 
   @ParameterizedTest
@@ -49,10 +46,10 @@ class FnNormalizeSpaceTest
 
   @Test
   void testNoFocus() {
-    InvalidTypeMetapathException throwable = assertThrows(InvalidTypeMetapathException.class,
+    DynamicMetapathException throwable = assertThrows(DynamicMetapathException.class,
         () -> {
           try {
-            ISequence<IStringItem> result = FunctionTestBase.executeFunction(
+            FunctionTestBase.executeFunction(
                 FnNormalizeSpace.SIGNATURE_NO_ARG,
                 newDynamicContext(),
                 null,
@@ -61,5 +58,6 @@ class FnNormalizeSpaceTest
             throw ex.getCause();
           }
         });
+    assertEquals(DynamicMetapathException.DYNAMIC_CONTEXT_ABSENT, throwable.getCode());
   }
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnNormalizeSpaceTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnNormalizeSpaceTest.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.function.library;
+
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.array;
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.integer;
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.sequence;
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.string;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import gov.nist.secauto.metaschema.core.metapath.ExpressionTestBase;
+import gov.nist.secauto.metaschema.core.metapath.ISequence;
+import gov.nist.secauto.metaschema.core.metapath.InvalidTypeMetapathException;
+import gov.nist.secauto.metaschema.core.metapath.MetapathException;
+import gov.nist.secauto.metaschema.core.metapath.MetapathExpression;
+import gov.nist.secauto.metaschema.core.metapath.function.InvalidTypeFunctionException;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+class FnNormalizeSpaceTest
+    extends ExpressionTestBase {
+  private static Stream<Arguments> provideValues() { // NOPMD - false positive
+    return Stream.of(
+        Arguments.of(
+            string("The wealthy curled darlings of our nation."),
+            "fn:normalize-space(\" The    wealthy curled darlings \n\r       \t                                 of    our    nation. \")"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideValues")
+  void testExpression(@NonNull IStringItem expected, @NonNull String metapath) {
+    IStringItem result = MetapathExpression.compile(metapath)
+        .evaluateAs(null, MetapathExpression.ResultType.ITEM, newDynamicContext());
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void testNoFocus() {
+    InvalidTypeMetapathException throwable = assertThrows(InvalidTypeMetapathException.class,
+        () -> {
+          try {
+            ISequence<IStringItem> result = FunctionTestBase.executeFunction(
+                FnNormalizeSpace.SIGNATURE_NO_ARG,
+                newDynamicContext(),
+                null,
+                List.of(sequence()));
+          } catch (MetapathException ex) {
+            throw ex.getCause();
+          }
+        });
+  }
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnStringTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnStringTest.java
@@ -12,6 +12,7 @@ import static gov.nist.secauto.metaschema.core.metapath.TestUtils.string;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import gov.nist.secauto.metaschema.core.metapath.DynamicMetapathException;
 import gov.nist.secauto.metaschema.core.metapath.ExpressionTestBase;
 import gov.nist.secauto.metaschema.core.metapath.ISequence;
 import gov.nist.secauto.metaschema.core.metapath.InvalidTypeMetapathException;
@@ -54,11 +55,28 @@ class FnStringTest
   }
 
   @Test
-  void testInvalidArgument() {
-    InvalidTypeMetapathException throwable = assertThrows(InvalidTypeMetapathException.class,
+  void testNoFocus() {
+    DynamicMetapathException throwable = assertThrows(DynamicMetapathException.class,
         () -> {
           try {
-            ISequence<IStringItem> result = FunctionTestBase.executeFunction(
+            FunctionTestBase.executeFunction(
+                FnString.SIGNATURE_NO_ARG,
+                newDynamicContext(),
+                null,
+                List.of(sequence()));
+          } catch (MetapathException ex) {
+            throw ex.getCause();
+          }
+        });
+    assertEquals(DynamicMetapathException.DYNAMIC_CONTEXT_ABSENT, throwable.getCode());
+  }
+
+  @Test
+  void testInvalidArgument() {
+    assertThrows(InvalidTypeMetapathException.class,
+        () -> {
+          try {
+            FunctionTestBase.executeFunction(
                 FnString.SIGNATURE_ONE_ARG,
                 newDynamicContext(),
                 ISequence.empty(),
@@ -74,7 +92,7 @@ class FnStringTest
     InvalidTypeFunctionException throwable = assertThrows(InvalidTypeFunctionException.class,
         () -> {
           try {
-            ISequence<IStringItem> result = FunctionTestBase.executeFunction(
+            FunctionTestBase.executeFunction(
                 FnString.SIGNATURE_ONE_ARG,
                 newDynamicContext(),
                 ISequence.empty(),

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTrueTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTrueTest.java
@@ -7,6 +7,7 @@ package gov.nist.secauto.metaschema.core.metapath.function.library;
 
 import gov.nist.secauto.metaschema.core.metapath.ISequence;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IBooleanItem;
+import gov.nist.secauto.metaschema.core.util.CollectionUtil;
 
 import org.junit.jupiter.api.Test;
 
@@ -18,6 +19,6 @@ class FnTrueTest
     assertFunctionResult(
         FnTrue.SIGNATURE,
         ISequence.of(IBooleanItem.TRUE),
-        null);
+        CollectionUtil.emptyList());
   }
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FunctionTestBase.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FunctionTestBase.java
@@ -105,7 +105,7 @@ public class FunctionTestBase
 
     DynamicContext context = dynamicContext == null ? new DynamicContext() : dynamicContext;
     ISequence<?> focusSeqence = function.isFocusDepenent()
-        ? ObjectUtils.requireNonNull(focus, "Function call requires a focus")
+        ? focus == null ? ISequence.empty() : focus
         : ISequence.empty();
     return (ISequence<R>) function.execute(
         arguments == null ? CollectionUtil.emptyList() : arguments,

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FunctionTestBase.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FunctionTestBase.java
@@ -15,8 +15,6 @@ import gov.nist.secauto.metaschema.core.metapath.function.FunctionUtils;
 import gov.nist.secauto.metaschema.core.metapath.function.IFunction;
 import gov.nist.secauto.metaschema.core.metapath.item.IItem;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.INumericItem;
-import gov.nist.secauto.metaschema.core.util.CollectionUtil;
-import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
 import java.util.List;
 
@@ -27,8 +25,7 @@ public class FunctionTestBase
     extends ExpressionTestBase {
 
   /**
-   * Assert that the execution of the provided function and arguments produce the
-   * desired results.
+   * Assert that the execution of the provided function and arguments produce the desired results.
    *
    * @param function
    *          the function to test
@@ -40,18 +37,17 @@ public class FunctionTestBase
   public static void assertFunctionResult(
       @NonNull IFunction function,
       @NonNull ISequence<?> expectedResult,
-      List<ISequence<?>> arguments) {
+      @NonNull List<ISequence<?>> arguments) {
     assertFunctionResult(function, null, expectedResult, arguments);
   }
 
   /**
-   * Assert that the execution of the provided function and arguments produce the
-   * desired results.
+   * Assert that the execution of the provided function and arguments produce the desired results.
    *
    * @param function
    *          the function to test
    * @param focus
-   *          the item focus to use for evaluation
+   *          the item focus to use for evaluation or {@code null} if there is no focus
    * @param expectedResult
    *          the expected result produced by the function
    * @param arguments
@@ -61,27 +57,7 @@ public class FunctionTestBase
       @NonNull IFunction function,
       @Nullable ISequence<?> focus,
       @NonNull ISequence<?> expectedResult,
-      List<ISequence<?>> arguments) {
-
-    List<ISequence<?>> usedArguments = arguments == null ? CollectionUtil.emptyList() : arguments;
-
-    // QName functionName = function.getQName();
-    //
-    // IFunction resolvedFunction =
-    // FunctionService.getInstance().getFunction(functionName,
-    // usedArguments.size());
-    //
-    // assertNotNull(resolvedFunction, String.format("Function '%s' not found in
-    // function service.", functionName));
-
-    assertFunctionResultInternal(function, focus, expectedResult, usedArguments);
-  }
-
-  private static void assertFunctionResultInternal(
-      @NonNull IFunction function,
-      @Nullable ISequence<?> focus,
-      @NonNull ISequence<?> expectedResult,
-      List<ISequence<?>> arguments) {
+      @NonNull List<ISequence<?>> arguments) {
     ISequence<INumericItem> result = FunctionTestBase.executeFunction(
         function,
         newDynamicContext(),
@@ -96,19 +72,35 @@ public class FunctionTestBase
 
   }
 
+  /**
+   * Execute the provided function using the provided context, focus and arguments.
+   * 
+   * @param <R>
+   *          the sequence result Java type
+   * @param function
+   *          the function to call
+   * @param dynamicContext
+   *          the dynamic evaluation context or {@code null} if the default should be used
+   * @param focus
+   *          the current focus or {@code null} if there is no focus
+   * @param arguments
+   *          the function arguments or an empty list if there are no arguments
+   * @return the result of evaluating the function
+   */
   @SuppressWarnings("unchecked")
+  @NonNull
   public static <R extends IItem> ISequence<R> executeFunction(
       @NonNull IFunction function,
       @Nullable DynamicContext dynamicContext,
       @Nullable ISequence<?> focus,
-      List<? extends ISequence<?>> arguments) {
+      @NonNull List<? extends ISequence<?>> arguments) {
 
     DynamicContext context = dynamicContext == null ? new DynamicContext() : dynamicContext;
     ISequence<?> focusSeqence = function.isFocusDepenent()
         ? focus == null ? ISequence.empty() : focus
         : ISequence.empty();
     return (ISequence<R>) function.execute(
-        arguments == null ? CollectionUtil.emptyList() : arguments,
+        arguments,
         context,
         focusSeqence);
   }

--- a/pom.xml
+++ b/pom.xml
@@ -92,16 +92,8 @@
 		<plugin.spotbugs.version>4.8.6.4</plugin.spotbugs.version>
 		<plugin.maven-surefire.version>3.5.0</plugin.maven-surefire.version>
 		<plugin.templating.version>3.0.0</plugin.templating.version>
-		<!-- The Surefire and Failsafe configurations override the <argLine>
-		element using the @{argLine} notation which
-         allows to include any argLine defined by plugins executing before them (such as
-		Jacoco). However, if no such
-         plugin executes before, the property is undefined and makes the tests fail.
-		Thus we define an empty property
-         here to make sure it doesn't fail. See also
-		https://issues.apache.org/jira/browse/SUREFIRE-1431
-        -->
-		<argLine />
+
+		<argLine>-Xmx1024m</argLine>
 	</properties>
 
 	<issueManagement>
@@ -651,7 +643,6 @@
 					<configuration>
 						<forkCount>1.5C</forkCount>
 						<reuseForks>true</reuseForks>
-						<argLine>@{argLine} -Xmx1024m</argLine>
 						<excludedEnvironmentVariables>
 							<excludedEnvironmentVariable>JAVA_TOOL_OPTIONS</excludedEnvironmentVariable>
 						</excludedEnvironmentVariables>


### PR DESCRIPTION
# Committer Notes

- Added support for the normalize-space Metapath function.
- Also fixed a bug in the string literal handling that inconsistently caused leading and trailing quotes to be removed. 
- Also fixed an issue with the build that was causing surefire to inconsistently handle a JUnit extension.

Resolves #133

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all website and readme documentation affected by the changes you made?
