### PR TITLE
Add contains and ends-with Metapath functions

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,5 +1,6 @@
 # broken plugin and dependency references
 https://bytebuddy.net/byte-buddy
+https://checkstyle.org/checks/indentation/indentation.html
 https://chronicle.software/java-parent-pom/compiler
 http://code.google.com/p/.*
 https://code.revelc.net/revelc/formatter-maven-plugin

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/DefaultFunction.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/DefaultFunction.java
@@ -158,13 +158,12 @@ public class DefaultFunction
   public static List<ISequence<?>> convertArguments(
       @NonNull IFunction function,
       @NonNull List<? extends ISequence<?>> parameters) {
-    @NonNull List<ISequence<?>> retval = new ArrayList<>(parameters.size());
+    @NonNull
+    List<ISequence<?>> retval = new ArrayList<>(parameters.size());
 
     Iterator<IArgument> argumentIterator = function.getArguments().iterator();
-    Iterator<? extends ISequence<?>> parametersIterator = parameters.iterator();
-
     IArgument argument = null;
-    while (parametersIterator.hasNext()) {
+    for (ISequence<?> parameter : parameters) {
       if (argumentIterator.hasNext()) {
         argument = argumentIterator.next();
       } else if (!function.isArityUnbounded()) {
@@ -173,7 +172,6 @@ public class DefaultFunction
             String.format("argument signature doesn't match '%s'", function.toSignature()));
       }
 
-      ISequence<?> parameter = parametersIterator.next();
       assert argument != null;
       assert parameter != null;
 
@@ -210,8 +208,7 @@ public class DefaultFunction
   }
 
   /**
-   * Based on XPath 3.1
-   * <a href="https://www.w3.org/TR/xpath-31/#dt-function-conversion">function
+   * Based on XPath 3.1 <a href="https://www.w3.org/TR/xpath-31/#dt-function-conversion">function
    * conversion</a> rules.
    *
    * @param argument
@@ -316,10 +313,7 @@ public class DefaultFunction
     if (this == obj) {
       return true; // NOPMD - readability
     }
-    if (obj == null) {
-      return false; // NOPMD - readability
-    }
-    if (getClass() != obj.getClass()) {
+    if ((obj == null) || (getClass() != obj.getClass())) {
       return false; // NOPMD - readability
     }
     DefaultFunction other = (DefaultFunction) obj;
@@ -389,8 +383,7 @@ public class DefaultFunction
       final int prime = 31;
       int result = 1;
       result = prime * result + getFunction().hashCode();
-      result = prime * result + Objects.hash(contextItem, arguments);
-      return result;
+      return prime * result + Objects.hash(contextItem, arguments);
     }
 
     @Override
@@ -398,10 +391,7 @@ public class DefaultFunction
       if (this == obj) {
         return true; // NOPMD - readability
       }
-      if (obj == null) {
-        return false; // NOPMD - readability
-      }
-      if (getClass() != obj.getClass()) {
+      if ((obj == null) || (getClass() != obj.getClass())) {
         return false; // NOPMD - readability
       }
       CallingContext other = (CallingContext) obj;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/DefaultFunction.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/DefaultFunction.java
@@ -158,8 +158,7 @@ public class DefaultFunction
   public static List<ISequence<?>> convertArguments(
       @NonNull IFunction function,
       @NonNull List<? extends ISequence<?>> parameters) {
-    @NonNull
-    List<ISequence<?>> retval = new ArrayList<>(parameters.size());
+    @NonNull List<ISequence<?>> retval = new ArrayList<>(parameters.size());
 
     Iterator<IArgument> argumentIterator = function.getArguments().iterator();
     IArgument argument = null;
@@ -208,7 +207,8 @@ public class DefaultFunction
   }
 
   /**
-   * Based on XPath 3.1 <a href="https://www.w3.org/TR/xpath-31/#dt-function-conversion">function
+   * Based on XPath 3.1
+   * <a href="https://www.w3.org/TR/xpath-31/#dt-function-conversion">function
    * conversion</a> rules.
    *
    * @param argument

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayAppend.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayAppend.java
@@ -22,9 +22,10 @@ import java.util.List;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class ArrayAppend {
+  private static final String NAME = "append";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("append")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_ARRAY)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayAppend.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayAppend.java
@@ -23,7 +23,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class ArrayAppend {
   @NonNull
-  public static final IFunction SIGNATURE = IFunction.builder()
+  static final IFunction SIGNATURE = IFunction.builder()
       .name("append")
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_ARRAY)
       .deterministic()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayFlatten.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayFlatten.java
@@ -20,9 +20,10 @@ import java.util.stream.Stream;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class ArrayFlatten {
+  private static final String NAME = "flatten";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("flatten")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_ARRAY)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayGet.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayGet.java
@@ -24,7 +24,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class ArrayGet {
   @NonNull
-  public static final IFunction SIGNATURE = IFunction.builder()
+  static final IFunction SIGNATURE = IFunction.builder()
       .name("get")
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_ARRAY)
       .deterministic()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayGet.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayGet.java
@@ -23,9 +23,10 @@ import java.util.List;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class ArrayGet {
+  private static final String NAME = "get";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("get")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_ARRAY)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayHead.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayHead.java
@@ -22,9 +22,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 public final class ArrayHead {
+  private static final String NAME = "head";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("head")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_ARRAY)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayInsertBefore.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayInsertBefore.java
@@ -24,7 +24,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class ArrayInsertBefore {
   @NonNull
-  public static final IFunction SIGNATURE = IFunction.builder()
+  static final IFunction SIGNATURE = IFunction.builder()
       .name("insert-before")
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_ARRAY)
       .deterministic()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayInsertBefore.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayInsertBefore.java
@@ -23,9 +23,10 @@ import java.util.List;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class ArrayInsertBefore {
+  private static final String NAME = "insert-before";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("insert-before")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_ARRAY)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayJoin.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayJoin.java
@@ -24,7 +24,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class ArrayJoin {
   @NonNull
-  public static final IFunction SIGNATURE = IFunction.builder()
+  static final IFunction SIGNATURE = IFunction.builder()
       .name("join")
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_ARRAY)
       .deterministic()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayJoin.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayJoin.java
@@ -23,9 +23,10 @@ import java.util.stream.Collectors;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class ArrayJoin {
+  private static final String NAME = "join";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("join")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_ARRAY)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayPut.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayPut.java
@@ -25,7 +25,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class ArrayPut {
   @NonNull
-  public static final IFunction SIGNATURE = IFunction.builder()
+  static final IFunction SIGNATURE = IFunction.builder()
       .name("put")
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_ARRAY)
       .deterministic()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayPut.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayPut.java
@@ -24,9 +24,10 @@ import java.util.List;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class ArrayPut {
+  private static final String NAME = "put";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("put")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_ARRAY)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayRemove.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayRemove.java
@@ -27,9 +27,10 @@ import java.util.stream.IntStream;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class ArrayRemove {
+  private static final String NAME = "remove";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("remove")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_ARRAY)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayRemove.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayRemove.java
@@ -28,7 +28,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class ArrayRemove {
   @NonNull
-  public static final IFunction SIGNATURE = IFunction.builder()
+  static final IFunction SIGNATURE = IFunction.builder()
       .name("remove")
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_ARRAY)
       .deterministic()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayReverse.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayReverse.java
@@ -23,9 +23,10 @@ import java.util.List;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class ArrayReverse {
+  private static final String NAME = "reverse";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("reverse")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_ARRAY)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayReverse.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayReverse.java
@@ -24,7 +24,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class ArrayReverse {
   @NonNull
-  public static final IFunction SIGNATURE = IFunction.builder()
+  static final IFunction SIGNATURE = IFunction.builder()
       .name("reverse")
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_ARRAY)
       .deterministic()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArraySize.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArraySize.java
@@ -21,9 +21,10 @@ import java.util.List;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class ArraySize {
+  private static final String NAME = "size";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("size")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_ARRAY)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArraySize.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArraySize.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-public class ArraySize {
+public final class ArraySize {
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
       .name("size")
@@ -55,5 +55,9 @@ public class ArraySize {
     IArrayItem<?> array = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(0).getFirstItem(true)));
 
     return ISequence.of(IIntegerItem.valueOf(array.size()));
+  }
+
+  private ArraySize() {
+    // disable
   }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArraySubarray.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArraySubarray.java
@@ -24,9 +24,10 @@ import java.util.List;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class ArraySubarray {
+  private static final String NAME = "subarray";
   @NonNull
-  public static final IFunction SIGNATURE_TWO_ARG = IFunction.builder()
-      .name("subarray")
+  static final IFunction SIGNATURE_TWO_ARG = IFunction.builder()
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_ARRAY)
       .deterministic()
       .contextIndependent()
@@ -46,8 +47,8 @@ public final class ArraySubarray {
       .functionHandler(ArraySubarray::executeTwoArg)
       .build();
   @NonNull
-  public static final IFunction SIGNATURE_THREE_ARG = IFunction.builder()
-      .name("subarray")
+  static final IFunction SIGNATURE_THREE_ARG = IFunction.builder()
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_ARRAY)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayTail.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArrayTail.java
@@ -21,9 +21,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 public final class ArrayTail {
+  private static final String NAME = "tail";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("tail")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_ARRAY)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/DefaultFunctionLibrary.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/DefaultFunctionLibrary.java
@@ -49,7 +49,8 @@ public class DefaultFunctionLibrary
     registerFunction(FnCompare.SIGNATURE);
     // https://www.w3.org/TR/xpath-functions-31/#func-concat
     registerFunction(FnConcat.SIGNATURE);
-    // P1: https://www.w3.org/TR/xpath-functions-31/#func-contains
+    // https://www.w3.org/TR/xpath-functions-31/#func-contains
+    registerFunction(FnContains.SIGNATURE);
     // https://www.w3.org/TR/xpath-functions-31/#func-count
     registerFunction(FnCount.SIGNATURE);
     // P2: https://www.w3.org/TR/xpath-functions-31/#func-current-date
@@ -74,7 +75,8 @@ public class DefaultFunctionLibrary
     // https://www.w3.org/TR/xpath-functions-31/#func-empty
     registerFunction(FnEmpty.SIGNATURE);
     // https://www.w3.org/TR/xpath-functions-31/#func-encode-for-uri
-    // P1: https://www.w3.org/TR/xpath-functions-31/#func-ends-with
+    // https://www.w3.org/TR/xpath-functions-31/#func-ends-with
+    registerFunction(FnEndsWith.SIGNATURE);
     // P2: https://www.w3.org/TR/xpath-functions-31/#func-exactly-one
     // https://www.w3.org/TR/xpath-functions-31/#func-exists
     registerFunction(FnExists.SIGNATURE);

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnBaseUri.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnBaseUri.java
@@ -27,10 +27,10 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * document-uri function.
  */
 public final class FnBaseUri {
-
+  private static final String NAME = "base-uri";
   @NonNull
   static final IFunction SIGNATURE_NO_ARG = IFunction.builder()
-      .name("base-uri")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextDependent()
@@ -42,7 +42,7 @@ public final class FnBaseUri {
 
   @NonNull
   static final IFunction SIGNATURE_ONE_ARG = IFunction.builder()
-      .name("base-uri")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnBoolean.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnBoolean.java
@@ -26,9 +26,10 @@ import java.util.List;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class FnBoolean {
+  private static final String NAME = "boolean";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("boolean")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnCompare.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnCompare.java
@@ -24,10 +24,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * "https://www.w3.org/TR/xpath-functions-31/#func-compare">fn:compare</a>.
  */
 public final class FnCompare {
-
+  private static final String NAME = "compare";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("compare")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextDependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnConcat.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnConcat.java
@@ -27,9 +27,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * "https://www.w3.org/TR/xpath-functions-31/#func-concat">fn:concat</a>.
  */
 public final class FnConcat {
+  private static final String NAME = "concat";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("concat")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextIndependent()
@@ -106,9 +107,7 @@ public final class FnConcat {
   @NonNull
   public static IStringItem concat(@NonNull Stream<? extends IAnyAtomicItem> items) {
     return IStringItem.valueOf(ObjectUtils.notNull(items
-        .map(item -> {
-          return item == null ? "" : IStringItem.cast(item).asString();
-        })
+        .map(item -> (item == null ? "" : IStringItem.cast(item).asString()))
         .collect(Collectors.joining())));
   }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnContains.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnContains.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.function.library;
+
+import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
+import gov.nist.secauto.metaschema.core.metapath.ISequence;
+import gov.nist.secauto.metaschema.core.metapath.MetapathConstants;
+import gov.nist.secauto.metaschema.core.metapath.function.FunctionUtils;
+import gov.nist.secauto.metaschema.core.metapath.function.IArgument;
+import gov.nist.secauto.metaschema.core.metapath.function.IFunction;
+import gov.nist.secauto.metaschema.core.metapath.item.IItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IBooleanItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
+
+import java.util.List;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public final class FnContains {
+
+  @NonNull
+  static final IFunction SIGNATURE = IFunction.builder()
+      .name("contains")
+      .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
+      .deterministic()
+      .contextDependent()
+      .focusIndependent()
+      .argument(IArgument.builder()
+          .name("arg1").type(IStringItem.class)
+          .zeroOrOne()
+          .build())
+      .argument(IArgument.builder()
+          .name("arg2")
+          .type(IStringItem.class)
+          .zeroOrOne()
+          .build())
+      .returnType(IBooleanItem.class)
+      .returnOne()
+      .functionHandler(FnContains::execute)
+      .build();
+
+  @SuppressWarnings("unused")
+  @NonNull
+  private static ISequence<IBooleanItem> execute(@NonNull IFunction function,
+      @NonNull List<ISequence<?>> arguments,
+      @NonNull DynamicContext dynamicContext,
+      IItem focus) {
+    IStringItem arg1 = FunctionUtils.asTypeOrNull(arguments.get(0).getFirstItem(true));
+
+    IStringItem arg2 = FunctionUtils.asTypeOrNull(arguments.get(1).getFirstItem(true));
+
+    return ISequence.of(IBooleanItem.valueOf(
+        fnContains(
+            arg1 == null ? "" : arg1.asString(),
+            arg2 == null ? "" : arg2.asString())));
+  }
+
+  /**
+   * Determine if the string provided in the first argument contains the string in
+   * the second argument as a substring.
+   * <p>
+   * Based on the XPath 3.1 <a href=
+   * "https://www.w3.org/TR/xpath-functions-31/#func-contains">fn:contains</a>
+   * function.
+   *
+   * @param arg1
+   *          the string to examine
+   * @param arg2
+   *          the string to check as the leading substring
+   * @return {@code true} if {@code arg1} contains {@code arg2}, or {@code false}
+   *         otherwise
+   */
+  public static boolean fnContains(@NonNull String arg1, @NonNull String arg2) {
+    boolean retval;
+    if (arg2.isEmpty()) {
+      retval = true;
+    } else if (arg1.isEmpty()) {
+      retval = false;
+    } else {
+      retval = arg1.contains(arg2);
+    }
+    return retval;
+  }
+
+  private FnContains() {
+    // disable construction
+  }
+}

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnContains.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnContains.java
@@ -20,10 +20,11 @@ import java.util.List;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class FnContains {
+  private static final String NAME = "contains";
 
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("contains")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextDependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnData.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnData.java
@@ -29,10 +29,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * <a href= "https://www.w3.org/TR/xpath-functions-31/#func-data">fn:data</a>.
  */
 public final class FnData {
-
+  private static final String NAME = "data";
   @NonNull
   static final IFunction SIGNATURE_NO_ARG = IFunction.builder()
-      .name("data")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextDependent()
@@ -44,7 +44,7 @@ public final class FnData {
 
   @NonNull
   static final IFunction SIGNATURE_ONE_ARG = IFunction.builder()
-      .name("data")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDoc.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDoc.java
@@ -25,8 +25,6 @@ import java.util.List;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class FnDoc {
-  // private static final Logger logger = LogManager.getLogger(FnDoc.class);
-
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
       .name("doc")

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDoc.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDoc.java
@@ -25,9 +25,10 @@ import java.util.List;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class FnDoc {
+  private static final String NAME = "doc";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("doc")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextDependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDocumentAvailable.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDocumentAvailable.java
@@ -27,10 +27,10 @@ import java.util.List;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class FnDocumentAvailable {
-
+  private static final String NAME = "doc-available";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("doc-available")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextDependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDocumentUri.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDocumentUri.java
@@ -24,10 +24,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 public final class FnDocumentUri {
-
+  private static final String NAME = "document-uri";
   @NonNull
   static final IFunction SIGNATURE_NO_ARG = IFunction.builder()
-      .name("document-uri")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextDependent()
@@ -39,7 +39,7 @@ public final class FnDocumentUri {
 
   @NonNull
   static final IFunction SIGNATURE_ONE_ARG = IFunction.builder()
-      .name("document-uri")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnEndsWith.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnEndsWith.java
@@ -20,10 +20,10 @@ import java.util.List;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class FnEndsWith {
-
+  private static final String NAME = "ends-with";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("ends-with")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextDependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnEndsWith.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnEndsWith.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.function.library;
+
+import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
+import gov.nist.secauto.metaschema.core.metapath.ISequence;
+import gov.nist.secauto.metaschema.core.metapath.MetapathConstants;
+import gov.nist.secauto.metaschema.core.metapath.function.FunctionUtils;
+import gov.nist.secauto.metaschema.core.metapath.function.IArgument;
+import gov.nist.secauto.metaschema.core.metapath.function.IFunction;
+import gov.nist.secauto.metaschema.core.metapath.item.IItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IBooleanItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
+
+import java.util.List;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public final class FnEndsWith {
+
+  @NonNull
+  static final IFunction SIGNATURE = IFunction.builder()
+      .name("ends-with")
+      .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
+      .deterministic()
+      .contextDependent()
+      .focusIndependent()
+      .argument(IArgument.builder()
+          .name("arg1").type(IStringItem.class)
+          .zeroOrOne()
+          .build())
+      .argument(IArgument.builder()
+          .name("arg2")
+          .type(IStringItem.class)
+          .zeroOrOne()
+          .build())
+      .returnType(IBooleanItem.class)
+      .returnOne()
+      .functionHandler(FnEndsWith::execute)
+      .build();
+
+  @SuppressWarnings("unused")
+  @NonNull
+  private static ISequence<IBooleanItem> execute(@NonNull IFunction function,
+      @NonNull List<ISequence<?>> arguments,
+      @NonNull DynamicContext dynamicContext,
+      IItem focus) {
+    IStringItem arg1 = FunctionUtils.asTypeOrNull(arguments.get(0).getFirstItem(true));
+
+    IStringItem arg2 = FunctionUtils.asTypeOrNull(arguments.get(1).getFirstItem(true));
+
+    return ISequence.of(IBooleanItem.valueOf(
+        fnEndsWith(
+            arg1 == null ? "" : arg1.asString(),
+            arg2 == null ? "" : arg2.asString())));
+  }
+
+  /**
+   * Determine if the string provided in the first argument ends with the string
+   * in the second argument.
+   * <p>
+   * Based on the XPath 3.1 <a href=
+   * "https://www.w3.org/TR/xpath-functions-31/#func-ends-with">fn:ends-with</a>
+   * function.
+   *
+   * @param arg1
+   *          the string to examine
+   * @param arg2
+   *          the string to check as the leading substring
+   * @return {@code true} if {@code arg1} ends with {@code arg2}, or {@code false}
+   *         otherwise
+   */
+  public static boolean fnEndsWith(@NonNull String arg1, @NonNull String arg2) {
+    boolean retval;
+    if (arg2.isEmpty()) {
+      retval = true;
+    } else if (arg1.isEmpty()) {
+      retval = false;
+    } else {
+      retval = arg1.endsWith(arg2);
+    }
+    return retval;
+  }
+
+  private FnEndsWith() {
+    // disable construction
+  }
+}

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnExists.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnExists.java
@@ -24,9 +24,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * "https://www.w3.org/TR/xpath-functions-31/#func-exists">fn:exists</a>.
  */
 public final class FnExists {
+  private static final String NAME = "exists";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("exists")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnFalse.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnFalse.java
@@ -21,9 +21,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * <a href= "https://www.w3.org/TR/xpath-functions-31/#func-false">fn:false</a>.
  */
 public final class FnFalse {
+  private static final String NAME = "false";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("false")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnHead.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnHead.java
@@ -23,9 +23,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * <a href= "https://www.w3.org/TR/xpath-functions-31/#func-head">fn:head</a>.
  */
 public final class FnHead {
+  private static final String NAME = "head";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("head")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnInsertBefore.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnInsertBefore.java
@@ -25,9 +25,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * "https://www.w3.org/TR/xpath-functions-31/#func-insert-before">fn:insert-before</a>.
  */
 public final class FnInsertBefore {
+  private static final String NAME = "insert-before";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("insert-before")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnMatches.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnMatches.java
@@ -30,9 +30,10 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * "https://www.w3.org/TR/xpath-functions-31/#func-matches">fn:matches</a>.
  */
 public final class FnMatches {
+  private static final String NAME = "matches";
   @NonNull
   static final IFunction SIGNATURE_TWO_ARG = IFunction.builder()
-      .name("matches")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextIndependent()
@@ -54,7 +55,7 @@ public final class FnMatches {
 
   @NonNull
   static final IFunction SIGNATURE_THREE_ARG = IFunction.builder()
-      .name("matches")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnNormalizeSpace.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnNormalizeSpace.java
@@ -24,9 +24,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * "https://www.w3.org/TR/xpath-functions-31/#func-normalize-space">fn:normalize-space</a>.
  */
 public final class FnNormalizeSpace {
+  private static final String NAME = "normalize-space";
   @NonNull
   static final IFunction SIGNATURE_NO_ARG = IFunction.builder()
-      .name("normalize-space")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextDependent()
@@ -38,7 +39,7 @@ public final class FnNormalizeSpace {
 
   @NonNull
   static final IFunction SIGNATURE_ONE_ARG = IFunction.builder()
-      .name("normalize-space")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnNot.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnNot.java
@@ -19,9 +19,10 @@ import java.util.List;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class FnNot {
+  private static final String NAME = "not";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("not")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnPath.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnPath.java
@@ -28,10 +28,10 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * document-uri function.
  */
 public final class FnPath {
-
+  private static final String NAME = "path";
   @NonNull
   static final IFunction SIGNATURE_NO_ARG = IFunction.builder()
-      .name("path")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextDependent()
@@ -43,7 +43,7 @@ public final class FnPath {
 
   @NonNull
   static final IFunction SIGNATURE_ONE_ARG = IFunction.builder()
-      .name("path")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnRemove.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnRemove.java
@@ -25,9 +25,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * "https://www.w3.org/TR/xpath-functions-31/#func-remove">fn:remove</a>.
  */
 public final class FnRemove {
+  private static final String NAME = "remove";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("remove")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextIndependent()
@@ -80,11 +81,7 @@ public final class FnRemove {
       @NonNull IIntegerItem positionItem) {
     int position = positionItem.asInteger().intValue();
 
-    if (position == 0) {
-      return target;
-    }
-
-    if (position > target.size()) {
+    if ((position == 0) || (position > target.size())) {
       return target;
     }
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnResolveUri.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnResolveUri.java
@@ -24,9 +24,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 public final class FnResolveUri {
+  private static final String NAME = "resolve-uri";
   @NonNull
   static final IFunction SIGNATURE_ONE_ARG = IFunction.builder()
-      .name("resolve-uri")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextDependent()
@@ -43,7 +44,7 @@ public final class FnResolveUri {
 
   @NonNull
   static final IFunction SIGNATURE_TWO_ARG = IFunction.builder()
-      .name("resolve-uri")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnReverse.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnReverse.java
@@ -25,9 +25,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * "https://www.w3.org/TR/xpath-functions-31/#func-reverse">fn:reverse</a>.
  */
 public final class FnReverse {
+  private static final String NAME = "reverse";
   @NonNull
   static final IFunction SIGNATURE_ONE_ARG = IFunction.builder()
-      .name("reverse")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnRound.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnRound.java
@@ -27,7 +27,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  */
 public final class FnRound {
   private static final String NAME = "round";
-
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
       .name(NAME)

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnStartsWith.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnStartsWith.java
@@ -18,7 +18,6 @@ import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
 import java.util.List;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 
 public final class FnStartsWith {
 
@@ -53,11 +52,10 @@ public final class FnStartsWith {
 
     IStringItem arg2 = FunctionUtils.asTypeOrNull(arguments.get(1).getFirstItem(true));
 
-    return ISequence.of(fnStartsWith(arg1, arg2));
-  }
-
-  private FnStartsWith() {
-    // disable construction
+    return ISequence.of(IBooleanItem.valueOf(
+        fnStartsWith(
+            arg1 == null ? "" : arg1.asString(),
+            arg2 == null ? "" : arg2.asString())));
   }
 
   /**
@@ -72,19 +70,22 @@ public final class FnStartsWith {
    *          the string to examine
    * @param arg2
    *          the string to check as the leading substring
-   * @return {@link IBooleanItem#TRUE} if {@code arg1} starts with {@code arg2},
-   *         or {@link IBooleanItem#FALSE} otherwise
+   * @return {@code true} if {@code arg1} starts with {@code arg2}, or
+   *         {@code false} otherwise
    */
-  public static IBooleanItem fnStartsWith(@Nullable IStringItem arg1, @Nullable IStringItem arg2) {
-    String arg2String = arg2 == null ? "" : arg2.asString();
-
+  public static boolean fnStartsWith(@NonNull String arg1, @NonNull String arg2) {
     boolean retval;
-    if (arg2String.isEmpty()) {
+    if (arg2.isEmpty()) {
       retval = true;
+    } else if (arg1.isEmpty()) {
+      retval = false;
     } else {
-      String arg1String = arg1 == null ? "" : arg1.asString();
-      retval = arg1String.startsWith(arg2String);
+      retval = arg1.startsWith(arg2);
     }
-    return IBooleanItem.valueOf(retval);
+    return retval;
+  }
+
+  private FnStartsWith() {
+    // disable construction
   }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnStartsWith.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnStartsWith.java
@@ -20,10 +20,10 @@ import java.util.List;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class FnStartsWith {
-
+  private static final String NAME = "starts-with";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("starts-with")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextDependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnStaticBaseUri.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnStaticBaseUri.java
@@ -21,9 +21,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 public final class FnStaticBaseUri {
+  private static final String NAME = "static-base-uri";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("static-base-uri")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextDependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnString.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnString.java
@@ -27,9 +27,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * "https://www.w3.org/TR/xpath-functions-31/#func-string">fn:string</a>.
  */
 public final class FnString {
+  private static final String NAME = "string";
   @NonNull
   static final IFunction SIGNATURE_NO_ARG = IFunction.builder()
-      .name("string")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextDependent()
@@ -41,7 +42,7 @@ public final class FnString {
 
   @NonNull
   static final IFunction SIGNATURE_ONE_ARG = IFunction.builder()
-      .name("string")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTail.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTail.java
@@ -24,9 +24,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * <a href= "https://www.w3.org/TR/xpath-functions-31/#func-tail">fn:tail</a>.
  */
 public final class FnTail {
+  private static final String NAME = "tail";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("tail")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTokenize.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTokenize.java
@@ -32,9 +32,10 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * "https://www.w3.org/TR/xpath-functions-31/#func-tokenize">fn:tokenize</a>.
  */
 public final class FnTokenize {
+  private static final String NAME = "tokenize";
   @NonNull
   static final IFunction SIGNATURE_ONE_ARG = IFunction.builder()
-      .name("tokenize")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextIndependent()
@@ -50,7 +51,7 @@ public final class FnTokenize {
       .build();
   @NonNull
   static final IFunction SIGNATURE_TWO_ARG = IFunction.builder()
-      .name("tokenize")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextIndependent()
@@ -72,7 +73,7 @@ public final class FnTokenize {
 
   @NonNull
   static final IFunction SIGNATURE_THREE_ARG = IFunction.builder()
-      .name("tokenize")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTrue.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTrue.java
@@ -21,9 +21,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * <a href= "https://www.w3.org/TR/xpath-functions-31/#func-true">fn:true</a>.
  */
 public final class FnTrue {
+  private static final String NAME = "true";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("true")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapContains.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapContains.java
@@ -23,9 +23,10 @@ import java.util.List;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class MapContains {
+  private static final String NAME = "contains";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("contains")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_MAP)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapContains.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapContains.java
@@ -24,7 +24,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class MapContains {
   @NonNull
-  public static final IFunction SIGNATURE = IFunction.builder()
+  static final IFunction SIGNATURE = IFunction.builder()
       .name("contains")
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_MAP)
       .deterministic()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapEntry.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapEntry.java
@@ -22,9 +22,10 @@ import java.util.List;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class MapEntry {
+  private static final String NAME = "entry";
   @NonNull
   public static final IFunction SIGNATURE = IFunction.builder()
-      .name("entry")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_MAP)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapFind.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapFind.java
@@ -26,9 +26,10 @@ import java.util.stream.Stream;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class MapFind {
+  private static final String NAME = "find";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("find")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_MAP)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapFind.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapFind.java
@@ -27,7 +27,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class MapFind {
   @NonNull
-  public static final IFunction SIGNATURE = IFunction.builder()
+  static final IFunction SIGNATURE = IFunction.builder()
       .name("find")
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_MAP)
       .deterministic()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapGet.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapGet.java
@@ -24,7 +24,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 
 public final class MapGet {
   @NonNull
-  public static final IFunction SIGNATURE = IFunction.builder()
+  static final IFunction SIGNATURE = IFunction.builder()
       .name("get")
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_MAP)
       .deterministic()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapGet.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapGet.java
@@ -23,9 +23,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 public final class MapGet {
+  private static final String NAME = "get";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("get")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_MAP)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapKeys.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapKeys.java
@@ -24,9 +24,10 @@ import java.util.stream.Stream;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class MapKeys {
+  private static final String NAME = "keys";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("keys")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_MAP)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapMerge.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapMerge.java
@@ -34,12 +34,13 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 public final class MapMerge {
+  private static final String NAME = "merge";
   private static final Random RANDOM = new Random();
   private static final IMapKey DUPLICATES_OPTION = IStringItem.valueOf("duplicates").asMapKey();
 
   @NonNull
   static final IFunction SIGNATURE_ONE_ARG = IFunction.builder()
-      .name("merge")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_MAP)
       .deterministic()
       .contextIndependent()
@@ -56,7 +57,7 @@ public final class MapMerge {
 
   @NonNull
   static final IFunction SIGNATURE_TWO_ARG = IFunction.builder()
-      .name("merge")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_MAP)
       .deterministic()
       .contextIndependent()
@@ -87,11 +88,11 @@ public final class MapMerge {
     USE_LAST("use-last", (key, v1, v2) -> v2),
     USE_ANY("use-any", (key, v1, v2) -> RANDOM.nextBoolean() ? v1 : v2),
     @SuppressWarnings("null")
-    COMBINE("combine", (key, v1, v2) -> {
-      return Stream.concat(
-          v1.asSequence().stream(),
-          v2.asSequence().stream()).collect(ISequence.toSequence());
-    });
+    COMBINE(
+        "combine",
+        (key, v1, v2) -> Stream.concat(
+            v1.asSequence().stream(),
+            v2.asSequence().stream()).collect(ISequence.toSequence()));
 
     private static final Map<String, Duplicates> BY_NAME;
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapPut.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapPut.java
@@ -26,7 +26,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class MapPut {
   @NonNull
-  public static final IFunction SIGNATURE = IFunction.builder()
+  static final IFunction SIGNATURE = IFunction.builder()
       .name("put")
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_MAP)
       .deterministic()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapPut.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapPut.java
@@ -25,9 +25,10 @@ import java.util.Map;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class MapPut {
+  private static final String NAME = "put";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("put")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_MAP)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapRemove.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapRemove.java
@@ -28,7 +28,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class MapRemove {
   @NonNull
-  public static final IFunction SIGNATURE = IFunction.builder()
+  static final IFunction SIGNATURE = IFunction.builder()
       .name("remove")
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_MAP)
       .deterministic()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapRemove.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapRemove.java
@@ -27,9 +27,10 @@ import java.util.stream.Collectors;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class MapRemove {
+  private static final String NAME = "remove";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("remove")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_MAP)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapSize.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapSize.java
@@ -21,9 +21,10 @@ import java.util.List;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class MapSize {
+  private static final String NAME = "size";
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("size")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_MAP)
       .deterministic()
       .contextIndependent()

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapSize.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapSize.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-public class MapSize {
+public final class MapSize {
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
       .name("size")
@@ -55,5 +55,9 @@ public class MapSize {
     IMapItem<?> map = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(0).getFirstItem(true)));
 
     return ISequence.of(IIntegerItem.valueOf(map.size()));
+  }
+
+  private MapSize() {
+    // disable
   }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MpRecurseDepth.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MpRecurseDepth.java
@@ -28,11 +28,11 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * Provides functions that evaluate a Metapath recursively over sequences.
  */
 public final class MpRecurseDepth {
-  // private static final Logger logger = LogManager.getLogger(FnDoc.class);
+  private static final String NAME = "recurse-depth";
 
   @NonNull
   static final IFunction SIGNATURE_ONE_ARG = IFunction.builder()
-      .name("recurse-depth")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_EXTENDED)
       .deterministic()
       .contextDependent()
@@ -49,7 +49,7 @@ public final class MpRecurseDepth {
 
   @NonNull
   static final IFunction SIGNATURE_TWO_ARG = IFunction.builder()
-      .name("recurse-depth")
+      .name(NAME)
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS_EXTENDED)
       .deterministic()
       .contextDependent()

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnContainsTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnContainsTest.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.function.library;
+
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.bool;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import gov.nist.secauto.metaschema.core.metapath.MetapathExpression;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IBooleanItem;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+class FnContainsTest
+    extends FunctionTestBase {
+  static Stream<Arguments> provideValues() {
+    return Stream.of(
+        Arguments.of(bool(true), "contains( \"tattoo\", \"t\")"),
+        Arguments.of(bool(false), "contains ( \"tattoo\", \"ttt\")"),
+        Arguments.of(bool(true), "ends-with( (), ())"),
+        Arguments.of(bool(true), "contains( \"\", ())"),
+        Arguments.of(bool(true), "contains( \"something\", \"\")"),
+        Arguments.of(bool(true), "contains( \"something\", ())"),
+        Arguments.of(bool(false), "contains( \"\", \"nothing\")"),
+        Arguments.of(bool(false), "contains( (), \"nothing\")"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideValues")
+  void test(@NonNull IBooleanItem expected, @NonNull String metapath) {
+    IBooleanItem result = MetapathExpression.compile(metapath)
+        .evaluateAs(null, MetapathExpression.ResultType.ITEM, newDynamicContext());
+    assertEquals(expected, result);
+  }
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnEndsWithTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnEndsWithTest.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.function.library;
+
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.bool;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import gov.nist.secauto.metaschema.core.metapath.MetapathExpression;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IBooleanItem;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+class FnEndsWithTest
+    extends FunctionTestBase {
+  static Stream<Arguments> provideValues() {
+    return Stream.of(
+        Arguments.of(bool(true), "ends-with( \"tattoo\", \"tattoo\")"),
+        Arguments.of(bool(false), "ends-with ( \"tattoo\", \"atto\")"),
+        Arguments.of(bool(true), "ends-with( (), ())"),
+        Arguments.of(bool(true), "ends-with( \"\", ())"),
+        Arguments.of(bool(true), "ends-with( \"something\", \"\")"),
+        Arguments.of(bool(true), "ends-with( \"something\", ())"),
+        Arguments.of(bool(false), "ends-with( \"\", \"nothing\")"),
+        Arguments.of(bool(false), "ends-with( (), \"nothing\")"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideValues")
+  void test(@NonNull IBooleanItem expected, @NonNull String metapath) {
+    IBooleanItem result = MetapathExpression.compile(metapath)
+        .evaluateAs(null, MetapathExpression.ResultType.ITEM, newDynamicContext());
+    assertEquals(expected, result);
+  }
+}


### PR DESCRIPTION
# Committer Notes

Added support for the contains and ends-with Metapath functions.

Also, cleaned up signatures for existing tests to reduce their visability.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
