### PR TITLE
Efficiently refresh resources changed in generation mojos

### DIFF
--- a/metaschema-maven-plugin/src/main/java/gov/nist/secauto/metaschema/maven/plugin/AbstractMetaschemaMojo.java
+++ b/metaschema-maven-plugin/src/main/java/gov/nist/secauto/metaschema/maven/plugin/AbstractMetaschemaMojo.java
@@ -481,6 +481,97 @@ public abstract class AbstractMetaschemaMojo
     }
   }
 
+  @SuppressWarnings("PMD.AvoidCatchingGenericException")
+  @Override
+  public void execute() throws MojoExecutionException {
+    File staleFile = getStaleFile();
+    try {
+      staleFile = ObjectUtils.notNull(staleFile.getCanonicalFile());
+    } catch (IOException ex) {
+      if (getLog().isWarnEnabled()) {
+        getLog().warn("Unable to resolve canonical path to stale file. Treating it as not existing.", ex);
+      }
+    }
+
+    boolean generate;
+    if (shouldExecutionBeSkipped()) {
+      if (getLog().isDebugEnabled()) {
+        getLog().debug(String.format("Generation is configured to be skipped. Skipping."));
+      }
+      generate = false;
+    } else if (staleFile.exists()) {
+      generate = isGenerationRequired();
+    } else {
+      if (getLog().isInfoEnabled()) {
+        getLog().info(String.format("Stale file '%s' doesn't exist! Generation is required.", staleFile.getPath()));
+      }
+      generate = true;
+    }
+
+    if (generate) {
+
+      List<File> generatedFiles;
+      try {
+        generatedFiles = performGeneration();
+      } finally {
+        // ensure the stale file is created to ensure that regeneration is only
+        // performed when a
+        // change is made
+        createStaleFile(staleFile);
+      }
+
+      if (getLog().isInfoEnabled()) {
+        getLog().info(String.format("Generated %d files.", generatedFiles.size()));
+      }
+
+      // for m2e
+      for (File file : generatedFiles) {
+        getBuildContext().refresh(file);
+      }
+    }
+  }
+
+  @SuppressWarnings({ "PMD.AvoidCatchingGenericException", "PMD.ExceptionAsFlowControl" })
+  @NonNull
+  private List<File> performGeneration() throws MojoExecutionException {
+    File outputDir = getOutputDirectory();
+    if (getLog().isDebugEnabled()) {
+      getLog().debug(String.format("Using outputDirectory: %s", outputDir.getPath()));
+    }
+
+    if (!outputDir.exists() && !outputDir.mkdirs()) {
+      throw new MojoExecutionException("Unable to create output directory: " + outputDir);
+    }
+
+    IBindingContext bindingContext;
+    try {
+      bindingContext = newBindingContext();
+    } catch (MetaschemaException | IOException ex) {
+      throw new MojoExecutionException("Failed to create the binding context", ex);
+    }
+
+    // generate Java sources based on provided metaschema sources
+    Set<IModule> modules;
+    try {
+      modules = getModulesToGenerateFor(bindingContext);
+    } catch (Exception ex) {
+      throw new MojoExecutionException("Loading of metaschema modules failed", ex);
+    }
+
+    return generate(modules);
+  }
+
+  /**
+   * Perform the generation operation.
+   *
+   * @return the files generated during the operation
+   *
+   * @throws MojoExecutionException
+   *           if an error occurred while performing the generation operation
+   */
+  @NonNull
+  protected abstract List<File> generate(@NonNull Set<IModule> modules) throws MojoExecutionException;
+
   protected final class LoggingValidationHandler
       extends AbstractValidationResultProcessor {
 

--- a/metaschema-maven-plugin/src/main/java/gov/nist/secauto/metaschema/maven/plugin/GenerateSchemaMojo.java
+++ b/metaschema-maven-plugin/src/main/java/gov/nist/secauto/metaschema/maven/plugin/GenerateSchemaMojo.java
@@ -9,9 +9,8 @@ import gov.nist.secauto.metaschema.core.configuration.DefaultConfiguration;
 import gov.nist.secauto.metaschema.core.configuration.IConfiguration;
 import gov.nist.secauto.metaschema.core.configuration.IMutableConfiguration;
 import gov.nist.secauto.metaschema.core.model.IModule;
-import gov.nist.secauto.metaschema.core.model.MetaschemaException;
+import gov.nist.secauto.metaschema.core.util.CollectionUtil;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
-import gov.nist.secauto.metaschema.databind.IBindingContext;
 import gov.nist.secauto.metaschema.schemagen.ISchemaGenerator;
 import gov.nist.secauto.metaschema.schemagen.SchemaGenerationFeature;
 import gov.nist.secauto.metaschema.schemagen.json.JsonSchemaGenerator;
@@ -30,6 +29,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.EnumSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -131,7 +131,9 @@ public class GenerateSchemaMojo
    * @throws MojoExecutionException
    *           if an error occurred during generation
    */
-  protected void generate(@NonNull Set<IModule> modules) throws MojoExecutionException {
+  @Override
+  @NonNull
+  protected List<File> generate(@NonNull Set<IModule> modules) throws MojoExecutionException {
     IMutableConfiguration<SchemaGenerationFeature<?>> schemaGenerationConfig
         = new DefaultConfiguration<>();
 
@@ -167,6 +169,7 @@ public class GenerateSchemaMojo
     }
 
     Path outputDirectory = ObjectUtils.notNull(getOutputDirectory().toPath());
+    List<File> generatedSchemas = new LinkedList<>();
     for (IModule module : modules) {
       if (getLog().isInfoEnabled()) {
         getLog().info(String.format("Processing metaschema: %s", module.getLocation()));
@@ -174,12 +177,14 @@ public class GenerateSchemaMojo
       if (module.getExportedRootAssemblyDefinitions().isEmpty()) {
         continue;
       }
-      generateSchemas(module, schemaGenerationConfig, outputDirectory, schemaFormats);
+      generatedSchemas.addAll(generateSchemas(module, schemaGenerationConfig, outputDirectory, schemaFormats));
     }
+    return CollectionUtil.unmodifiableList(generatedSchemas);
   }
 
   @SuppressWarnings("PMD.AvoidCatchingGenericException")
-  private static void generateSchemas(
+  @NonNull
+  private List<File> generateSchemas(
       @NonNull IModule module,
       @NonNull IConfiguration<SchemaGenerationFeature<?>> schemaGenerationConfig,
       @NonNull Path outputDirectory,
@@ -187,11 +192,13 @@ public class GenerateSchemaMojo
 
     String shortName = module.getShortName();
 
+    List<File> generatedSchemas = new LinkedList<>();
     if (schemaFormats.contains(SchemaFormat.XSD)) {
       try { // XML Schema
         String filename = String.format("%s_schema.xsd", shortName);
         Path xmlSchema = ObjectUtils.notNull(outputDirectory.resolve(filename));
         generateSchema(module, schemaGenerationConfig, xmlSchema, XML_SCHEMA_GENERATOR);
+        generatedSchemas.add(xmlSchema.toFile());
       } catch (Exception ex) {
         throw new MojoExecutionException("Unable to generate XML schema.", ex);
       }
@@ -200,12 +207,14 @@ public class GenerateSchemaMojo
     if (schemaFormats.contains(SchemaFormat.JSON_SCHEMA)) {
       try { // JSON Schema
         String filename = String.format("%s_schema.json", shortName);
-        Path xmlSchema = ObjectUtils.notNull(outputDirectory.resolve(filename));
-        generateSchema(module, schemaGenerationConfig, xmlSchema, JSON_SCHEMA_GENERATOR);
+        Path jsonSchema = ObjectUtils.notNull(outputDirectory.resolve(filename));
+        generateSchema(module, schemaGenerationConfig, jsonSchema, JSON_SCHEMA_GENERATOR);
+        generatedSchemas.add(jsonSchema.toFile());
       } catch (Exception ex) {
         throw new MojoExecutionException("Unable to generate JSON schema.", ex);
       }
     }
+    return CollectionUtil.unmodifiableList(generatedSchemas);
   }
 
   private static void generateSchema(
@@ -222,76 +231,5 @@ public class GenerateSchemaMojo
         StandardOpenOption.TRUNCATE_EXISTING))) {
       generator.generateFromModule(module, writer, schemaGenerationConfig);
     }
-  }
-
-  @Override
-  public void execute() throws MojoExecutionException {
-    File staleFile = getStaleFile();
-    try {
-      staleFile = ObjectUtils.notNull(staleFile.getCanonicalFile());
-    } catch (IOException ex) {
-      if (getLog().isWarnEnabled()) {
-        getLog().warn("Unable to resolve canonical path to stale file. Treating it as not existing.", ex);
-      }
-    }
-
-    boolean generate;
-    if (shouldExecutionBeSkipped()) {
-      if (getLog().isDebugEnabled()) {
-        getLog().debug(String.format("Schema generation is configured to be skipped. Skipping."));
-      }
-      generate = false;
-    } else if (staleFile.exists()) {
-      generate = isGenerationRequired();
-    } else {
-      if (getLog().isInfoEnabled()) {
-        getLog().info(String.format("Stale file '%s' doesn't exist! Generating source files.", staleFile.getPath()));
-      }
-      generate = true;
-    }
-
-    if (generate) {
-      performGeneration();
-      createStaleFile(staleFile);
-
-      // for m2e
-      getBuildContext().refresh(getOutputDirectory());
-    }
-    // // add generated sources to Maven
-    // try {
-    // getMavenProject()..addCompileSourceRoot(getOutputDirectory().getCanonicalFile().getPath());
-    // } catch (IOException ex) {
-    // throw new MojoExecutionException("Unable to add output directory to maven
-    // sources.", ex);
-    // }
-  }
-
-  @SuppressWarnings("PMD.AvoidCatchingGenericException")
-  private void performGeneration() throws MojoExecutionException {
-    File outputDir = getOutputDirectory();
-    if (getLog().isDebugEnabled()) {
-      getLog().debug(String.format("Using outputDirectory: %s", outputDir.getPath()));
-    }
-
-    if (!outputDir.exists() && !outputDir.mkdirs()) {
-      throw new MojoExecutionException("Unable to create output directory: " + outputDir);
-    }
-
-    IBindingContext bindingContext;
-    try {
-      bindingContext = newBindingContext();
-    } catch (MetaschemaException | IOException ex) {
-      throw new MojoExecutionException("Failed to create the binding context", ex);
-    }
-
-    // generate schemas based on provided metaschema sources
-    Set<IModule> modules;
-    try {
-      modules = getModulesToGenerateFor(bindingContext);
-    } catch (Exception ex) {
-      throw new MojoExecutionException("Loading of metaschema modules failed", ex);
-    }
-
-    generate(modules);
   }
 }

