### PR TITLE
Add op:dateTime-equal to Metapath default function library

### DIFF
--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/DefaultFunctionLibrary.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/DefaultFunctionLibrary.java
@@ -32,6 +32,8 @@ public class DefaultFunctionLibrary
     // https://www.w3.org/TR/xpath-functions-31/#func-adjust-dateTime-to-timezone
     // https://www.w3.org/TR/xpath-functions-31/#func-adjust-date-to-timezone
     // https://www.w3.org/TR/xpath-functions-31/#func-adjust-time-to-timezone
+    // https://www.w3.org/TR/xpath-functions-31/#func-dateTime-equal
+    registerFunction(FnDateTimeEqual.SIGNATURE);
     // https://www.w3.org/TR/xpath-functions-31/#func-avg
     registerFunction(FnAvg.SIGNATURE);
     // https://www.w3.org/TR/xpath-functions-31/#func-base-uri

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDateTimeEqual.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDateTimeEqual.java
@@ -1,0 +1,78 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.function.library;
+
+import java.util.List;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
+import gov.nist.secauto.metaschema.core.metapath.MetapathConstants;
+import gov.nist.secauto.metaschema.core.metapath.function.FunctionUtils;
+import gov.nist.secauto.metaschema.core.metapath.function.IArgument;
+import gov.nist.secauto.metaschema.core.metapath.function.IFunction;
+import gov.nist.secauto.metaschema.core.metapath.function.impl.OperationFunctions;
+import gov.nist.secauto.metaschema.core.metapath.item.IItem;
+import gov.nist.secauto.metaschema.core.metapath.item.ISequence;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IBooleanItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IDateTimeItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IDateTimeWithTimeZoneItem;
+
+/**
+ * Implements the XPath 3.1 <a href=
+ * "https://www.w3.org/TR/xpath-functions-31/#func-current-date">fn:current-date</a>
+ * function.
+ */
+public final class FnDateTimeEqual {
+  @NonNull
+  static final IFunction SIGNATURE = IFunction.builder()
+      .name("dateTime-equal")
+      .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
+      .deterministic()
+      .contextDependent()
+      .focusIndependent()
+      .argument(IArgument.builder()
+              .name("arg1")
+              .type(IDateTimeItem.type())
+              .one()
+              .build())
+      .argument(IArgument.builder()
+          .name("arg2")
+          .type(IDateTimeItem.type())
+          .one()
+          .build())      
+      .returnType(IBooleanItem.type())
+      .returnOne()
+      .functionHandler(FnDateTimeEqual::execute)
+      .build();
+
+  private FnDateTimeEqual() {
+    // disable construction
+  }
+
+  @SuppressWarnings("unused")
+  @NonNull
+  private static ISequence<IBooleanItem> execute(@NonNull IFunction function,
+      @NonNull List<ISequence<?>> arguments,
+      @NonNull DynamicContext dynamicContext,
+      IItem focus) {
+    IDateTimeItem arg1 = FunctionUtils.asTypeOrNull(arguments.get(0).getFirstItem(true));
+    IDateTimeItem arg2 = FunctionUtils.asTypeOrNull(arguments.get(1).getFirstItem(true));
+    return ISequence.of(fnDateTimeEqual(dynamicContext, arg1, arg2));
+  }
+
+  /**
+   * Implements <a href=
+   * "https://www.w3.org/TR/xpath-functions-31/#func-current-date">fn:current-date</a>.
+   *
+   * @param dynamicContext
+   *          the dynamic evaluation context
+   * @return the current date
+   */
+  @NonNull
+  public static IBooleanItem fnDateTimeEqual(@NonNull DynamicContext dynamicContext, IDateTimeItem arg1, IDateTimeItem arg2) {
+    return OperationFunctions.opDateTimeEqual(arg1, arg2);
+  }
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDateTimeEqualTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDateTimeEqualTest.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.function.library;
+
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.bool;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IBooleanItem;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+class FnDateTimeEqualTest
+    extends FunctionTestBase {
+  static Stream<Arguments> provideValues() {
+    return Stream.of(
+        Arguments.of(bool(true), "dateTime-equal(meta:date-time('2002-04-02T12:00:00-01:00'), meta:date-time('2002-04-02T17:00:00+04:00'))"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideValues")
+  void test(@NonNull IBooleanItem expected, @NonNull String metapath) {
+    IBooleanItem result = IMetapathExpression.compile(metapath)
+        .evaluateAs(null, IMetapathExpression.ResultType.ITEM, newDynamicContext());
+    assertEquals(expected, result);
+  }
+}


### PR DESCRIPTION
# Committer Notes

Add op:dateTime-equal to Metapath default function library as part of 367.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- ~Have you included examples of how to use your new feature(s)?~
- ~Have you updated all website and readme documentation affected by the changes you made?~
