### PR TITLE
Fix partial metapath parse

### DIFF
--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/MetapathExpression.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/MetapathExpression.java
@@ -188,7 +188,7 @@ public class MetapathExpression {
           }
         });
 
-        ParseTree tree = ObjectUtils.notNull(parser.expr());
+        ParseTree tree = ObjectUtils.notNull(parser.metapath());
 
         if (LOGGER.isDebugEnabled()) {
           try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/antlr/AbstractAstVisitor.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/antlr/AbstractAstVisitor.java
@@ -146,7 +146,7 @@ public abstract class AbstractAstVisitor<R>
   @Override
   public R visitMetapath(MetapathContext ctx) {
     assert ctx != null;
-    return delegateToChild(ctx);
+    return ctx.expr().accept(this);
   }
 
   /**

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/MetapathExpressionTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/MetapathExpressionTest.java
@@ -15,6 +15,8 @@ import gov.nist.secauto.metaschema.core.metapath.item.atomic.IBooleanItem;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+
 import io.hosuaby.inject.resources.junit.jupiter.GivenTextResource;
 import io.hosuaby.inject.resources.junit.jupiter.TestWithResources;
 
@@ -70,5 +72,13 @@ class MetapathExpressionTest {
     assertTrue(!result.isEmpty(), "result was empty");
     assertEquals(1, result.size(), "unexpected size");
     assertEquals(true, ((IBooleanItem) result.getValue().iterator().next()).toBoolean(), "unexpected result");
+  }
+
+  @Test
+  void testMalformedIf() throws IOException {
+    StaticMetapathException ex = assertThrows(StaticMetapathException.class, () -> {
+      MetapathExpression.compile("if 'a' = '1.1.2' then true() else false()");
+    });
+    assertEquals(StaticMetapathException.INVALID_PATH_GRAMMAR, ex.getCode());
   }
 }


### PR DESCRIPTION
# Committer Notes

Fixed partial metapath parsing, which allowed invalid metapaths to be used if the first part was seen as valid.

Resolves #258

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
