### PR TITLE
Improve parser data type error handling

### DIFF
--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/IDataTypeAdapter.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/IDataTypeAdapter.java
@@ -24,7 +24,6 @@ import java.util.function.Supplier;
 
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventWriter;
-import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 
@@ -95,7 +94,7 @@ public interface IDataTypeAdapter<TYPE> {
    * @param value
    *          the data to formatted as a string
    * @return a string
-   * @throws UnsupportedOperationException
+   * @throws IllegalArgumentException
    *           if the data type cannot be represented as a string
    */
   @NonNull
@@ -127,6 +126,7 @@ public interface IDataTypeAdapter<TYPE> {
    *
    * @return the java associated item type
    */
+  // TODO: move to IAnyAtomicItem
   @NonNull
   Class<? extends IAnyAtomicItem> getItemClass();
 
@@ -139,6 +139,7 @@ public interface IDataTypeAdapter<TYPE> {
    */
   // TODO: markup types are not atomic values.
   // Figure out a better base type (i.e., IValuedItem)
+  // TODO: move to IAnyAtomicItem
   @NonNull
   IAnyAtomicItem newItem(@NonNull Object value);
 
@@ -151,6 +152,7 @@ public interface IDataTypeAdapter<TYPE> {
    * @throws InvalidValueForCastFunctionException
    *           if the provided item type cannot be cast to this item type
    */
+  // TODO: move to IAnyAtomicItem
   @NonNull
   IAnyAtomicItem cast(IAnyAtomicItem item);
 
@@ -203,6 +205,7 @@ public interface IDataTypeAdapter<TYPE> {
    * @throws IOException
    *           if a parsing error occurs
    */
+  // TODO: migrate code to XML parser implementation.
   @NonNull
   TYPE parse(@NonNull XMLEventReader2 eventReader) throws IOException;
 
@@ -215,6 +218,7 @@ public interface IDataTypeAdapter<TYPE> {
    * @throws IOException
    *           if a parsing error occurs
    */
+  // TODO: migrate code to JSON parser implementation.
   @NonNull
   TYPE parse(@NonNull JsonParser parser) throws IOException;
 
@@ -254,6 +258,7 @@ public interface IDataTypeAdapter<TYPE> {
    * @see #parse(String)
    * @see #parse(XMLEventReader2)
    */
+  // TODO: migrate code to XML parser implementation.
   @NonNull
   default Supplier<TYPE> parseAndSupply(@NonNull XMLEventReader2 eventReader) throws IOException {
     TYPE retval = parse(eventReader);
@@ -274,6 +279,7 @@ public interface IDataTypeAdapter<TYPE> {
    * @see #parse(String)
    * @see #parse(JsonParser)
    */
+  // TODO: migrate code to JSON parser implementation.
   @NonNull
   default Supplier<TYPE> parseAndSupply(@NonNull JsonParser parser) throws IOException {
     TYPE retval = parse(parser);
@@ -296,14 +302,13 @@ public interface IDataTypeAdapter<TYPE> {
    *          the XML event factory used to generate XML writing events
    * @param eventWriter
    *          the XML writer used to output XML as events
-   * @throws XMLStreamException
-   *           if an unexpected error occurred while processing the XML output
    * @throws IOException
    *           if an unexpected error occurred while writing to the output stream
    */
+  // TODO: migrate code to XML writer implementation.
   void writeXmlValue(@NonNull Object instance, @NonNull StartElement parent, @NonNull XMLEventFactory2 eventFactory,
       @NonNull XMLEventWriter eventWriter)
-      throws IOException, XMLStreamException;
+      throws IOException;
 
   /**
    * Writes the provided Java class instance data as XML. The parent element
@@ -319,11 +324,12 @@ public interface IDataTypeAdapter<TYPE> {
    *          the qualified name of the XML data's parent element
    * @param writer
    *          the XML writer used to output the XML data
-   * @throws XMLStreamException
+   * @throws IOException
    *           if an unexpected error occurred while processing the XML output
    */
+  // TODO: migrate code to XML writer implementation.
   void writeXmlValue(@NonNull Object instance, @NonNull QName parentName, @NonNull XMLStreamWriter2 writer)
-      throws XMLStreamException;
+      throws IOException;
 
   /**
    * Writes the provided Java class instance as a JSON/YAML field value.
@@ -335,6 +341,7 @@ public interface IDataTypeAdapter<TYPE> {
    * @throws IOException
    *           if an unexpected error occurred while writing the JSON/YAML output
    */
+  // TODO: migrate code to JSON writer implementation.
   void writeJsonValue(@NonNull Object instance, @NonNull JsonGenerator writer) throws IOException;
 
   /**
@@ -343,6 +350,7 @@ public interface IDataTypeAdapter<TYPE> {
    *
    * @return the default field name to use
    */
+  // TODO: migrate code to JSON implementations.
   @NonNull
   String getDefaultJsonValueKey();
 
@@ -352,6 +360,7 @@ public interface IDataTypeAdapter<TYPE> {
    *
    * @return {@code true} if allowed, or {@code false} otherwise.
    */
+  // TODO: migrate code to XML implementations.
   boolean isUnrappedValueAllowedInXml();
 
   /**
@@ -360,5 +369,6 @@ public interface IDataTypeAdapter<TYPE> {
    * @return {@code true} if the datatype uses mixed text and element content in
    *         XML, or {@code false} otherwise
    */
+  // TODO: migrate code to XML implementations.
   boolean isXmlMixed();
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/adapter/BooleanAdapter.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/adapter/BooleanAdapter.java
@@ -94,7 +94,11 @@ public class BooleanAdapter
     } else if (item instanceof IStringItem) {
       retval = castToBoolean((IStringItem) item);
     } else {
-      retval = castToBoolean(item.asStringItem());
+      try {
+        retval = castToBoolean(item.asStringItem());
+      } catch (IllegalStateException ex) {
+        throw new InvalidValueForCastFunctionException(ex.getLocalizedMessage(), ex);
+      }
     }
     return retval;
   }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/adapter/DateTimeWithTZAdapter.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/adapter/DateTimeWithTZAdapter.java
@@ -12,6 +12,7 @@ import gov.nist.secauto.metaschema.core.metapath.MetapathConstants;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IDateTimeItem;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
+import java.time.DateTimeException;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.List;
@@ -56,7 +57,15 @@ public class DateTimeWithTZAdapter
   @SuppressWarnings("null")
   @Override
   public String asString(Object value) {
-    return DateFormats.DATE_TIME_WITH_TZ.format((ZonedDateTime) value);
+    try {
+      return DateFormats.DATE_TIME_WITH_TZ.format((ZonedDateTime) value);
+    } catch (DateTimeException ex) {
+      throw new IllegalArgumentException(
+          String.format("The provided value '%s' cannot be formatted as a date/time value. %s",
+              value.toString(),
+              ex.getMessage()),
+          ex);
+    }
   }
 
   @SuppressWarnings("null")

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/adapter/DateWithTZAdapter.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/adapter/DateWithTZAdapter.java
@@ -12,6 +12,7 @@ import gov.nist.secauto.metaschema.core.metapath.MetapathConstants;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IDateItem;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
+import java.time.DateTimeException;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.List;
@@ -68,7 +69,15 @@ public class DateWithTZAdapter
   @SuppressWarnings("null")
   @Override
   public String asString(Object value) {
-    return DateFormats.DATE_WITH_TZ.format((ZonedDateTime) value);
+    try {
+      return DateFormats.DATE_WITH_TZ.format((ZonedDateTime) value);
+    } catch (DateTimeException ex) {
+      throw new IllegalArgumentException(
+          String.format("The provided value '%s' cannot be formatted as a date value. %s",
+              value.toString(),
+              ex.getMessage()),
+          ex);
+    }
   }
 
   @SuppressWarnings("null")

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/adapter/UuidAdapter.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/adapter/UuidAdapter.java
@@ -45,7 +45,13 @@ public class UuidAdapter
   @SuppressWarnings("null")
   @Override
   public UUID parse(String value) {
-    return UUID.fromString(value);
+    try {
+      return UUID.fromString(value);
+    } catch (IllegalArgumentException ex) {
+      throw new IllegalArgumentException(
+          String.format("Value '%s' is not a valid UUID.", value),
+          ex);
+    }
   }
 
   @Override

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/AbstractMarkupAdapter.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/AbstractMarkupAdapter.java
@@ -54,24 +54,32 @@ public abstract class AbstractMarkupAdapter<TYPE extends IMarkupString<TYPE>>
       StartElement parent,
       XMLEventFactory2 eventFactory,
       XMLEventWriter eventWriter)
-      throws XMLStreamException {
+      throws IOException {
 
     IMarkupString<?> markupString = (IMarkupString<?>) value;
 
-    markupString.writeXHtml(
-        ObjectUtils.notNull(parent.getName().getNamespaceURI()),
-        eventFactory,
-        eventWriter);
+    try {
+      markupString.writeXHtml(
+          ObjectUtils.notNull(parent.getName().getNamespaceURI()),
+          eventFactory,
+          eventWriter);
+    } catch (XMLStreamException ex) {
+      throw new IOException(ex);
+    }
   }
 
   @Override
   public void writeXmlValue(Object value, QName parentName, XMLStreamWriter2 streamWriter)
-      throws XMLStreamException {
+      throws IOException {
     IMarkupString<?> markupString = (IMarkupString<?>) value;
 
-    markupString.writeXHtml(
-        ObjectUtils.notNull(parentName.getNamespaceURI()),
-        streamWriter);
+    try {
+      markupString.writeXHtml(
+          ObjectUtils.notNull(parentName.getNamespaceURI()),
+          streamWriter);
+    } catch (XMLStreamException ex) {
+      throw new IOException(ex);
+    }
   }
 
   @Override

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/MetapathExpression.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/MetapathExpression.java
@@ -111,7 +111,8 @@ public class MetapathExpression {
    */
   @NonNull
   public static MetapathExpression compile(@NonNull String path, @NonNull StaticContext context) {
-    @NonNull MetapathExpression retval;
+    @NonNull
+    MetapathExpression retval;
     if (".".equals(path)) {
       retval = CONTEXT_NODE;
     } else {
@@ -412,7 +413,10 @@ public class MetapathExpression {
       return (ISequence<T>) getASTNode().accept(dynamicContext, ISequence.of(focus));
     } catch (MetapathException ex) { // NOPMD - intentional
       throw new MetapathException(
-          String.format("An error occurred while evaluating the expression '%s'.", getPath()), ex);
+          String.format("An error occurred while evaluating the expression '%s'. %s",
+              getPath(),
+              ex.getLocalizedMessage()),
+          ex);
     }
   }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnData.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnData.java
@@ -120,6 +120,9 @@ public final class FnData {
    * @param item
    *          the item to atomize
    * @return the atomized result
+   * @throws InvalidTypeFunctionException
+   *           if the item cannot be cast to an atomic value, most likely because
+   *           it doesn't have a typed value
    */
   @NonNull
   public static IAnyAtomicItem fnDataItem(@NonNull IItem item) {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnString.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnString.java
@@ -7,6 +7,7 @@ package gov.nist.secauto.metaschema.core.metapath.function.library;
 
 import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
 import gov.nist.secauto.metaschema.core.metapath.ISequence;
+import gov.nist.secauto.metaschema.core.metapath.InvalidTypeMetapathException;
 import gov.nist.secauto.metaschema.core.metapath.MetapathConstants;
 import gov.nist.secauto.metaschema.core.metapath.function.FunctionUtils;
 import gov.nist.secauto.metaschema.core.metapath.function.IArgument;
@@ -103,7 +104,11 @@ public final class FnString {
     if (item instanceof INodeItem) {
       retval = IStringItem.valueOf(((INodeItem) item).stringValue());
     } else if (item instanceof IAnyAtomicItem) {
-      retval = ((IAnyAtomicItem) item).asStringItem();
+      try {
+        retval = ((IAnyAtomicItem) item).asStringItem();
+      } catch (IllegalStateException ex) {
+        throw new InvalidTypeMetapathException(item, ex.getMessage(), ex);
+      }
     } else {
       throw new InvalidTypeFunctionException(InvalidTypeFunctionException.ARGUMENT_TO_STRING_IS_FUNCTION, item);
     }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/IDurationItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/IDurationItem.java
@@ -30,10 +30,10 @@ public interface IDurationItem extends IAnyAtomicItem {
     } else {
       try {
         retval = IDayTimeDurationItem.valueOf(item.asString());
-      } catch (IllegalArgumentException ex) {
+      } catch (IllegalStateException ex) {
         try {
           retval = IYearMonthDurationItem.valueOf(item.asString());
-        } catch (IllegalArgumentException ex2) {
+        } catch (IllegalStateException ex2) {
           InvalidValueForCastFunctionException newEx = new InvalidValueForCastFunctionException(ex2);
           newEx.addSuppressed(ex);
           throw newEx; // NOPMD context as suppressed

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/IStringItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/IStringItem.java
@@ -34,7 +34,11 @@ public interface IStringItem extends IAnyAtomicItem {
    */
   @NonNull
   static IStringItem cast(@NonNull IAnyAtomicItem item) {
-    return item.asStringItem();
+    try {
+      return item.asStringItem();
+    } catch (IllegalStateException ex) {
+      throw new InvalidValueForCastFunctionException(ex.getLocalizedMessage(), ex);
+    }
   }
 
   @Override

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/json/MetaschemaJsonReader.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/json/MetaschemaJsonReader.java
@@ -781,7 +781,17 @@ public class MetaschemaJsonReader
           throw new IOException(String.format("Null value for json-key for definition '%s'",
               jsonKey.getContainingDefinition().toCoordinates()));
         }
-        String key = jsonKey.getJavaTypeAdapter().asString(keyValue);
+        String key;
+        try {
+          key = jsonKey.getJavaTypeAdapter().asString(keyValue);
+        } catch (IllegalArgumentException ex) {
+          throw new IOException(
+              String.format("Malformed data '%s'%s. %s",
+                  keyValue,
+                  JsonUtil.generateLocationMessage(parser),
+                  ex.getLocalizedMessage()),
+              ex);
+        }
         items.put(key, item);
 
         // the next item will be a FIELD_NAME, or we will encounter an END_OBJECT if all

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/json/MetaschemaJsonWriter.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/json/MetaschemaJsonWriter.java
@@ -330,7 +330,7 @@ public class MetaschemaJsonWriter implements IJsonWritingContext, IItemWriteHand
         key = jsonKey.getJavaTypeAdapter().asString(keyValue);
       } catch (IllegalArgumentException ex) {
         throw new IOException(
-            String.format("Invalid value '%s' for json--key for definition '%s'",
+            String.format("Invalid value '%s' for json-key for definition '%s'",
                 keyValue,
                 jsonKey.getContainingDefinition().toCoordinates()),
             ex);

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/json/MetaschemaJsonWriter.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/json/MetaschemaJsonWriter.java
@@ -124,8 +124,16 @@ public class MetaschemaJsonWriter implements IJsonWritingContext, IItemWriteHand
           throw new IOException(String.format("Null value for json-value-key for definition '%s'",
               jsonValueKey.getContainingDefinition().toCoordinates()));
         }
-        // this is the JSON value key case
-        valueKeyName = jsonValueKey.getJavaTypeAdapter().asString(keyValue);
+        try {
+          // this is the JSON value key case
+          valueKeyName = jsonValueKey.getJavaTypeAdapter().asString(keyValue);
+        } catch (IllegalArgumentException ex) {
+          throw new IOException(
+              String.format("Invalid value '%s' for json-value-key for definition '%s'",
+                  keyValue,
+                  jsonValueKey.getContainingDefinition().toCoordinates()),
+              ex);
+        }
       } else {
         valueKeyName = fieldValue.getParentFieldDefinition().getEffectiveJsonValueKeyName();
       }
@@ -270,12 +278,22 @@ public class MetaschemaJsonWriter implements IJsonWritingContext, IItemWriteHand
     if (jsonKey != null) {
       Object keyValue = jsonKey.getValue(parent);
       if (keyValue == null) {
-        throw new IOException(String.format("Null value for json-key for definition '%s'",
-            jsonKey.getContainingDefinition().toCoordinates()));
+        throw new IOException(
+            String.format("Null value for json-key for definition '%s'",
+                jsonKey.getContainingDefinition().toCoordinates()));
       }
 
       // the field will be the JSON key value
-      String key = jsonKey.getJavaTypeAdapter().asString(keyValue);
+      String key;
+      try {
+        key = jsonKey.getJavaTypeAdapter().asString(keyValue);
+      } catch (IllegalArgumentException ex) {
+        throw new IOException(
+            String.format("Illegal value '%s' for json-key for definition '%s'",
+                keyValue,
+                jsonKey.getContainingDefinition().toCoordinates()),
+            ex);
+      }
       generator.writeFieldName(key);
 
       // next the value will be a start object
@@ -307,7 +325,16 @@ public class MetaschemaJsonWriter implements IJsonWritingContext, IItemWriteHand
       }
 
       // the field will be the JSON key value
-      String key = jsonKey.getJavaTypeAdapter().asString(keyValue);
+      String key;
+      try {
+        key = jsonKey.getJavaTypeAdapter().asString(keyValue);
+      } catch (IllegalArgumentException ex) {
+        throw new IOException(
+            String.format("Invalid value '%s' for json--key for definition '%s'",
+                keyValue,
+                jsonKey.getContainingDefinition().toCoordinates()),
+            ex);
+      }
       generator.writeFieldName(key);
 
       // next the value will be a start object

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/xml/MetaschemaXmlWriter.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/xml/MetaschemaXmlWriter.java
@@ -268,7 +268,12 @@ public class MetaschemaXmlWriter implements IXmlWritingContext {
 
     @Override
     public void writeItemFlag(Object item, IBoundInstanceFlag instance) throws IOException {
-      String itemString = instance.getJavaTypeAdapter().asString(item);
+      String itemString;
+      try {
+        itemString = instance.getJavaTypeAdapter().asString(item);
+      } catch (IllegalArgumentException ex) {
+        throw new IOException(ex);
+      }
       QName name = instance.getXmlQName();
       try {
         if (name.getNamespaceURI().isEmpty()) {
@@ -331,11 +336,7 @@ public class MetaschemaXmlWriter implements IXmlWritingContext {
     public void writeItemFieldValue(Object parentItem, IBoundFieldValue fieldValue) throws IOException {
       Object item = fieldValue.getValue(parentItem);
       if (item != null) {
-        try {
-          fieldValue.getJavaTypeAdapter().writeXmlValue(item, getObjectQName(), writer);
-        } catch (XMLStreamException ex) {
-          throw new IOException(ex);
-        }
+        fieldValue.getJavaTypeAdapter().writeXmlValue(item, getObjectQName(), writer);
       }
     }
 

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/info/IFeatureScalarItemValueHandler.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/info/IFeatureScalarItemValueHandler.java
@@ -11,7 +11,6 @@ import gov.nist.secauto.metaschema.databind.io.BindingException;
 import gov.nist.secauto.metaschema.databind.model.IValuedMutable;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 
 public interface IFeatureScalarItemValueHandler
     extends IItemValueHandler<Object>, IValuedMutable {
@@ -33,12 +32,6 @@ public interface IFeatureScalarItemValueHandler
   default void setValue(@NonNull Object parent, @NonNull String text) {
     Object item = getValueFromString(text);
     setValue(parent, item);
-  }
-
-  @Nullable
-  default String toStringFromItem(@NonNull Object parent) {
-    Object item = getValue(parent);
-    return item == null ? null : getJavaTypeAdapter().asString(item);
   }
 
   /**


### PR DESCRIPTION
# Committer Notes

Addressed inconsistent handling of data type parsing calls to provide more consistent error reporting for data type related errors.

Resolves GSA/fedramp-automation#823

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
