### PR TITLE
Fix parsing of parameter handling for functions with multiple parameters

### DIFF
--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/BuildCSTVisitor.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/BuildCSTVisitor.java
@@ -415,7 +415,7 @@ public class BuildCSTVisitor
             0,
             2,
             (ctx, idx) -> {
-              int pos = (idx - 1) / 2;
+              int pos = idx / 2;
               ParamContext tree = ctx.param(pos);
               return IArgument.of(
                   getContext().parseVariableName(ObjectUtils.notNull(tree.eqname().getText())),

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/AnonymousFunctionCallTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/AnonymousFunctionCallTest.java
@@ -7,9 +7,12 @@ package gov.nist.secauto.metaschema.core.metapath.cst;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.qname;
 import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
 import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
 import gov.nist.secauto.metaschema.core.metapath.StaticContext;
+import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression.ResultType;
+import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
 
 import org.junit.jupiter.api.Test;
 
@@ -51,7 +54,15 @@ class AnonymousFunctionCallTest {
 
   @Test
   void testMultipleParameters() {
-    // FIXME: Add test for function with multiple parameters
+	    StaticContext staticContext = StaticContext.builder()
+	            .namespace("ex", NS)
+	            .build();
+	    DynamicContext dynamicContext = new DynamicContext(staticContext);
+	    String metapath = "function ($argument1 as meta:string, $argument2 as meta:string) as meta:string { $argument2 }";
+	    dynamicContext.bindVariableValue(qname(NS, "boom"), 
+	    		IMetapathExpression.compile(metapath, staticContext).evaluate(null, dynamicContext));    
+	    String result = IMetapathExpression.compile("$ex:boom('a', 'b')", staticContext).evaluateAs(null, ResultType.STRING , dynamicContext);
+	    assertEquals(result, "b");
   }
 
   @Test


### PR DESCRIPTION
# Committer Notes

Fixes #320.


### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them? Yes, see issue for details
- [x] Have you written new tests for your core changes, as applicable?
- ~Have you included examples of how to use your new feature(s)?~ This is a bug fix, proper usage is addressed in unit tests.
- ~Have you updated all website and readme documentation affected by the changes you made?~ This is a bug fix to the internal implementation of a core processing feature of the parser, and Java docs as written stay the same unless instructed otherwise during PR review.
