### PR TITLE
Ensure a double slash Metapath returns unique items

### DIFF
--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/MetapathExpression.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/MetapathExpression.java
@@ -117,7 +117,8 @@ public class MetapathExpression {
    */
   @NonNull
   public static MetapathExpression compile(@NonNull String path, @NonNull StaticContext context) {
-    @NonNull MetapathExpression retval;
+    @NonNull
+    MetapathExpression retval;
     if (".".equals(path)) {
       retval = CONTEXT_NODE;
     } else {
@@ -355,8 +356,7 @@ public class MetapathExpression {
       throw new InvalidTypeMetapathException(null, String.format("unsupported result type '%s'", resultType.name()));
     }
 
-    @SuppressWarnings("unchecked") T retval = (T) result;
-    return retval;
+    return (T) result;
   }
 
   /**

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/path/AbstractPathExpression.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/path/AbstractPathExpression.java
@@ -77,9 +77,7 @@ public abstract class AbstractPathExpression<RESULT_TYPE extends IItem>
           return matches;
         });
 
-    @SuppressWarnings("null")
-    @NonNull Stream<? extends INodeItem> result = Stream.concat(nodeMatches, childMatches);
-    return result;
+    return ObjectUtils.notNull(Stream.concat(nodeMatches, childMatches).distinct());
   }
 
   /**

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/DefaultBoundLoader.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/DefaultBoundLoader.java
@@ -51,8 +51,7 @@ public class DefaultBoundLoader
   private final IMutableConfiguration<DeserializationFeature<?>> configuration;
 
   /**
-   * Construct a new OSCAL loader instance, using the provided
-   * {@link IBindingContext}.
+   * Construct a new loader instance, using the provided {@link IBindingContext}.
    *
    * @param bindingContext
    *          the Module binding context to use to load Java types

--- a/databind/src/test/java/gov/nist/secauto/metaschema/databind/io/DefaultBoundLoaderTest.java
+++ b/databind/src/test/java/gov/nist/secauto/metaschema/databind/io/DefaultBoundLoaderTest.java
@@ -1,0 +1,41 @@
+
+package gov.nist.secauto.metaschema.databind.io;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import gov.nist.secauto.metaschema.core.metapath.ISequence;
+import gov.nist.secauto.metaschema.core.metapath.MetapathExpression;
+import gov.nist.secauto.metaschema.core.metapath.item.node.IDocumentNodeItem;
+import gov.nist.secauto.metaschema.core.model.IModule;
+import gov.nist.secauto.metaschema.core.model.MetaschemaException;
+import gov.nist.secauto.metaschema.core.model.xml.ModuleLoader;
+import gov.nist.secauto.metaschema.databind.IBindingContext;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+class DefaultBoundLoaderTest {
+
+  @Test
+  void testIssue187() throws IOException, MetaschemaException {
+
+    IModule module = new ModuleLoader().load(Paths.get("src/test/resources/content/issue187-metaschema.xml"));
+
+    IBindingContext bindingContext = IBindingContext.instance();
+
+    bindingContext.registerModule(module, Files.createTempDirectory(Paths.get("target"), "modules-"));
+
+    IBoundLoader loader = bindingContext.newBoundLoader();
+
+    IDocumentNodeItem docItem = loader.loadAsNodeItem(Paths.get("src/test/resources/content/issue187-instance.xml"));
+
+    MetapathExpression metapath = MetapathExpression.compile("//a//b", docItem.getStaticContext());
+
+    ISequence<?> result = metapath.evaluate(docItem);
+
+    assertEquals(8, result.size());
+  }
+}

--- a/databind/src/test/resources/content/issue187-instance.xml
+++ b/databind/src/test/resources/content/issue187-instance.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<a xmlns="http://csrc.nist.gov/ns/test/metaschema/issue187-test">
+	<a value="a1">
+		<b>
+			<b value="value1"/>
+		</b>
+		<b>
+			<b value="value2"/>
+		</b>
+	</a>
+	<a value="a2">
+		<b>
+			<b value="value1"/>
+		</b>
+		<b>
+			<b value="value2"/>
+		</b>
+	</a>
+</a>

--- a/databind/src/test/resources/content/issue187-metaschema.xml
+++ b/databind/src/test/resources/content/issue187-metaschema.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../../../../core/metaschema/schema/xml/metaschema.xsd" type="application/xml" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<METASCHEMA xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0">
+	<schema-name>Test Metaschema with an external entity</schema-name>
+	<schema-version>1.0.0</schema-version>
+	<short-name>issue187-test</short-name>
+	<namespace>http://csrc.nist.gov/ns/test/metaschema/issue187-test</namespace>
+	<json-base-uri>http://csrc.nist.gov/ns/test/metaschema/issue187-test</json-base-uri>
+	<define-assembly name="a">
+		<root-name>a</root-name>
+        <define-flag name="value" as-type="string"/>
+		<model>
+            <assembly ref="a" max-occurs="unbounded">
+				<group-as name="as" in-json="ARRAY" />
+			</assembly>
+            <assembly ref="a" max-occurs="unbounded">
+            	<use-name>b</use-name>
+				<group-as name="bs" in-json="ARRAY" />
+			</assembly>
+		</model>
+	</define-assembly>
+</METASCHEMA>


### PR DESCRIPTION
# Committer Notes

Fixed a bug causing non-unique items to be returned in metapaths like `//a//b`.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
