### PR TITLE
Add `index-of()` function to Metapath default function registry

### DIFF
--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/DefaultFunctionLibrary.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/DefaultFunctionLibrary.java
@@ -96,7 +96,8 @@ public class DefaultFunctionLibrary
     // https://www.w3.org/TR/xpath-functions-31/#func-hours-from-time
     // https://www.w3.org/TR/xpath-functions-31/#func-implicit-timezone
     registerFunction(FnImplicitTimezone.SIGNATURE);
-    // P1: https://www.w3.org/TR/xpath-functions-31/#func-index-of
+    // https://www.w3.org/TR/xpath-functions-31/#func-index-of
+    registerFunction(FnIndexOf.SIGNATURE_TWO_ARG);
     // https://www.w3.org/TR/xpath-functions-31/#func-innermost
     // https://www.w3.org/TR/xpath-functions-31/#func-insert-before
     registerFunction(FnInsertBefore.SIGNATURE);

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnIndexOf.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnIndexOf.java
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.function.library;
+
+import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
+import gov.nist.secauto.metaschema.core.metapath.MetapathConstants;
+import gov.nist.secauto.metaschema.core.metapath.function.ComparisonFunctions;
+import gov.nist.secauto.metaschema.core.metapath.function.FunctionUtils;
+import gov.nist.secauto.metaschema.core.metapath.function.IArgument;
+import gov.nist.secauto.metaschema.core.metapath.function.IFunction;
+import gov.nist.secauto.metaschema.core.metapath.item.IItem;
+import gov.nist.secauto.metaschema.core.metapath.item.ISequence;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IIntegerItem;
+import gov.nist.secauto.metaschema.core.util.ObjectUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ListIterator;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * /** Implements <a href=
+ * "https://www.w3.org/TR/xpath-functions-31/#func-index-of">fn:index-of</a>
+ * functions. This implementation does not implement the three-arg variant with
+ * collation at this time.
+ */
+public final class FnIndexOf {
+  @NonNull
+  private static final String NAME = "index-of";
+  @NonNull
+  static final IFunction SIGNATURE_TWO_ARG = IFunction.builder()
+      .name(NAME)
+      .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
+      .deterministic()
+      .contextDependent()
+      .focusIndependent()
+      .argument(IArgument.builder()
+          .name("seq")
+          .type(IAnyAtomicItem.type())
+          .zeroOrMore()
+          .build())
+      .argument(IArgument.builder()
+          .name("search")
+          .type(IAnyAtomicItem.type())
+          .one()
+          .build())
+      .returnType(IIntegerItem.type())
+      .returnZeroOrMore()
+      .functionHandler(FnIndexOf::executeTwoArg)
+      .build();
+
+  @SuppressWarnings("unused")
+  @NonNull
+  private static ISequence<IIntegerItem> executeTwoArg(@NonNull IFunction function,
+      @NonNull List<ISequence<?>> arguments,
+      @NonNull DynamicContext dynamicContext,
+      IItem focus) {
+    ISequence<IAnyAtomicItem> seq = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(0)));
+    IAnyAtomicItem search = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(1).getFirstItem(true)));
+
+    if (seq.size() == 0) {
+      return ISequence.empty();
+    }
+    return fnIndexOf(seq, search);
+  }
+
+  /**
+   * Determine if the string provided in the first argument contains the string in
+   * the second argument as a substring.
+   * <p>
+   * Based on the XPath 3.1 <a href=
+   * "https://www.w3.org/TR/xpath-functions-31/#func-index-of">fn:index-of</a>
+   * function.
+   *
+   * @param items
+   *          the items to match against
+   * @param search
+   *          the item to match
+   * @return a list of index numbers indicating the position of matches in the
+   *         sequence
+   */
+  public static ISequence<IIntegerItem> fnIndexOf(@NonNull List<IAnyAtomicItem> items,
+      @NonNull IAnyAtomicItem search) {
+    int index = 0;
+    ListIterator<IAnyAtomicItem> iterator = items.listIterator();
+    List<IIntegerItem> indices = new ArrayList<>();
+    while (iterator.hasNext()) {
+      ++index;
+      IAnyAtomicItem item = iterator.next();
+      assert item != null;
+      // use the "eq" operator
+      if (ComparisonFunctions.valueCompairison(item, ComparisonFunctions.Operator.EQ, search).toBoolean()) {
+        // Offset for Metapath indices that start from 1
+        indices.add(IIntegerItem.valueOf(index));
+      }
+    }
+    return ISequence.ofCollection(indices);
+  }
+
+  private FnIndexOf() {
+    // disable construction
+  }
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnIndexOfTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnIndexOfTest.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.function.library;
+
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.integer;
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.sequence;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import gov.nist.secauto.metaschema.core.metapath.ExpressionTestBase;
+import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
+import gov.nist.secauto.metaschema.core.metapath.item.ISequence;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IIntegerItem;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+class FnIndexOfTest
+    extends ExpressionTestBase {
+  private static Stream<Arguments> provideValues() { // NOPMD - false positive
+    return Stream.of(
+        Arguments.of(
+            sequence(),
+            "index-of((10, 20, 30, 40), 35)"),
+        Arguments.of(
+            sequence(integer(2), integer(5)),
+            "index-of((10, 20, 30, 30, 20, 10), 20)"),
+        Arguments.of(
+            sequence(integer(1), integer(4)),
+            "index-of(('a', 'sport', 'and', 'a', 'pasttime'), 'a')"),
+        // TODO: add current-date() test after metaschema-framework/metaschema-java#162
+        // complete
+        // Arguments.of(
+        // ISequence.empty(),
+        // "index-of(current-date(), 23)"),
+        Arguments.of(
+            sequence(integer(1)),
+            "index-of((true()), 'true')"),
+        Arguments.of(
+            sequence(integer(3), integer(4)),
+            "index-of([1, [5, 6], [6, 7]], 6)"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideValues")
+  void test(@NonNull ISequence<IIntegerItem> expected, @NonNull String metapath) {
+    assertEquals(expected, IMetapathExpression.compile(metapath)
+        .evaluate(null, newDynamicContext()));
+  }
+}


### PR DESCRIPTION
# Committer Notes

Closes #204.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- ~Have you updated all website and readme documentation affected by the changes you made?~
