### PR TITLE
Metapath additional axes

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -132,10 +132,22 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+		</dependency>
+			    
+        <dependency>
 		    <groupId>com.github.seregamorph</groupId>
 		    <artifactId>hamcrest-more-matchers</artifactId>
 		    <scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+
         <dependency>
             <groupId>biz.aQute.bnd</groupId>
             <artifactId>biz.aQute.bnd.util</artifactId>

--- a/core/src/main/antlr4/Metapath10.g4
+++ b/core/src/main/antlr4/Metapath10.g4
@@ -55,12 +55,11 @@ stepexpr : postfixexpr | axisstep ;
 axisstep : (reversestep | forwardstep) predicatelist ;
 // [40]
 forwardstep : forwardaxis nodetest | abbrevforwardstep ;
-// forwardaxis : KW_CHILD COLONCOLON | KW_DESCENDANT COLONCOLON | KW_ATTRIBUTE COLONCOLON | KW_SELF COLONCOLON | KW_DESCENDANT_OR_SELF COLONCOLON | KW_FOLLOWING_SIBLING COLONCOLON | KW_FOLLOWING COLONCOLON | KW_NAMESPACE COLONCOLON ;
-forwardaxis : KW_CHILD COLONCOLON | KW_DESCENDANT COLONCOLON | KW_SELF COLONCOLON | KW_DESCENDANT_OR_SELF COLONCOLON ;
+// forwardaxis : KW_CHILD COLONCOLON | KW_DESCENDANT COLONCOLON | KW_FLAG COLONCOLON | KW_SELF COLONCOLON | KW_DESCENDANT_OR_SELF COLONCOLON | KW_FOLLOWING_SIBLING COLONCOLON | KW_FOLLOWING COLONCOLON | KW_NAMESPACE COLONCOLON ;
+forwardaxis : KW_CHILD COLONCOLON | KW_DESCENDANT COLONCOLON | KW_FLAG COLONCOLON | KW_SELF COLONCOLON | KW_DESCENDANT_OR_SELF COLONCOLON | KW_FOLLOWING_SIBLING COLONCOLON | KW_FOLLOWING COLONCOLON ;
 abbrevforwardstep : AT? nodetest ;
 reversestep : reverseaxis nodetest | abbrevreversestep ;
-// reverseaxis : KW_PARENT COLONCOLON | KW_ANCESTOR COLONCOLON | KW_PRECEDING_SIBLING COLONCOLON | KW_PRECEDING COLONCOLON | KW_ANCESTOR_OR_SELF COLONCOLON ;
-reverseaxis : KW_PARENT COLONCOLON | KW_ANCESTOR COLONCOLON | KW_ANCESTOR_OR_SELF COLONCOLON ;
+reverseaxis : KW_PARENT COLONCOLON | KW_ANCESTOR COLONCOLON | KW_PRECEDING_SIBLING COLONCOLON | KW_PRECEDING COLONCOLON | KW_ANCESTOR_OR_SELF COLONCOLON ;
 // [45]
 abbrevreversestep : DD ;
 // nodetest : kindtest | nametest ;
@@ -120,7 +119,7 @@ unarylookup : QM keyspecifier ;
 // namespacenodetest : KW_NAMESPACE_NODE OP CP ;
 // pitest : KW_PROCESSING_INSTRUCTION OP (NCName | StringLiteral)? CP ;
 // [90]
-// attributetest : KW_ATTRIBUTE OP (attribnameorwildcard ( COMMA typename_)?)? CP ;
+// attributetest : KW_FLAG OP (attribnameorwildcard ( COMMA typename_)?)? CP ;
 // attribnameorwildcard : attributename | STAR ;
 // schemaattributetest : KW_SCHEMA_ATTRIBUTE OP attributedeclaration CP ;
 // attributedeclaration : attributename ;
@@ -155,7 +154,7 @@ eqname : NCName | QName | URIQualifiedName
  | KW_AND
  | KW_ARRAY
  | KW_AS
- | KW_ATTRIBUTE
+ | KW_FLAG
  | KW_CAST
  | KW_CASTABLE
  | KW_CHILD

--- a/core/src/main/antlr4/Metapath10Lexer.g4
+++ b/core/src/main/antlr4/Metapath10Lexer.g4
@@ -52,7 +52,7 @@ KW_ANCESTOR_OR_SELF       : 'ancestor-or-self';
 KW_AND                    : 'and';
 KW_ARRAY                  : 'array';
 KW_AS                     : 'as';
