### PR TITLE
Restore proper choice behavior in schema generation

### DIFF
--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractValidateContentCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractValidateContentCommand.java
@@ -249,7 +249,8 @@ public abstract class AbstractValidateContentCommand
 
       IValidationResult validationResult = null;
       try {
-        IModule module = bindingContext.registerModule(getModule(commandLine, bindingContext));
+        // get the module, but don't register it
+        IModule module = getModule(commandLine, bindingContext);
         if (!commandLine.hasOption(NO_SCHEMA_VALIDATION_OPTION)) {
           // perform schema validation
           validationResult = getSchemaValidationProvider(module, commandLine, bindingContext)
@@ -263,6 +264,7 @@ public abstract class AbstractValidateContentCommand
           }
 
           // perform constraint validation
+          bindingContext.registerModule(module); // ensure the module is registered
           IValidationResult constraintValidationResult = bindingContext.validateWithConstraints(source, configuration);
           validationResult = validationResult == null
               ? constraintValidationResult


### PR DESCRIPTION
# Committer Notes

Delayed registering module to just before constraint validation to ensure schemas are generated directly from the loaded module and not the compiled version.

This issue was caused by the lack for proper choice support in generated bindings. Previous versions of this library used the loaded Metaschema module information directly, without first generating classes for the module. This was changed in the 2.0.0 and 2.0.1 versions. This PR restores the original behavior.

See #262 for follow-on work to fully implement the choice construct in generated bindings.

Resolves #259

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
