### PR TITLE
Support for fn:current-date

### DIFF
--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/DefaultFunctionLibrary.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/DefaultFunctionLibrary.java
@@ -50,7 +50,8 @@ public class DefaultFunctionLibrary
     registerFunction(FnContains.SIGNATURE);
     // https://www.w3.org/TR/xpath-functions-31/#func-count
     registerFunction(FnCount.SIGNATURE);
-    // P2: https://www.w3.org/TR/xpath-functions-31/#func-current-date
+    // https://www.w3.org/TR/xpath-functions-31/#func-current-date
+    registerFunction(FnCurrentDate.SIGNATURE);
     // https://www.w3.org/TR/xpath-functions-31/#func-current-dateTime
     registerFunction(FnCurrentDateTime.SIGNATURE);
     // https://www.w3.org/TR/xpath-functions-31/#func-current-time

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnCurrentDate.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnCurrentDate.java
@@ -19,7 +19,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Implements the XPath 3.1 <a href=
- * "https://www.w3.org/TR/xpath-functions-31/#func-current-dateTime">fn:current-dateTime</a>
+ * "https://www.w3.org/TR/xpath-functions-31/#func-current-date">fn:current-date</a>
  * function.
  */
 public final class FnCurrentDate {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnCurrentDate.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnCurrentDate.java
@@ -10,8 +10,8 @@ import gov.nist.secauto.metaschema.core.metapath.MetapathConstants;
 import gov.nist.secauto.metaschema.core.metapath.function.IFunction;
 import gov.nist.secauto.metaschema.core.metapath.item.IItem;
 import gov.nist.secauto.metaschema.core.metapath.item.ISequence;
-import gov.nist.secauto.metaschema.core.metapath.item.atomic.ITimeItem;
-import gov.nist.secauto.metaschema.core.metapath.item.atomic.ITimeWithTimeZoneItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IDateItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IDateWithTimeZoneItem;
 
 import java.util.List;
 
@@ -19,45 +19,45 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Implements the XPath 3.1 <a href=
- * "https://www.w3.org/TR/xpath-functions-31/#func-current-time">fn:current-time</a>
+ * "https://www.w3.org/TR/xpath-functions-31/#func-current-dateTime">fn:current-dateTime</a>
  * function.
  */
-public final class FnCurrentTime {
+public final class FnCurrentDate {
   @NonNull
   static final IFunction SIGNATURE = IFunction.builder()
-      .name("current-time")
+      .name("current-date")
       .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
       .deterministic()
       .contextDependent()
       .focusIndependent()
-      .returnType(ITimeItem.type())
+      .returnType(IDateItem.type())
       .returnOne()
-      .functionHandler(FnCurrentTime::execute)
+      .functionHandler(FnCurrentDate::execute)
       .build();
 
-  private FnCurrentTime() {
+  private FnCurrentDate() {
     // disable construction
   }
 
   @SuppressWarnings("unused")
   @NonNull
-  private static ISequence<ITimeItem> execute(@NonNull IFunction function,
+  private static ISequence<IDateItem> execute(@NonNull IFunction function,
       @NonNull List<ISequence<?>> arguments,
       @NonNull DynamicContext dynamicContext,
       IItem focus) {
-    return ISequence.of(fnCurrentTime(dynamicContext));
+    return ISequence.of(fnCurrentDate(dynamicContext));
   }
 
   /**
    * Implements <a href=
-   * "https://www.w3.org/TR/xpath-functions-31/#func-current-time">fn:current-time</a>.
+   * "https://www.w3.org/TR/xpath-functions-31/#func-current-date">fn:current-date</a>.
    *
    * @param dynamicContext
    *          the dynamic evaluation context
    * @return the current date
    */
   @NonNull
-  public static ITimeItem fnCurrentTime(@NonNull DynamicContext dynamicContext) {
-    return ITimeWithTimeZoneItem.valueOf(dynamicContext.getCurrentDateTime());
+  public static IDateItem fnCurrentDate(@NonNull DynamicContext dynamicContext) {
+    return IDateWithTimeZoneItem.valueOf(dynamicContext.getCurrentDateTime());
   }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnIndexOf.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnIndexOf.java
@@ -15,6 +15,7 @@ import gov.nist.secauto.metaschema.core.metapath.item.IItem;
 import gov.nist.secauto.metaschema.core.metapath.item.ISequence;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IIntegerItem;
+import gov.nist.secauto.metaschema.core.metapath.type.InvalidTypeMetapathException;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
 import java.util.ArrayList;
@@ -84,6 +85,7 @@ public final class FnIndexOf {
    * @return a list of index numbers indicating the position of matches in the
    *         sequence
    */
+  @NonNull
   public static ISequence<IIntegerItem> fnIndexOf(@NonNull List<IAnyAtomicItem> items,
       @NonNull IAnyAtomicItem search) {
     int index = 0;
@@ -94,9 +96,13 @@ public final class FnIndexOf {
       IAnyAtomicItem item = iterator.next();
       assert item != null;
       // use the "eq" operator
-      if (ComparisonFunctions.valueCompairison(item, ComparisonFunctions.Operator.EQ, search).toBoolean()) {
-        // Offset for Metapath indices that start from 1
-        indices.add(IIntegerItem.valueOf(index));
+      try {
+        if (ComparisonFunctions.valueCompairison(item, ComparisonFunctions.Operator.EQ, search).toBoolean()) {
+          // Offset for Metapath indices that start from 1
+          indices.add(IIntegerItem.valueOf(index));
+        }
+      } catch (InvalidTypeMetapathException ex) {
+        // this is an effective false on the match
       }
     }
     return ISequence.ofCollection(indices);

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnIndexOfTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnIndexOfTest.java
@@ -35,11 +35,9 @@ class FnIndexOfTest
         Arguments.of(
             sequence(integer(1), integer(4)),
             "index-of(('a', 'sport', 'and', 'a', 'pasttime'), 'a')"),
-        // TODO: add current-date() test after metaschema-framework/metaschema-java#162
-        // complete
-        // Arguments.of(
-        // ISequence.empty(),
-        // "index-of(current-date(), 23)"),
+        Arguments.of(
+            ISequence.empty(),
+            "index-of(current-date(), 23)"),
         Arguments.of(
             sequence(integer(1)),
             "index-of((true()), 'true')"),


### PR DESCRIPTION
# Committer Notes

Added the fn:current-date Metapath function in support of #162.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
