### PR TITLE
Support Metaschema module and constraint string property values

### DIFF
--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/binding/metaschema/Property.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/binding/metaschema/Property.java
@@ -46,7 +46,7 @@ public class Property implements IBoundObject {
       formalName = "Property Value",
       name = "value",
       required = true,
-      typeAdapter = TokenAdapter.class)
+      typeAdapter = StringAdapter.class)
   private String _value;
 
   public Property() {


### PR DESCRIPTION
# Committer Notes

Add support for Metaschema module and constraint property values that are generic strings per metaschema-framework/metaschema#27.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
