### PR TITLE
Eval command improvments

### DIFF
--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/DefaultItemWriter.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/DefaultItemWriter.java
@@ -7,7 +7,9 @@ package gov.nist.secauto.metaschema.core.metapath.item;
 
 import gov.nist.secauto.metaschema.core.metapath.ICollectionValue;
 import gov.nist.secauto.metaschema.core.metapath.ISequence;
+import gov.nist.secauto.metaschema.core.metapath.function.library.FnData;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IAtomicValuedItem;
 import gov.nist.secauto.metaschema.core.metapath.item.function.IArrayItem;
 import gov.nist.secauto.metaschema.core.metapath.item.function.IMapItem;
 import gov.nist.secauto.metaschema.core.metapath.item.node.INodeItem;
@@ -45,6 +47,7 @@ public class DefaultItemWriter implements IItemWriter {
     if (wrap) {
       writer.append('(');
     }
+
     boolean first = true;
     for (IItem item : sequence) {
 
@@ -103,6 +106,12 @@ public class DefaultItemWriter implements IItemWriter {
     writer.append(node.getBaseUri().toString());
     writer.append('#');
     writer.append(node.getMetapath());
+
+    if (node instanceof IAtomicValuedItem) {
+      writer.append('<');
+      writer.append(FnData.fnDataItem(node).asString());
+      writer.append('>');
+    }
   }
 
   @Override

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/ConvertContentUsingModuleCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/ConvertContentUsingModuleCommand.java
@@ -58,7 +58,7 @@ public class ConvertContentUsingModuleCommand
 
     List<Option> retval = new ArrayList<>(orig.size() + 1);
     retval.addAll(orig);
-    retval.add(MetaschemaCommands.METASCHEMA_OPTION);
+    retval.add(MetaschemaCommands.METASCHEMA_REQUIRED_OPTION);
 
     return CollectionUtil.unmodifiableCollection(retval);
   }
@@ -86,7 +86,11 @@ public class ConvertContentUsingModuleCommand
 
       IModule module;
       try {
-        module = MetaschemaCommands.handleModule(getCommandLine(), cwd, retval);
+        module = MetaschemaCommands.handleModule(
+            getCommandLine(),
+            MetaschemaCommands.METASCHEMA_REQUIRED_OPTION,
+            cwd,
+            retval);
       } catch (URISyntaxException ex) {
         throw new IOException(String.format("Cannot load module as '%s' is not a valid file or URL.", ex.getInput()),
             ex);

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/MetaschemaCommands.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/MetaschemaCommands.java
@@ -40,7 +40,15 @@ public final class MetaschemaCommands {
       new MetapathCommand()));
 
   @NonNull
-  public static final Option METASCHEMA_OPTION = ObjectUtils.notNull(
+  public static final Option METASCHEMA_REQUIRED_OPTION = ObjectUtils.notNull(
+      Option.builder("m")
+          .hasArg()
+          .argName("FILE_OR_URL")
+          .required()
+          .desc("metaschema resource")
+          .build());
+  @NonNull
+  public static final Option METASCHEMA_OPTIONAL_OPTION = ObjectUtils.notNull(
       Option.builder("m")
           .hasArg()
           .argName("FILE_OR_URL")
@@ -57,9 +65,10 @@ public final class MetaschemaCommands {
   @NonNull
   public static IModule handleModule(
       @NonNull CommandLine commandLine,
+      @NonNull Option option,
       @NonNull URI cwd,
       @NonNull IBindingContext bindingContext) throws URISyntaxException, IOException, MetaschemaException {
-    String moduleName = ObjectUtils.requireNonNull(commandLine.getOptionValue(METASCHEMA_OPTION));
+    String moduleName = ObjectUtils.requireNonNull(commandLine.getOptionValue(option));
     URI moduleUri = UriUtils.toUri(moduleName, cwd);
     return handleModule(moduleUri, bindingContext);
   }

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/ValidateContentUsingModuleCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/ValidateContentUsingModuleCommand.java
@@ -66,7 +66,7 @@ public class ValidateContentUsingModuleCommand
 
     List<Option> retval = new ArrayList<>(orig.size() + 1);
     retval.addAll(orig);
-    retval.add(MetaschemaCommands.METASCHEMA_OPTION);
+    retval.add(MetaschemaCommands.METASCHEMA_REQUIRED_OPTION);
 
     return CollectionUtil.unmodifiableCollection(retval);
   }
@@ -100,7 +100,11 @@ public class ValidateContentUsingModuleCommand
 
       IModule module;
       try {
-        module = MetaschemaCommands.handleModule(commandLine, cwd, bindingContext);
+        module = MetaschemaCommands.handleModule(
+            commandLine,
+            MetaschemaCommands.METASCHEMA_REQUIRED_OPTION,
+            cwd,
+            bindingContext);
       } catch (URISyntaxException ex) {
         throw new IOException(String.format("Cannot load module as '%s' is not a valid file or URL.", ex.getInput()),
             ex);

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/metapath/EvaluateMetapathCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/metapath/EvaluateMetapathCommand.java
@@ -83,7 +83,7 @@ public class EvaluateMetapathCommand
   @Override
   public Collection<? extends Option> gatherOptions() {
     return List.of(
-        MetaschemaCommands.METASCHEMA_OPTION,
+        MetaschemaCommands.METASCHEMA_OPTIONAL_OPTION,
         CONTENT_OPTION,
         EXPRESSION_OPTION);
   }
@@ -119,7 +119,7 @@ public class EvaluateMetapathCommand
 
     IModule module = null;
     INodeItem item = null;
-    if (cmdLine.hasOption(MetaschemaCommands.METASCHEMA_OPTION)) {
+    if (cmdLine.hasOption(MetaschemaCommands.METASCHEMA_OPTIONAL_OPTION)) {
       IBindingContext bindingContext;
       try {
         bindingContext = MetaschemaCommands.newBindingContextWithDynamicCompilation();
@@ -132,6 +132,7 @@ public class EvaluateMetapathCommand
       try {
         module = MetaschemaCommands.handleModule(
             cmdLine,
+            MetaschemaCommands.METASCHEMA_OPTIONAL_OPTION,
             cwd,
             bindingContext);
       } catch (URISyntaxException ex) {


### PR DESCRIPTION
# Committer Notes

Enhanced the eval command to output the atomic value of a field or flag.

Also fixed an issue that made the module required, when it should be optional.
### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