-KW_ATTRIBUTE              : 'attribute';
+KW_FLAG                   : 'flag';
 KW_CAST                   : 'cast';
 KW_CASTABLE               : 'castable';
 KW_CHILD                  : 'child';

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/ISequence.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/ISequence.java
@@ -95,7 +95,7 @@ public interface ISequence<ITEM extends IItem> extends List<ITEM>, IPrintable, I
    *           {@code true}
    */
   static <T extends IItem> T getFirstItem(@NonNull ISequence<T> items, boolean requireSingleton) {
-    return getFirstItem(items.stream(), requireSingleton);
+    return getFirstItem(items.safeStream(), requireSingleton);
   }
 
   /**

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/antlr/Metapath10ParserBase.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/antlr/Metapath10ParserBase.java
@@ -28,7 +28,7 @@ public abstract class Metapath10ParserBase
    */
   protected boolean isFuncCall() {
     return !(getInputStream().LA(1) == Metapath10.KW_ARRAY
-        || getInputStream().LA(1) == Metapath10.KW_ATTRIBUTE
+        || getInputStream().LA(1) == Metapath10.KW_FLAG
         || getInputStream().LA(1) == Metapath10.KW_COMMENT
         || getInputStream().LA(1) == Metapath10.KW_DOCUMENT_NODE
         || getInputStream().LA(1) == Metapath10.KW_ELEMENT

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/ArraySequenceConstructor.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/ArraySequenceConstructor.java
@@ -26,11 +26,11 @@ public class ArraySequenceConstructor implements IExpression {
    * Construct a new array constructor expression that uses the provided
    * expression to initialize the array.
    *
-   * @param expr
+   * @param expression
    *          the expression used to produce the array members
    */
-  public ArraySequenceConstructor(@Nullable IExpression expr) {
-    this.expr = expr;
+  public ArraySequenceConstructor(@Nullable IExpression expression) {
+    this.expr = expression;
   }
 
   @SuppressWarnings("rawtypes")

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/BuildCSTVisitor.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/BuildCSTVisitor.java
@@ -655,6 +655,15 @@ public class BuildCSTVisitor
       case Metapath10Lexer.KW_DESCENDANT_OR_SELF:
         axis = Axis.DESCENDANT_OR_SELF;
         break;
+      case Metapath10Lexer.KW_FLAG:
+        axis = Axis.FLAG;
+        break;
+      case Metapath10Lexer.KW_FOLLOWING_SIBLING:
+        axis = Axis.FOLLOWING_SIBLING;
+        break;
+      case Metapath10Lexer.KW_FOLLOWING:
+        axis = Axis.FOLLOWING;
+        break;
       default:
         throw new UnsupportedOperationException(token.getText());
       }
@@ -684,6 +693,12 @@ public class BuildCSTVisitor
       break;
     case Metapath10Lexer.KW_ANCESTOR_OR_SELF:
       axis = Axis.ANCESTOR_OR_SELF;
+      break;
+    case Metapath10Lexer.KW_PRECEDING_SIBLING:
+      axis = Axis.PRECEDING_SIBLING;
+      break;
+    case Metapath10Lexer.KW_PRECEDING:
+      axis = Axis.PRECEDING;
       break;
     default:
       throw new UnsupportedOperationException(token.getText());

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/Except.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/Except.java
@@ -22,15 +22,16 @@ public class Except
     extends AbstractFilterExpression {
 
   /**
-   * Construct a new Metapath except expression CST node.
+   * Construct a except filter expression, which removes the items resulting from
+   * the filter expression from the items expression.
    *
-   * @param left
+   * @param itemsExpression
    *          an expression indicating the items to filter
-   * @param right
+   * @param filterExpression
    *          an expression indicating the items to omit
    */
-  public Except(@NonNull IExpression left, @NonNull IExpression right) {
-    super(left, right);
+  public Except(@NonNull IExpression itemsExpression, @NonNull IExpression filterExpression) {
+    super(itemsExpression, filterExpression);
   }
 
   @Override

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/path/Axis.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/path/Axis.java
@@ -24,11 +24,16 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public enum Axis implements IExpression {
   SELF(Stream::of),
   PARENT(focus -> Stream.ofNullable(focus.getParentNodeItem())),
+  FLAG(INodeItem::flags),
   ANCESTOR(INodeItem::ancestor),
   ANCESTOR_OR_SELF(INodeItem::ancestorOrSelf),
   CHILDREN(INodeItem::modelItems),
   DESCENDANT(INodeItem::descendant),
-  DESCENDANT_OR_SELF(INodeItem::descendantOrSelf);
+  DESCENDANT_OR_SELF(INodeItem::descendantOrSelf),
+  FOLLOWING_SIBLING(INodeItem::followingSibling),
+  PRECEDING_SIBLING(INodeItem::precedingSibling),
+  FOLLOWING(INodeItem::following),
+  PRECEDING(INodeItem::preceding);
 
   @NonNull
   private final Function<INodeItem, Stream<? extends INodeItem>> action;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/path/Step.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/path/Step.java
@@ -84,7 +84,6 @@ public class Step implements IExpression { // NOPMD - intentional
 
   @Override
   public ISequence<?> accept(DynamicContext dynamicContext, ISequence<?> focus) {
-
     ISequence<? extends INodeItem> axisResult = getAxis().accept(dynamicContext, focus);
     return getStep().accept(dynamicContext, axisResult);
   }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/impl/StreamSequence.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/impl/StreamSequence.java
@@ -45,11 +45,22 @@ public class StreamSequence<ITEM extends IItem>
   }
 
   @Override
+  public Object[] toArray() {
+    return getValue().toArray();
+  }
+
+  @Override
+  public <T> T[] toArray(T[] a) {
+    return getValue().toArray(a);
+  }
+
+  @Override
   public List<ITEM> getValue() {
     instanceLock.lock();
     try {
       if (list == null) {
-        list = stream().collect(Collectors.toUnmodifiableList());
+        list = stream.collect(Collectors.toUnmodifiableList());
+        stream = null;
       }
       assert list != null;
       return list;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/IDocumentBasedNodeItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/IDocumentBasedNodeItem.java
@@ -31,5 +31,4 @@ public interface IDocumentBasedNodeItem extends INodeItem {
     // there is no parent
     return null;
   }
-
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/INodeItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/INodeItem.java
@@ -23,6 +23,21 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * Represents a queryable Metapath model node.
  */
 public interface INodeItem extends IItem, IPathSegment, INodeItemVisitable {
+  /**
+   * Retrieve the relative position of this node relative to sibling nodes.
+   * <p>
+   * A singleton item in a sequence will have a position value of {@code 1}.
+   * <p>
+   * The value {@code 1} is used as the starting value to align with the XPath
+   * specification.
+   *
+   * @return a positive integer value designating this instance's position within
+   *         a collection
+   */
+  default int getPosition() {
+    // only model node items have positions other than 1
+    return 1;
+  }
 
   /**
    * Generate a path for this node in the directed node graph, using the provided
@@ -159,7 +174,7 @@ public interface INodeItem extends IItem, IPathSegment, INodeItemVisitable {
    * @return a stream of descendant node items
    */
   @NonNull
-  default Stream<? extends INodeItem> descendant() {
+  default Stream<? extends IModelNodeItem<?, ?>> descendant() {
     return decendantsOf(this);
   }
 
@@ -174,8 +189,8 @@ public interface INodeItem extends IItem, IPathSegment, INodeItemVisitable {
    * @return a stream of descendant node items
    */
   @NonNull
-  static Stream<? extends INodeItem> decendantsOf(@NonNull INodeItem item) {
-    Stream<? extends INodeItem> children = item.modelItems();
+  static Stream<? extends IModelNodeItem<?, ?>> decendantsOf(@NonNull INodeItem item) {
+    Stream<? extends IModelNodeItem<?, ?>> children = item.modelItems();
 
     return ObjectUtils.notNull(children.flatMap(child -> {
       assert child != null;
@@ -193,6 +208,48 @@ public interface INodeItem extends IItem, IPathSegment, INodeItemVisitable {
   @NonNull
   default Stream<? extends INodeItem> descendantOrSelf() {
     return ObjectUtils.notNull(Stream.concat(Stream.of(this), descendant()));
+  }
+
+  /**
+   * Get the children of this node's parent that occur after this node in a
+   * depth-first order.
+   *
+   * @return a stream of nodes
+   */
+  @NonNull
+  default Stream<? extends IModelNodeItem<?, ?>> followingSibling() {
+    return ObjectUtils.notNull(Stream.empty());
+  }
+
+  /**
+   * Get the children of this node's parent, and their descendants, that occur
+   * before this node in a depth-first order.
+   *
+   * @return a stream of nodes
+   */
+  @NonNull
+  default Stream<? extends IModelNodeItem<?, ?>> precedingSibling() {
+    return ObjectUtils.notNull(Stream.empty());
+  }
+
+  /**
+   * Get the children of this node's parent, and their descendants, that occur
+   * before this node in a depth-first order.
+   *
+   * @return a stream of nodes
+   */
+  default Stream<? extends IModelNodeItem<?, ?>> following() {
+    return ObjectUtils.notNull(Stream.empty());
+  }
+
+  /**
+   * Get the children of this node's parent, and their descendants, that occur
+   * after this node in a depth-first order.
+   *
+   * @return a stream of nodes
+   */
+  default Stream<? extends IModelNodeItem<?, ?>> preceding() {
+    return ObjectUtils.notNull(Stream.empty());
   }
 
   /**

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/ExpressionTestBase.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/ExpressionTestBase.java
@@ -21,6 +21,11 @@ import java.util.stream.Stream;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public class ExpressionTestBase {
+  @NonNull
+  protected static final URI NS_URI = ObjectUtils.notNull(URI.create("http://example.com/ns"));
+  @NonNull
+  protected static final String NS = ObjectUtils.notNull(NS_URI.toASCIIString());
+
   @SuppressWarnings("exports")
   @NonNull
   @RegisterExtension
@@ -47,6 +52,7 @@ public class ExpressionTestBase {
 
     return new DynamicContext(StaticContext.builder()
         .baseUri(baseUri)
+        .defaultModelNamespace(NS_URI)
         .build());
   }
 

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/BuildCstVisitorTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/BuildCstVisitorTest.java
@@ -86,7 +86,7 @@ class BuildCstVisitorTest {
   @SuppressWarnings("null")
   @NonNull
   private IDocumentNodeItem newTestDocument() {
-    MockNodeItemFactory factory = new MockNodeItemFactory(context);
+    MockNodeItemFactory factory = new MockNodeItemFactory();
 
     return factory.document(URI.create("http://example.com/content"), ROOT,
         List.of(

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/path/StepTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/path/StepTest.java
@@ -1,0 +1,563 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.cst.path;
+
+import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
+import gov.nist.secauto.metaschema.core.metapath.ExpressionTestBase;
+import gov.nist.secauto.metaschema.core.metapath.ISequence;
+import gov.nist.secauto.metaschema.core.metapath.MetapathExpression;
+import gov.nist.secauto.metaschema.core.metapath.function.library.FnData;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
+import gov.nist.secauto.metaschema.core.metapath.item.node.IDocumentNodeItem;
+import gov.nist.secauto.metaschema.core.metapath.item.node.IFlagNodeItem;
+import gov.nist.secauto.metaschema.core.metapath.item.node.IModelNodeItem;
+import gov.nist.secauto.metaschema.core.metapath.item.node.INodeItem;
+import gov.nist.secauto.metaschema.core.metapath.item.node.MockNodeItemFactory;
+import gov.nist.secauto.metaschema.core.util.ObjectUtils;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.List;
+
+import javax.xml.namespace.QName;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+class StepTest
+    extends ExpressionTestBase {
+
+  @NonNull
+  private static final QName ROOT = new QName(NS, "root");
+
+  IDocumentNodeItem getTestNodeItem() {
+    MockNodeItemFactory factory = new MockNodeItemFactory();
+
+    return factory.document(URI.create("http://example.com/content"), ROOT, List.of(), List.of(
+        factory.assembly(new QName(NS, "node-1"),
+            List.of(
+                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-1-v1")),
+                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-1-v2")),
+                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-1-v3"))),
+            List.of(
+                factory.assembly(new QName(NS, "a"),
+                    List.of(
+                        factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-1-a-v1")),
+                        factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-1-a-v2")),
+                        factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-1-a-v3"))),
+                    List.of(
+                        factory.assembly(new QName(NS, "x"),
+                            List.of(
+                                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-1-a-x-v1")),
+                                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-1-a-x-v2")),
+                                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-1-a-x-v3"))),
+                            List.of()),
+                        factory.assembly(new QName(NS, "y"),
+                            List.of(
+                                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-1-a-y-v1")),
+                                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-1-a-y-v2")),
+                                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-1-a-y-v3"))),
+                            List.of()),
+                        factory.assembly(new QName(NS, "z"),
+                            List.of(
+                                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-1-a-z-v1")),
+                                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-1-a-z-v2")),
+                                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-1-a-z-v3"))),
+                            List.of()))),
+                factory.assembly(new QName(NS, "b"),
+                    List.of(
+                        factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-1-b-v1")),
+                        factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-1-b-v2")),
+                        factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-1-b-v3"))),
+                    List.of(
+                        factory.assembly(new QName(NS, "x"),
+                            List.of(
+                                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-1-b-x-v1")),
+                                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-1-b-x-v2")),
+                                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-1-b-x-v3"))),
+                            List.of()),
+                        factory.assembly(new QName(NS, "y"),
+                            List.of(
+                                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-1-b-y-v1")),
+                                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-1-b-y-v2")),
+                                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-1-b-y-v3"))),
+                            List.of()),
+                        factory.assembly(new QName(NS, "z"),
+                            List.of(
+                                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-1-b-z-v1")),
+                                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-1-b-z-v2")),
+                                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-1-b-z-v3"))),
+                            List.of()))),
+                factory.assembly(new QName(NS, "c"),
+                    List.of(
+                        factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-1-c-v1")),
+                        factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-1-c-v2")),
+                        factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-1-c-v3"))),
+                    List.of(
+                        factory.assembly(new QName(NS, "x"),
+                            List.of(
+                                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-1-c-x-v1")),
+                                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-1-c-x-v2")),
+                                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-1-c-x-v3"))),
+                            List.of()),
+                        factory.assembly(new QName(NS, "y"),
+                            List.of(
+                                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-1-c-y-v1")),
+                                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-1-c-y-v2")),
+                                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-1-c-y-v3"))),
+                            List.of()),
+                        factory.assembly(new QName(NS, "z"),
+                            List.of(
+                                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-1-c-z-v1")),
+                                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-1-c-z-v2")),
+                                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-1-c-z-v3"))),
+                            List.of()))))),
+        factory.assembly(new QName(NS, "node-2"),
+            List.of(
+                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-2-v1")),
+                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-2-v2")),
+                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-2-v3"))),
+            List.of(
+                factory.assembly(new QName(NS, "a"),
+                    List.of(
+                        factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-2-a-v1")),
+                        factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-2-a-v2")),
+                        factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-2-a-v3"))),
+                    List.of(
+                        factory.assembly(new QName(NS, "x"),
+                            List.of(
+                                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-2-a-x-v1")),
+                                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-2-a-x-v2")),
+                                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-2-a-x-v3"))),
+                            List.of()),
+                        factory.assembly(new QName(NS, "y"),
+                            List.of(
+                                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-2-a-y-v1")),
+                                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-2-a-y-v2")),
+                                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-2-a-y-v3"))),
+                            List.of()),
+                        factory.assembly(new QName(NS, "z"),
+                            List.of(
+                                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-2-a-z-v1")),
+                                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-2-a-z-v2")),
+                                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-2-a-z-v3"))),
+                            List.of()))),
+                factory.assembly(new QName(NS, "b"),
+                    List.of(
+                        factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-2-b-v1")),
+                        factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-2-b-v2")),
+                        factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-2-b-v3"))),
+                    List.of(
+                        factory.assembly(new QName(NS, "x"),
+                            List.of(
+                                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-2-b-x-v1")),
+                                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-2-b-x-v2")),
+                                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-2-b-x-v3"))),
+                            List.of()),
+                        factory.assembly(new QName(NS, "y"),
+                            List.of(
+                                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-2-b-y-v1")),
+                                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-2-b-y-v2")),
+                                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-2-b-y-v3"))),
+                            List.of()),
+                        factory.assembly(new QName(NS, "z"),
+                            List.of(
+                                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-2-b-z-v1")),
+                                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-2-b-z-v2")),
+                                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-2-b-z-v3"))),
+                            List.of()))),
+                factory.assembly(new QName(NS, "c"),
+                    List.of(
+                        factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-2-c-v1")),
+                        factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-2-c-v2")),
+                        factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-2-c-v3"))),
+                    List.of(
+                        factory.assembly(new QName(NS, "x"),
+                            List.of(
+                                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-2-c-x-v1")),
+                                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-2-c-x-v2")),
+                                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-2-c-x-v3"))),
+                            List.of()),
+                        factory.assembly(new QName(NS, "y"),
+                            List.of(
+                                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-2-c-y-v1")),
+                                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-2-c-y-v2")),
+                                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-2-c-y-v3"))),
+                            List.of()),
+                        factory.assembly(new QName(NS, "z"),
+                            List.of(
+                                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-2-c-z-v1")),
+                                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-2-c-z-v2")),
+                                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-2-c-z-v3"))),
+                            List.of()))))),
+        factory.assembly(new QName(NS, "node-3"),
+            List.of(
+                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-3-v1")),
+                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-3-v2")),
+                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-3-v3"))),
+            List.of(
+                factory.assembly(new QName(NS, "a"),
+                    List.of(
+                        factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-3-a-v1")),
+                        factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-3-a-v2")),
+                        factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-3-a-v3"))),
+                    List.of(
+                        factory.assembly(new QName(NS, "x"),
+                            List.of(
+                                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-3-a-x-v1")),
+                                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-3-a-x-v2")),
+                                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-3-a-x-v3"))),
+                            List.of()),
+                        factory.assembly(new QName(NS, "y"),
+                            List.of(
+                                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-3-a-y-v1")),
+                                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-3-a-y-v2")),
+                                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-3-a-y-v3"))),
+                            List.of()),
+                        factory.assembly(new QName(NS, "z"),
+                            List.of(
+                                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-3-a-z-v1")),
+                                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-3-a-z-v2")),
+                                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-3-a-z-v3"))),
+                            List.of()))),
+                factory.assembly(new QName(NS, "b"),
+                    List.of(
+                        factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-3-b-v1")),
+                        factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-3-b-v2")),
+                        factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-3-b-v3"))),
+                    List.of(
+                        factory.assembly(new QName(NS, "x"),
+                            List.of(
+                                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-3-b-x-v1")),
+                                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-3-b-x-v2")),
+                                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-3-b-x-v3"))),
+                            List.of()),
+                        factory.assembly(new QName(NS, "y"),
+                            List.of(
+                                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-3-b-y-v1")),
+                                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-3-b-y-v2")),
+                                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-3-b-y-v3"))),
+                            List.of()),
+                        factory.assembly(new QName(NS, "z"),
+                            List.of(
+                                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-3-b-z-v1")),
+                                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-3-b-z-v2")),
+                                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-3-b-z-v3"))),
+                            List.of()))),
+                factory.assembly(new QName(NS, "c"),
+                    List.of(
+                        factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-3-c-v1")),
+                        factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-3-c-v2")),
+                        factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-3-c-v3"))),
+                    List.of(
+                        factory.assembly(new QName(NS, "x"),
+                            List.of(
+                                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-3-c-x-v1")),
+                                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-3-c-x-v2")),
+                                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-3-c-x-v3"))),
+                            List.of()),
+                        factory.assembly(new QName(NS, "y"),
+                            List.of(
+                                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-3-c-y-v1")),
+                                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-3-c-y-v2")),
+                                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-3-c-y-v3"))),
+                            List.of()),
+                        factory.assembly(new QName(NS, "z"),
+                            List.of(
+                                factory.flag(new QName("flag-v1"), IStringItem.valueOf("flag-3-c-z-v1")),
+                                factory.flag(new QName("flag-v2"), IStringItem.valueOf("flag-3-c-z-v2")),
+                                factory.flag(new QName("flag-v3"), IStringItem.valueOf("flag-3-c-z-v3"))),
+                            List.of())))))));
+  }
+
+  @Test
+  void testSelfAxis() {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    IModelNodeItem<?, ?> nodeB = MetapathExpression.compile("/root/node-2/b", dynamicContext.getStaticContext())
+        .evaluateAs(getTestNodeItem(), MetapathExpression.ResultType.ITEM, dynamicContext);
+
+    INodeItem actual = MetapathExpression.compile("self::*", dynamicContext.getStaticContext())
+        .evaluateAs(nodeB, MetapathExpression.ResultType.ITEM, dynamicContext);
+
+    Assertions.assertThat(actual)
+        .isEqualTo(nodeB)
+        .isNotNull();
+  }
+
+  @Test
+  void testParentAxis() {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    IModelNodeItem<?, ?> nodeB = ObjectUtils.requireNonNull(
+        MetapathExpression.compile("/root/node-2/b", dynamicContext.getStaticContext())
+            .evaluateAs(getTestNodeItem(), MetapathExpression.ResultType.ITEM, dynamicContext));
+
+    INodeItem actual = MetapathExpression.compile("parent::*", dynamicContext.getStaticContext())
+        .evaluateAs(nodeB, MetapathExpression.ResultType.ITEM, dynamicContext);
+
+    Assertions.assertThat(actual)
+        .isEqualTo(nodeB.getParentNodeItem())
+        .isNotNull();
+  }
+
+  @Test
+  void testFlagAxis() {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    IModelNodeItem<?, ?> nodeB = MetapathExpression.compile("/root/node-2/b", dynamicContext.getStaticContext())
+        .evaluateAs(getTestNodeItem(), MetapathExpression.ResultType.ITEM, dynamicContext);
+
+    ISequence<?> actual = MetapathExpression.compile("flag::*", dynamicContext.getStaticContext())
+        .evaluate(nodeB, dynamicContext);
+
+    Assertions.assertThat(actual.getValue())
+        .hasOnlyElementsOfType(IFlagNodeItem.class)
+        .map(flag -> FnData.fnDataItem(flag).asString())
+        .containsExactly("flag-2-b-v1", "flag-2-b-v2", "flag-2-b-v3");
+  }
+
+  @Test
+  void testAncestorAxis() {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    IDocumentNodeItem document = getTestNodeItem();
+
+    IModelNodeItem<?, ?> nodeB = MetapathExpression.compile("/root/node-2/b", dynamicContext.getStaticContext())
+        .evaluateAs(document, MetapathExpression.ResultType.ITEM, dynamicContext);
+
+    ISequence<? extends INodeItem> actual = MetapathExpression.compile("ancestor::*", dynamicContext.getStaticContext())
+        .evaluate(nodeB, dynamicContext);
+
+    Assertions.assertThat(actual.getValue()).isEqualTo(List.of(
+        document.getRootAssemblyNodeItem()
+            .getModelItemsByName(new QName(NS, "node-2"))
+            .iterator().next(),
+        document.getRootAssemblyNodeItem(),
+        document));
+  }
+
+  @Test
+  void testAncestorOrSelfAxis() {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    IDocumentNodeItem document = getTestNodeItem();
+
+    IModelNodeItem<?, ?> nodeB = MetapathExpression.compile("/root/node-2/b", dynamicContext.getStaticContext())
+        .evaluateAs(document, MetapathExpression.ResultType.ITEM, dynamicContext);
+
+    ISequence<? extends INodeItem> actual
+        = MetapathExpression.compile("ancestor-or-self::*", dynamicContext.getStaticContext())
+            .evaluate(nodeB, dynamicContext);
+
+    Assertions.assertThat(actual.getValue()).isEqualTo(List.of(
+        nodeB,
+        document.getRootAssemblyNodeItem()
+            .getModelItemsByName(new QName(NS, "node-2"))
+            .iterator().next(),
+        document.getRootAssemblyNodeItem(),
+        document));
+  }
+
+  @Test
+  void testChildrenAxis() {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    IDocumentNodeItem document = getTestNodeItem();
+
+    IModelNodeItem<?, ?> nodeB
+        = ObjectUtils.requireNonNull(MetapathExpression.compile("/root/node-2/b", dynamicContext.getStaticContext())
+            .evaluateAs(document, MetapathExpression.ResultType.ITEM, dynamicContext));
+
+    ISequence<? extends INodeItem> actual
+        = MetapathExpression.compile("child::*", dynamicContext.getStaticContext())
+            .evaluate(nodeB, dynamicContext);
+
+    Assertions.assertThat(actual.getValue()).isEqualTo(
+        List.of(
+            ObjectUtils.requireNonNull(nodeB.getModelItemsByName(new QName(NS, "x"))).iterator().next(),
+            ObjectUtils.requireNonNull(nodeB.getModelItemsByName(new QName(NS, "y"))).iterator().next(),
+            ObjectUtils.requireNonNull(nodeB.getModelItemsByName(new QName(NS, "z"))).iterator().next()));
+  }
+
+  @Test
+  void testDescendantAxis() {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    IDocumentNodeItem document = getTestNodeItem();
+
+    IModelNodeItem<?, ?> node2
+        = ObjectUtils.requireNonNull(MetapathExpression.compile("/root/node-2", dynamicContext.getStaticContext())
+            .evaluateAs(document, MetapathExpression.ResultType.ITEM, dynamicContext));
+
+    ISequence<? extends INodeItem> actual
+        = MetapathExpression.compile("descendant::*", dynamicContext.getStaticContext())
+            .evaluate(node2, dynamicContext);
+
+    IModelNodeItem<?, ?> a
+        = ObjectUtils.requireNonNull(node2.getModelItemsByName(new QName(NS, "a"))).iterator().next();
+    IModelNodeItem<?, ?> b
+        = ObjectUtils.requireNonNull(node2.getModelItemsByName(new QName(NS, "b"))).iterator().next();
+    IModelNodeItem<?, ?> c
+        = ObjectUtils.requireNonNull(node2.getModelItemsByName(new QName(NS, "c"))).iterator().next();
+
+    Assertions.assertThat(actual.getValue()).isEqualTo(
+        List.of(
+            a,
+            ObjectUtils.requireNonNull(a.getModelItemsByName(new QName(NS, "x"))).iterator().next(),
+            ObjectUtils.requireNonNull(a.getModelItemsByName(new QName(NS, "y"))).iterator().next(),
+            ObjectUtils.requireNonNull(a.getModelItemsByName(new QName(NS, "z"))).iterator().next(),
+            b,
+            ObjectUtils.requireNonNull(b.getModelItemsByName(new QName(NS, "x"))).iterator().next(),
+            ObjectUtils.requireNonNull(b.getModelItemsByName(new QName(NS, "y"))).iterator().next(),
+            ObjectUtils.requireNonNull(b.getModelItemsByName(new QName(NS, "z"))).iterator().next(),
+            c,
+            ObjectUtils.requireNonNull(c.getModelItemsByName(new QName(NS, "x"))).iterator().next(),
+            ObjectUtils.requireNonNull(c.getModelItemsByName(new QName(NS, "y"))).iterator().next(),
+            ObjectUtils.requireNonNull(c.getModelItemsByName(new QName(NS, "z"))).iterator().next()));
+  }
+
+  @Test
+  void testDescendantOrSelfAxis() {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    IDocumentNodeItem document = getTestNodeItem();
+
+    IModelNodeItem<?, ?> node2
+        = ObjectUtils.requireNonNull(MetapathExpression.compile("/root/node-2", dynamicContext.getStaticContext())
+            .evaluateAs(document, MetapathExpression.ResultType.ITEM, dynamicContext));
+
+    ISequence<? extends INodeItem> actual
+        = MetapathExpression.compile("descendant-or-self::*", dynamicContext.getStaticContext())
+            .evaluate(node2, dynamicContext);
+
+    IModelNodeItem<?, ?> a
+        = ObjectUtils.requireNonNull(node2.getModelItemsByName(new QName(NS, "a"))).iterator().next();
+    IModelNodeItem<?, ?> b
+        = ObjectUtils.requireNonNull(node2.getModelItemsByName(new QName(NS, "b"))).iterator().next();
+    IModelNodeItem<?, ?> c
+        = ObjectUtils.requireNonNull(node2.getModelItemsByName(new QName(NS, "c"))).iterator().next();
+
+    Assertions.assertThat(actual.getValue()).isEqualTo(
+        List.of(
+            node2,
+            a,
+            ObjectUtils.requireNonNull(a.getModelItemsByName(new QName(NS, "x"))).iterator().next(),
+            ObjectUtils.requireNonNull(a.getModelItemsByName(new QName(NS, "y"))).iterator().next(),
+            ObjectUtils.requireNonNull(a.getModelItemsByName(new QName(NS, "z"))).iterator().next(),
+            b,
+            ObjectUtils.requireNonNull(b.getModelItemsByName(new QName(NS, "x"))).iterator().next(),
+            ObjectUtils.requireNonNull(b.getModelItemsByName(new QName(NS, "y"))).iterator().next(),
+            ObjectUtils.requireNonNull(b.getModelItemsByName(new QName(NS, "z"))).iterator().next(),
+            c,
+            ObjectUtils.requireNonNull(c.getModelItemsByName(new QName(NS, "x"))).iterator().next(),
+            ObjectUtils.requireNonNull(c.getModelItemsByName(new QName(NS, "y"))).iterator().next(),
+            ObjectUtils.requireNonNull(c.getModelItemsByName(new QName(NS, "z"))).iterator().next()));
+  }
+
+  @Test
+  void testFollowingSiblingAxis() {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    IDocumentNodeItem document = getTestNodeItem();
+
+    IModelNodeItem<?, ?> nodeB
+        = ObjectUtils.requireNonNull(MetapathExpression.compile("/root/node-2/b", dynamicContext.getStaticContext())
+            .evaluateAs(document, MetapathExpression.ResultType.ITEM, dynamicContext));
+
+    ISequence<? extends INodeItem> actual
+        = MetapathExpression.compile("following-sibling::*", dynamicContext.getStaticContext())
+            .evaluate(nodeB, dynamicContext);
+
+    IModelNodeItem<?, ?> node2 = document.getRootAssemblyNodeItem()
+        .getModelItemsByName(new QName(NS, "node-2"))
+        .iterator().next();
+
+    Assertions.assertThat(actual.getValue()).isEqualTo(
+        List.of(ObjectUtils.requireNonNull(node2.getModelItemsByName(new QName(NS, "c"))).iterator().next()));
+  }
+
+  @Test
+  void testPrecedingSiblingAxis() {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    IDocumentNodeItem document = getTestNodeItem();
+
+    IModelNodeItem<?, ?> nodeB
+        = ObjectUtils.requireNonNull(MetapathExpression.compile("/root/node-2/b", dynamicContext.getStaticContext())
+            .evaluateAs(document, MetapathExpression.ResultType.ITEM, dynamicContext));
+
+    ISequence<? extends INodeItem> actual
+        = MetapathExpression.compile("preceding-sibling::*", dynamicContext.getStaticContext())
+            .evaluate(nodeB, dynamicContext);
+
+    IModelNodeItem<?, ?> node2 = document.getRootAssemblyNodeItem()
+        .getModelItemsByName(new QName(NS, "node-2"))
+        .iterator().next();
+
+    Assertions.assertThat(actual.getValue()).isEqualTo(
+        List.of(ObjectUtils.requireNonNull(node2.getModelItemsByName(new QName(NS, "a"))).iterator().next()));
+  }
+
+  @Test
+  void testFollowingAxis() {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    IDocumentNodeItem document = getTestNodeItem();
+
+    IModelNodeItem<?, ?> nodeB
+        = ObjectUtils.requireNonNull(MetapathExpression.compile("/root/node-2/b", dynamicContext.getStaticContext())
+            .evaluateAs(document, MetapathExpression.ResultType.ITEM, dynamicContext));
+
+    ISequence<? extends INodeItem> actual
+        = MetapathExpression.compile("following::*", dynamicContext.getStaticContext())
+            .evaluate(nodeB, dynamicContext);
+
+    IModelNodeItem<?, ?> node2 = document.getRootAssemblyNodeItem()
+        .getModelItemsByName(new QName(NS, "node-2"))
+        .iterator().next();
+
+    IModelNodeItem<?, ?> c
+        = ObjectUtils.requireNonNull(node2.getModelItemsByName(new QName(NS, "c"))).iterator().next();
+
+    Assertions.assertThat(actual.getValue()).isEqualTo(
+        List.of(
+            c,
+            ObjectUtils.requireNonNull(c.getModelItemsByName(new QName(NS, "x"))).iterator().next(),
+            ObjectUtils.requireNonNull(c.getModelItemsByName(new QName(NS, "y"))).iterator().next(),
+            ObjectUtils.requireNonNull(c.getModelItemsByName(new QName(NS, "z"))).iterator().next()));
+  }
+
+  @Test
+  void testPrecedingAxis() {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    IDocumentNodeItem document = getTestNodeItem();
+
+    IModelNodeItem<?, ?> nodeB
+        = ObjectUtils.requireNonNull(MetapathExpression.compile("/root/node-2/b", dynamicContext.getStaticContext())
+            .evaluateAs(document, MetapathExpression.ResultType.ITEM, dynamicContext));
+
+    ISequence<? extends INodeItem> actual
+        = MetapathExpression.compile("preceding::*", dynamicContext.getStaticContext())
+            .evaluate(nodeB, dynamicContext);
+
+    IModelNodeItem<?, ?> node2 = document.getRootAssemblyNodeItem()
+        .getModelItemsByName(new QName(NS, "node-2"))
+        .iterator().next();
+
+    IModelNodeItem<?, ?> a
+        = ObjectUtils.requireNonNull(node2.getModelItemsByName(new QName(NS, "a"))).iterator().next();
+
+    Assertions.assertThat(actual.getValue()).isEqualTo(
+        List.of(
+            a,
+            ObjectUtils.requireNonNull(a.getModelItemsByName(new QName(NS, "x"))).iterator().next(),
+            ObjectUtils.requireNonNull(a.getModelItemsByName(new QName(NS, "y"))).iterator().next(),
+            ObjectUtils.requireNonNull(a.getModelItemsByName(new QName(NS, "z"))).iterator().next()));
+  }
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/model/constraint/DefaultConstraintValidatorTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/model/constraint/DefaultConstraintValidatorTest.java
@@ -13,11 +13,16 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 import gov.nist.secauto.metaschema.core.datatype.markup.MarkupLine;
 import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
 import gov.nist.secauto.metaschema.core.metapath.StaticContext;
 import gov.nist.secauto.metaschema.core.metapath.format.IPathFormatter;
+import gov.nist.secauto.metaschema.core.metapath.item.IItemVisitor;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
 import gov.nist.secauto.metaschema.core.metapath.item.node.IFlagNodeItem;
 import gov.nist.secauto.metaschema.core.metapath.item.node.MockNodeItemFactory;
@@ -25,13 +30,9 @@ import gov.nist.secauto.metaschema.core.model.IFlagDefinition;
 import gov.nist.secauto.metaschema.core.model.ISource;
 import gov.nist.secauto.metaschema.core.util.CollectionUtil;
 
-import org.jmock.Expectations;
-import org.jmock.Mockery;
 import org.jmock.api.Invocation;
-import org.jmock.junit5.JUnit5Mockery;
 import org.jmock.lib.action.CustomAction;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.net.URI;
 import java.util.List;
@@ -44,9 +45,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 class DefaultConstraintValidatorTest {
   private static final String NS = URI.create("http://example.com/ns").toASCIIString();
 
-  @RegisterExtension
-  Mockery context = new JUnit5Mockery();
-
   @NonNull
   private static QName qname(@NonNull String name) {
     return new QName(NS, name);
@@ -55,13 +53,13 @@ class DefaultConstraintValidatorTest {
   @SuppressWarnings("null")
   @Test
   void testAllowedValuesAllowOther() {
-    MockNodeItemFactory itemFactory = new MockNodeItemFactory(context);
+    MockNodeItemFactory itemFactory = new MockNodeItemFactory();
 
     IFlagNodeItem flag = itemFactory.flag(qname("value"), IStringItem.valueOf("value"));
 
-    IFlagDefinition flagDefinition = context.mock(IFlagDefinition.class);
+    IFlagDefinition flagDefinition = mock(IFlagDefinition.class);
 
-    ISource source = context.mock(ISource.class);
+    ISource source = mock(ISource.class);
 
     IAllowedValuesConstraint allowedValues = IAllowedValuesConstraint.builder()
         .source(source)
@@ -74,30 +72,17 @@ class DefaultConstraintValidatorTest {
 
     DynamicContext dynamicContext = new DynamicContext();
 
-    context.checking(new Expectations() {
-      { // NOPMD - intentional
-        allowing(flag).getDefinition();
-        will(returnValue(flagDefinition));
-        allowing(flag).accept(with(any(DefaultConstraintValidator.Visitor.class)), with(dynamicContext));
-        will(new FlagVisitorAction(dynamicContext));
-        allowing(flag).toPath(with(any(IPathFormatter.class)));
-        will(returnValue("flag/path"));
+    doReturn(flagDefinition).when(flag).getDefinition();
+    doReturn("flag/path").when(flag).toPath(any(IPathFormatter.class));
 
-        allowing(flagDefinition).getLetExpressions();
-        will(returnValue(CollectionUtil.emptyMap()));
-        allowing(flagDefinition).getAllowedValuesConstraints();
-        will(returnValue(CollectionUtil.singletonList(allowedValues)));
-        allowing(flagDefinition).getExpectConstraints();
-        will(returnValue(CollectionUtil.emptyList()));
-        allowing(flagDefinition).getMatchesConstraints();
-        will(returnValue(CollectionUtil.emptyList()));
-        allowing(flagDefinition).getIndexHasKeyConstraints();
-        will(returnValue(CollectionUtil.emptyList()));
+    doReturn(CollectionUtil.emptyMap()).when(flagDefinition).getLetExpressions();
+    doReturn(CollectionUtil.singletonList(allowedValues)).when(flagDefinition).getAllowedValuesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getExpectConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getMatchesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getIndexHasKeyConstraints();
 
-        allowing(source).getStaticContext();
-        will(returnValue(StaticContext.instance()));
-      }
-    });
+    doReturn(StaticContext.instance()).when(source).getStaticContext();
+
     FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
     DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
     validator.validate(flag, dynamicContext);
@@ -109,13 +94,13 @@ class DefaultConstraintValidatorTest {
   @SuppressWarnings("null")
   @Test
   void testAllowedValuesMultipleAllowOther() {
-    MockNodeItemFactory itemFactory = new MockNodeItemFactory(context);
+    MockNodeItemFactory itemFactory = new MockNodeItemFactory();
 
     IFlagNodeItem flag = itemFactory.flag(qname("value"), IStringItem.valueOf("value"));
 
-    IFlagDefinition flagDefinition = context.mock(IFlagDefinition.class);
+    IFlagDefinition flagDefinition = mock(IFlagDefinition.class);
 
-    ISource source = context.mock(ISource.class);
+    ISource source = mock(ISource.class);
 
     IAllowedValuesConstraint allowedValues1 = IAllowedValuesConstraint.builder()
         .source(source)
@@ -138,30 +123,17 @@ class DefaultConstraintValidatorTest {
 
     DynamicContext dynamicContext = new DynamicContext();
 
-    context.checking(new Expectations() {
-      { // NOPMD - intentional
-        allowing(flag).getDefinition();
-        will(returnValue(flagDefinition));
-        allowing(flag).accept(with(any(DefaultConstraintValidator.Visitor.class)), with(dynamicContext));
-        will(new FlagVisitorAction(dynamicContext));
-        allowing(flag).toPath(with(any(IPathFormatter.class)));
-        will(returnValue("flag/path"));
+    doReturn(flagDefinition).when(flag).getDefinition();
+    doReturn("flag/path").when(flag).toPath(any(IPathFormatter.class));
 
-        allowing(flagDefinition).getLetExpressions();
-        will(returnValue(CollectionUtil.emptyMap()));
-        allowing(flagDefinition).getAllowedValuesConstraints();
-        will(returnValue(allowedValuesConstraints));
-        allowing(flagDefinition).getExpectConstraints();
-        will(returnValue(CollectionUtil.emptyList()));
-        allowing(flagDefinition).getMatchesConstraints();
-        will(returnValue(CollectionUtil.emptyList()));
-        allowing(flagDefinition).getIndexHasKeyConstraints();
-        will(returnValue(CollectionUtil.emptyList()));
+    doReturn(CollectionUtil.emptyMap()).when(flagDefinition).getLetExpressions();
+    doReturn(allowedValuesConstraints).when(flagDefinition).getAllowedValuesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getExpectConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getMatchesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getIndexHasKeyConstraints();
 
-        allowing(source).getStaticContext();
-        will(returnValue(StaticContext.instance()));
-      }
-    });
+    doReturn(StaticContext.instance()).when(source).getStaticContext();
+
     FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
     DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
     validator.validate(flag, dynamicContext);
@@ -173,14 +145,14 @@ class DefaultConstraintValidatorTest {
   @SuppressWarnings("null")
   @Test
   void testMultipleAllowedValuesConflictingAllowOther() {
-    MockNodeItemFactory itemFactory = new MockNodeItemFactory(context);
+    MockNodeItemFactory itemFactory = new MockNodeItemFactory();
 
     IFlagNodeItem flag1 = itemFactory.flag(qname("value"), IStringItem.valueOf("value"));
     IFlagNodeItem flag2 = itemFactory.flag(qname("other2"), IStringItem.valueOf("other2"));
 
-    IFlagDefinition flagDefinition = context.mock(IFlagDefinition.class);
+    IFlagDefinition flagDefinition = mock(IFlagDefinition.class);
 
-    ISource source = context.mock(ISource.class);
+    ISource source = mock(ISource.class);
 
     IAllowedValuesConstraint allowedValues1 = IAllowedValuesConstraint.builder()
         .source(source)
@@ -204,37 +176,26 @@ class DefaultConstraintValidatorTest {
 
     DynamicContext dynamicContext = new DynamicContext();
 
-    context.checking(new Expectations() {
-      { // NOPMD - intentional
-        allowing(flag1).getDefinition();
-        will(returnValue(flagDefinition));
-        allowing(flag1).accept(with(any(DefaultConstraintValidator.Visitor.class)), with(dynamicContext));
-        will(new FlagVisitorAction(dynamicContext));
-        allowing(flag1).toPath(with(any(IPathFormatter.class)));
-        will(returnValue("flag1/path"));
+    doReturn(flagDefinition).when(flag1).getDefinition();
+    doAnswer(invocation -> invocation.getArgument(0, DefaultConstraintValidator.Visitor.class)
+        .visitFlag((IFlagNodeItem) invocation.getMock(), dynamicContext))
+            .when(flag1).accept(any(IItemVisitor.class));
+    doReturn("flag1/path").when(flag1).toPath(any(IPathFormatter.class));
 
-        allowing(flag2).getDefinition();
-        will(returnValue(flagDefinition));
-        allowing(flag2).accept(with(any(DefaultConstraintValidator.Visitor.class)), with(any(DynamicContext.class)));
-        will(new FlagVisitorAction(dynamicContext));
-        allowing(flag2).toPath(with(any(IPathFormatter.class)));
-        will(returnValue("flag2/path"));
+    doReturn(flagDefinition).when(flag2).getDefinition();
+    doAnswer(invocation -> invocation.getArgument(0, DefaultConstraintValidator.Visitor.class)
+        .visitFlag((IFlagNodeItem) invocation.getMock(), dynamicContext))
+            .when(flag2).accept(any(IItemVisitor.class));
+    doReturn("flag1/path").when(flag2).toPath(any(IPathFormatter.class));
 
-        allowing(flagDefinition).getLetExpressions();
-        will(returnValue(CollectionUtil.emptyMap()));
-        allowing(flagDefinition).getAllowedValuesConstraints();
-        will(returnValue(allowedValuesConstraints));
-        allowing(flagDefinition).getExpectConstraints();
-        will(returnValue(CollectionUtil.emptyList()));
-        allowing(flagDefinition).getMatchesConstraints();
-        will(returnValue(CollectionUtil.emptyList()));
-        allowing(flagDefinition).getIndexHasKeyConstraints();
-        will(returnValue(CollectionUtil.emptyList()));
+    doReturn(CollectionUtil.emptyMap()).when(flagDefinition).getLetExpressions();
+    doReturn(allowedValuesConstraints).when(flagDefinition).getAllowedValuesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getExpectConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getMatchesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getIndexHasKeyConstraints();
 
-        allowing(source).getStaticContext();
-        will(returnValue(StaticContext.instance()));
-      }
-    });
+    doReturn(StaticContext.instance()).when(source).getStaticContext();
+
     FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
     DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
     validator.validate(flag1, dynamicContext);

--- a/databind/pom.xml
+++ b/databind/pom.xml
@@ -87,7 +87,11 @@
 			<artifactId>jmock-junit5</artifactId>
 			<scope>test</scope>
 		</dependency>
-
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 		    <groupId>org.eclipse.jdt</groupId>
 		    <artifactId>org.eclipse.jdt.annotation</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
 		<dependency.junit5.version>5.11.3</dependency.junit5.version>
 		<dependency.log4j2.version>2.24.1</dependency.log4j2.version>
 		<dependency.logcaptor.version>2.9.3</dependency.logcaptor.version>
+		<dependency.mokito.version>5.14.2</dependency.mokito.version>
 		<dependency.moxy.version>4.0.4</dependency.moxy.version>
 		<dependency.oss-maven.version>${project.parent.version}</dependency.oss-maven.version>
 		<dependency.plexus-utils.version>4.0.2</dependency.plexus-utils.version>
@@ -420,6 +421,11 @@
 						<artifactId>annotations</artifactId>
 					</exclusion>
 				</exclusions>
+			</dependency>
+			<dependency>
+			    <groupId>org.mockito</groupId>
+			    <artifactId>mockito-core</artifactId>
+			    <version>${dependency.mokito.version}</version>
 			</dependency>
 	        <dependency>
 			    <groupId>com.github.seregamorph</groupId>


### PR DESCRIPTION
# Committer Notes

Added preceding, preceding-sibling, following, and following-sibling axis [support in Metapath](https://www.w3.org/TR/xpath-31/#axes).

Also replaced JMock with Mockito for better mocking support.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
