### PR TITLE
Add substring-after impl to Metapath default function registry

### DIFF
--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/DefaultFunctionLibrary.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/DefaultFunctionLibrary.java
@@ -164,6 +164,7 @@ public class DefaultFunctionLibrary
     registerFunction(FnStringLength.SIGNATURE_ONE_ARG);
     // P1: https://www.w3.org/TR/xpath-functions-31/#func-subsequence
     // P1: https://www.w3.org/TR/xpath-functions-31/#func-substring-after
+    registerFunction(FnSubstringAfter.SIGNATURE_TWO_ARG);
     // P1: https://www.w3.org/TR/xpath-functions-31/#func-substring-before
     // https://www.w3.org/TR/xpath-functions-31/#func-sum
     registerFunction(FnSum.SIGNATURE_ONE_ARG);

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstringAfter.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstringAfter.java
@@ -62,11 +62,11 @@ public final class FnSubstringAfter {
       @NonNull DynamicContext dynamicContext,
       IItem focus) {
 	
-	// From the XPath 3.1 specification:
-	// If the value of $arg1 or $arg2 is the empty sequence, or contains only
-	// ignorable collation units, it is interpreted as the zero-length string.
-    IStringItem arg1 = arguments.get(0) == ISequence.empty() ? IStringItem.valueOf("") : FunctionUtils.asTypeOrNull(arguments.get(0).getFirstItem(true));
-    IStringItem arg2 = arguments.get(1) == ISequence.empty() ? IStringItem.valueOf("") : FunctionUtils.asTypeOrNull(arguments.get(1).getFirstItem(true));
+    // From the XPath 3.1 specification:
+    // If the value of $arg1 or $arg2 is the empty sequence, or contains only
+    // ignorable collation units, it is interpreted as the zero-length string.
+    IStringItem arg1 = arguments.get(0).isEmpty() ? IStringItem.valueOf("") : FunctionUtils.asTypeOrNull(arguments.get(0).getFirstItem(true));
+    IStringItem arg2 = arguments.get(1).isEmpty() ? IStringItem.valueOf("") : FunctionUtils.asTypeOrNull(arguments.get(1).getFirstItem(true));
     
     return ISequence.of(IStringItem.valueOf(fnSubstringAfter(arg1.asString(), arg2.asString())));
   }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstringAfter.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstringAfter.java
@@ -1,0 +1,90 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.function.library;
+
+import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
+import gov.nist.secauto.metaschema.core.metapath.ISequence;
+import gov.nist.secauto.metaschema.core.metapath.MetapathConstants;
+import gov.nist.secauto.metaschema.core.metapath.function.FunctionUtils;
+import gov.nist.secauto.metaschema.core.metapath.function.IArgument;
+import gov.nist.secauto.metaschema.core.metapath.function.IFunction;
+import gov.nist.secauto.metaschema.core.metapath.item.IItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IDecimalItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
+import gov.nist.secauto.metaschema.core.util.ObjectUtils;
+
+import java.util.List;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Implements <a href=
+ * "https://www.w3.org/TR/xpath-functions-31/#func-substring-after">fn:substring-after</a>.
+ */
+public final class FnSubstringAfter {
+  private static final String NAME = "substring-after";
+  @NonNull
+  static final IFunction SIGNATURE_TWO_ARG = IFunction.builder()
+      .name(NAME)
+      .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
+      .deterministic()
+      .contextIndependent()
+      .focusIndependent()
+      .argument(IArgument.builder()
+          .name("arg1")
+          .type(IStringItem.class)
+          .zeroOrOne()
+          .build())
+      .argument(IArgument.builder()
+          .name("arg2")
+          .type(IStringItem.class)
+          .zeroOrOne()
+          .build())
+      .returnType(IStringItem.class)
+      .returnOne()
+      .functionHandler(FnSubstringAfter::executeTwoArg)
+      .build();
+
+  private FnSubstringAfter() {
+    // disable construction
+  }
+
+  @SuppressWarnings({ "unused", "PMD.OnlyOneReturn" })
+  @NonNull
+  private static ISequence<IStringItem> executeTwoArg(
+      @NonNull IFunction function,
+      @NonNull List<ISequence<?>> arguments,
+      @NonNull DynamicContext dynamicContext,
+      IItem focus) {
+	
+	// From the XPath 3.1 specification:
+	// If the value of $arg1 or $arg2 is the empty sequence, or contains only
+	// ignorable collation units, it is interpreted as the zero-length string.
+    IStringItem arg1 = arguments.get(0) == ISequence.empty() ? IStringItem.valueOf("") : FunctionUtils.asTypeOrNull(arguments.get(0).getFirstItem(true));
+    IStringItem arg2 = arguments.get(1) == ISequence.empty() ? IStringItem.valueOf("") : FunctionUtils.asTypeOrNull(arguments.get(1).getFirstItem(true));
+    
+    return ISequence.of(IStringItem.valueOf(fnSubstringAfter(arg1.asString(), arg2.asString())));
+  }
+
+  /**
+   * An implementation of XPath 3.1 <a href=
+   * "https://www.w3.org/TR/xpath-functions-31/#func-substring-after">fn:substring-after</a>.
+   *
+   * @param arg1
+   *          the source string to get a substring from
+   * @param arg2
+   *          the substring to match and find the substring to return after the match
+   * @return the substring
+   */
+  @NonNull
+  public static String fnSubstringAfter(
+      @NonNull String arg1,
+      @NonNull String arg2) {
+    return StringUtils.substringAfterLast(arg1, arg2);
+  }
+}

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstringAfter.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstringAfter.java
@@ -85,6 +85,6 @@ public final class FnSubstringAfter {
   public static String fnSubstringAfter(
       @NonNull String arg1,
       @NonNull String arg2) {
-    return StringUtils.substringAfterLast(arg1, arg2);
+    return StringUtils.substringAfter(arg1, arg2);
   }
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstringAfterTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstringAfterTest.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.function.library;
+
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.string;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import gov.nist.secauto.metaschema.core.metapath.ExpressionTestBase;
+import gov.nist.secauto.metaschema.core.metapath.MetapathExpression;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+class FnSubstringAfterTest
+    extends ExpressionTestBase {
+  private static Stream<Arguments> provideValues() { // NOPMD - false positive
+    return Stream.of(
+        Arguments.of(
+            string("too"),
+            "substring-after('tattoo', 'tat')"),
+        Arguments.of(
+                string(""),
+                "substring-after('tattoo', 'tattoo')"),
+        Arguments.of(
+                string(""),
+                "substring-after((), ())")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideValues")
+  void testExpression(@NonNull IStringItem expected, @NonNull String metapath) {
+    assertEquals(
+        expected,
+        MetapathExpression.compile(metapath)
+            .evaluateAs(null, MetapathExpression.ResultType.ITEM, newDynamicContext()));
+  }
+
+}


### PR DESCRIPTION
# Committer Notes

Implement the `substring-after` function, without collation and three-arg arity variant for #132.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- ~Have you updated all website and readme documentation affected by the changes you made?~