--- a/metaschema-maven-plugin/src/main/java/gov/nist/secauto/metaschema/maven/plugin/GenerateSourcesMojo.java
+++ b/metaschema-maven-plugin/src/main/java/gov/nist/secauto/metaschema/maven/plugin/GenerateSourcesMojo.java
@@ -6,9 +6,8 @@
 package gov.nist.secauto.metaschema.maven.plugin;
 
 import gov.nist.secauto.metaschema.core.model.IModule;
-import gov.nist.secauto.metaschema.core.model.MetaschemaException;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
-import gov.nist.secauto.metaschema.databind.IBindingContext;
+import gov.nist.secauto.metaschema.databind.codegen.IProduction;
 import gov.nist.secauto.metaschema.databind.codegen.JavaGenerator;
 import gov.nist.secauto.metaschema.databind.codegen.config.DefaultBindingConfiguration;
 
@@ -23,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -78,7 +78,9 @@ public class GenerateSourcesMojo
    * @throws MojoExecutionException
    *           if an error occurred while generating sources
    */
-  protected void generate(@NonNull Set<IModule> modules) throws MojoExecutionException {
+  @Override
+  @NonNull
+  protected List<File> generate(@NonNull Set<IModule> modules) throws MojoExecutionException {
     DefaultBindingConfiguration bindingConfiguration = new DefaultBindingConfiguration();
     for (File config : getConfigs()) {
       try {
@@ -92,50 +94,17 @@ public class GenerateSourcesMojo
       }
     }
 
+    IProduction production;
     try {
       if (getLog().isInfoEnabled()) {
         getLog().info("Generating Java classes in: " + getOutputDirectory().getPath());
       }
-      JavaGenerator.generate(modules, ObjectUtils.notNull(getOutputDirectory().toPath()),
+      production = JavaGenerator.generate(
+          modules,
+          ObjectUtils.notNull(getOutputDirectory().toPath()),
           bindingConfiguration);
     } catch (IOException ex) {
       throw new MojoExecutionException("Creation of Java classes failed.", ex);
-    }
-  }
-
-  @SuppressWarnings("PMD.AvoidCatchingGenericException")
-  @Override
-  public void execute() throws MojoExecutionException {
-    File staleFile = getStaleFile();
-    try {
-      staleFile = ObjectUtils.notNull(staleFile.getCanonicalFile());
-    } catch (IOException ex) {
-      if (getLog().isWarnEnabled()) {
-        getLog().warn("Unable to resolve canonical path to stale file. Treating it as not existing.", ex);
-      }
-    }
-
-    boolean generate;
-    if (shouldExecutionBeSkipped()) {
-      if (getLog().isDebugEnabled()) {
-        getLog().debug(String.format("Source file generation is configured to be skipped. Skipping."));
-      }
-      generate = false;
-    } else if (staleFile.exists()) {
-      generate = isGenerationRequired();
-    } else {
-      if (getLog().isInfoEnabled()) {
-        getLog().info(String.format("Stale file '%s' doesn't exist! Generating source files.", staleFile.getPath()));
-      }
-      generate = true;
-    }
-
-    if (generate) {
-      performGeneration();
-      createStaleFile(staleFile);
-
-      // for m2e
-      getBuildContext().refresh(getOutputDirectory());
     }
 
     // add generated sources to Maven
@@ -144,35 +113,9 @@ public class GenerateSourcesMojo
     } catch (IOException ex) {
       throw new MojoExecutionException("Unable to add output directory to maven sources.", ex);
     }
+
+    return ObjectUtils.notNull(production.getGeneratedClasses()
+        .map(gen -> gen.getClassFile().toFile())
+        .collect(Collectors.toUnmodifiableList()));
   }
-
-  @SuppressWarnings({ "PMD.AvoidCatchingGenericException", "PMD.ExceptionAsFlowControl" })
-  private void performGeneration() throws MojoExecutionException {
-    File outputDir = getOutputDirectory();
-    if (getLog().isDebugEnabled()) {
-      getLog().debug(String.format("Using outputDirectory: %s", outputDir.getPath()));
-    }
-
-    if (!outputDir.exists() && !outputDir.mkdirs()) {
-      throw new MojoExecutionException("Unable to create output directory: " + outputDir);
-    }
-
-    IBindingContext bindingContext;
-    try {
-      bindingContext = newBindingContext();
-    } catch (MetaschemaException | IOException ex) {
-      throw new MojoExecutionException("Failed to create the binding context", ex);
-    }
-
-    // generate Java sources based on provided metaschema sources
-    Set<IModule> modules;
-    try {
-      modules = getModulesToGenerateFor(bindingContext);
-    } catch (Exception ex) {
-      throw new MojoExecutionException("Loading of metaschema modules failed", ex);
-    }
-
-    generate(modules);
-  }
-
 }


### PR DESCRIPTION
# Committer Notes

Refactored Maven generation mojos to more efficiently handle refreshing the IDE (through m2e) for resources that changed. Also ensured that the stale file is created, even when a processing error occurs. This may fix some runaway problems in Eclipse.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
