### PR TITLE
Avoid resolving an already resolved URI in doc-available

### DIFF
--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnResolveUri.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnResolveUri.java
@@ -177,6 +177,8 @@ public final class FnResolveUri {
    *          the evaluation context used to get the static base URI if needed
    * @return the resolved URI or {@code null} if the {@code relative} URI in
    *         {@code null}
+   * @throws UriFunctionException
+   *           if the base URI is not configured in the dynamic context
    */
   @NonNull
   public static IAnyUriItem fnResolveUri(

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDocumentAvailableTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDocumentAvailableTest.java
@@ -1,0 +1,23 @@
+
+package gov.nist.secauto.metaschema.core.metapath.function.library;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyUriItem;
+
+import org.junit.jupiter.api.Test;
+
+class FnDocumentAvailableTest {
+
+  /**
+   * Tests for https://github.com/metaschema-framework/metaschema-java/issues/208.
+   */
+  @Test
+  void issue208Test() {
+    IAnyUriItem uri = IAnyUriItem.valueOf(
+        "https://raw.githubusercontent.com/GSA/fedramp-automation/8301e380c88532ebbb22aca55521701750eb0b83/src/content/awesome-cloud/xml/AwesomeCloudSSP1.xml");
+
+    assertTrue(FnDocumentAvailable.fnDocAvailable(uri, new DynamicContext()).toBoolean());
+  }
+}


### PR DESCRIPTION
# Committer Notes

This PR fixes a bug caused when an already absolute or opaque URI is attempted to be resolved, when not necessary.

Typically this will be a no-op, but if the baseUri is not defined in the static context, this will cause an error.

The fix was to check if the URI is already absolute or opaque before attempting to resolve it. When already absolute or opaque, there is no need to resolve it.

Resolves #208.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
