### PR TITLE
Ensure the exit message is not dropped

### DIFF
--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CLIProcessor.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CLIProcessor.java
@@ -413,17 +413,14 @@ public class CLIProcessor {
       if (cmdLine.hasOption(QUIET_OPTION)) {
         handleQuiet();
       }
-      ExitStatus retval = invokeCommand(cmdLine);
-      if (ExitCode.OK.equals(retval.getExitCode())) {
-        handleError(retval, cmdLine, false);
-      }
-      return retval;
+      return invokeCommand(cmdLine);
     }
 
     @SuppressWarnings({
         "PMD.OnlyOneReturn", // readability
         "PMD.AvoidCatchingGenericException" // needed here
     })
+    @NonNull
     protected ExitStatus invokeCommand(@NonNull CommandLine cmdLine) {
       ExitStatus retval;
       try {
@@ -443,14 +440,18 @@ public class CLIProcessor {
                 .withThrowable(ex);
           }
         }
-
-        if (ExitCode.INVALID_COMMAND.equals(retval.getExitCode())) {
-          showHelp();
-        }
       } catch (RuntimeException ex) {
         retval = ExitCode.RUNTIME_ERROR
             .exitMessage(String.format("An uncaught runtime error occurred. %s", ex.getLocalizedMessage()))
             .withThrowable(ex);
+      }
+
+      if (!ExitCode.OK.equals(retval.getExitCode())) {
+        retval.generateMessage(cmdLine.hasOption(SHOW_STACK_TRACE_OPTION));
+
+        if (ExitCode.INVALID_COMMAND.equals(retval.getExitCode())) {
+          showHelp();
+        }
       }
       return retval;
     }

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractConvertSubcommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractConvertSubcommand.java
@@ -145,8 +145,10 @@ public abstract class AbstractConvertSubcommand
             handleConversion(source, toFormat, writer, loader);
           }
         }
-      } catch (IOException | IllegalArgumentException ex) {
+      } catch (IllegalArgumentException ex) {
         throw new CommandExecutionException(ExitCode.PROCESSING_ERROR, ex);
+      } catch (IOException ex) {
+        throw new CommandExecutionException(ExitCode.IO_ERROR, ex);
       }
       if (destination != null && LOGGER.isInfoEnabled()) {
         LOGGER.info("Generated {} file: {}", toFormat.toString(), destination);

--- a/metaschema-cli/src/test/java/gov/nist/secauto/metaschema/cli/CLITest.java
+++ b/metaschema-cli/src/test/java/gov/nist/secauto/metaschema/cli/CLITest.java
@@ -39,7 +39,6 @@ public class CLITest {
 
   void evaluateResult(@NonNull ExitStatus status, @NonNull ExitCode expectedCode,
       @NonNull Class<? extends Throwable> thrownClass) {
-    status.generateMessage(true);
     Throwable thrown = status.getThrowable();
     assertAll(
         () -> assertEquals(expectedCode, status.getExitCode(), "exit code mismatch"),


### PR DESCRIPTION
# Committer Notes

This PR fixes a bug that causes the exit message to be dropped and the CLI tool to exit silently with an error code.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
