### PR TITLE
Support DEBUG Constraint Level

### DIFF
--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/util/LoggingValidationHandler.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/util/LoggingValidationHandler.java
@@ -162,6 +162,9 @@ public final class LoggingValidationHandler
     case INFORMATIONAL:
       retval = LOGGER.atInfo();
       break;
+    case DEBUG:
+      retval = LOGGER.isDebugEnabled() ? LOGGER.atDebug() : LOGGER.atInfo();
+      break;
     default:
       throw new IllegalArgumentException("Unknown level: " + finding.getSeverity().name());
     }
@@ -192,6 +195,9 @@ public final class LoggingValidationHandler
       break;
     case INFORMATIONAL:
       ansi = ansi.fgBrightBlue().a("INFO").reset();
+      break;
+    case DEBUG:
+      ansi = ansi.fgBrightCyan().a("DEBUG").reset();
       break;
     default:
       ansi = ansi().fgBright(Color.MAGENTA).a(level.name()).reset();


### PR DESCRIPTION
# Committer Notes

Added support for DEBUG level constraints in tool output.

Resolves metaschema-framework/oscal-cli#92

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
