### PR TITLE
date, date/time, and time extraction functions part 1

### DIFF
--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/DefaultFunctionLibrary.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/DefaultFunctionLibrary.java
@@ -205,8 +205,11 @@ public class DefaultFunctionLibrary
     // https://www.w3.org/TR/xpath-functions-31/#func-tail
     registerFunction(FnTail.SIGNATURE);
     // https://www.w3.org/TR/xpath-functions-31/#func-timezone-from-date
+    registerFunction(FnTimezoneFromDate.SIGNATURE);
     // https://www.w3.org/TR/xpath-functions-31/#func-timezone-from-dateTime
+    registerFunction(FnTimezoneFromDateTime.SIGNATURE);
     // https://www.w3.org/TR/xpath-functions-31/#func-timezone-from-time
+    registerFunction(FnTimezoneFromTime.SIGNATURE);
     // https://www.w3.org/TR/xpath-functions-31/#func-tokenize
     registerFunction(FnTokenize.SIGNATURE_ONE_ARG);
     registerFunction(FnTokenize.SIGNATURE_TWO_ARG);

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTimezoneFromDate.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTimezoneFromDate.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.function.library;
+
+import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
+import gov.nist.secauto.metaschema.core.metapath.MetapathConstants;
+import gov.nist.secauto.metaschema.core.metapath.function.FunctionUtils;
+import gov.nist.secauto.metaschema.core.metapath.function.IArgument;
+import gov.nist.secauto.metaschema.core.metapath.function.IFunction;
+import gov.nist.secauto.metaschema.core.metapath.item.IItem;
+import gov.nist.secauto.metaschema.core.metapath.item.ISequence;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IDateItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IDayTimeDurationItem;
+import gov.nist.secauto.metaschema.core.util.ObjectUtils;
+
+import java.util.List;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Implements the XPath 3.1 <a href=
+ * "https://www.w3.org/TR/xpath-functions-31/#func-timezone-from-date">fn:timezone-from-date</a>
+ * function.
+ */
+public final class FnTimezoneFromDate {
+  private static final String NAME = "timezone-from-date";
+  @NonNull
+  static final IFunction SIGNATURE = IFunction.builder()
+      .name(NAME)
+      .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
+      .deterministic()
+      .contextDependent()
+      .focusIndependent()
+      .argument(IArgument.builder()
+          .name("arg")
+          .zeroOrOne()
+          .type(IDateItem.type())
+          .build())
+      .returnType(IDayTimeDurationItem.type())
+      .returnZeroOrOne()
+      .functionHandler(FnTimezoneFromDate::execute)
+      .build();
+
+  private FnTimezoneFromDate() {
+    // disable construction
+  }
+
+  @SuppressWarnings("unused")
+  @NonNull
+  private static ISequence<IDayTimeDurationItem> execute(@NonNull IFunction function,
+      @NonNull List<ISequence<?>> arguments,
+      @NonNull DynamicContext dynamicContext,
+      IItem focus) {
+    IDateItem arg = FunctionUtils.asTypeOrNull(ObjectUtils.requireNonNull(arguments.get(0).getFirstItem(true)));
+
+    return arg == null || !arg.hasTimezone()
+        ? ISequence.empty()
+        : ISequence.of(arg.getOffset());
+  }
+}

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTimezoneFromDateTime.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTimezoneFromDateTime.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.function.library;
+
+import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
+import gov.nist.secauto.metaschema.core.metapath.MetapathConstants;
+import gov.nist.secauto.metaschema.core.metapath.function.FunctionUtils;
+import gov.nist.secauto.metaschema.core.metapath.function.IArgument;
+import gov.nist.secauto.metaschema.core.metapath.function.IFunction;
+import gov.nist.secauto.metaschema.core.metapath.item.IItem;
+import gov.nist.secauto.metaschema.core.metapath.item.ISequence;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IDateTimeItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IDayTimeDurationItem;
+import gov.nist.secauto.metaschema.core.util.ObjectUtils;
+
+import java.util.List;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Implements the XPath 3.1 <a href=
+ * "https://www.w3.org/TR/xpath-functions-31/#func-timezone-from-dateTime">fn:timezone-from-dateTime</a>
+ * function.
+ */
+public final class FnTimezoneFromDateTime {
+  private static final String NAME = "timezone-from-dateTime";
+  @NonNull
+  static final IFunction SIGNATURE = IFunction.builder()
+      .name(NAME)
+      .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
+      .deterministic()
+      .contextDependent()
+      .focusIndependent()
+      .argument(IArgument.builder()
+          .name("arg")
+          .zeroOrOne()
+          .type(IDateTimeItem.type())
+          .build())
+      .returnType(IDayTimeDurationItem.type())
+      .returnZeroOrOne()
+      .functionHandler(FnTimezoneFromDateTime::execute)
+      .build();
+
+  private FnTimezoneFromDateTime() {
+    // disable construction
+  }
+
+  @SuppressWarnings("unused")
+  @NonNull
+  private static ISequence<IDayTimeDurationItem> execute(@NonNull IFunction function,
+      @NonNull List<ISequence<?>> arguments,
+      @NonNull DynamicContext dynamicContext,
+      IItem focus) {
+    IDateTimeItem arg = FunctionUtils.asTypeOrNull(ObjectUtils.requireNonNull(arguments.get(0).getFirstItem(true)));
+
+    return arg == null || !arg.hasTimezone()
+        ? ISequence.empty()
+        : ISequence.of(arg.getOffset());
+  }
+}

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTimezoneFromTime.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTimezoneFromTime.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.function.library;
+
+import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
+import gov.nist.secauto.metaschema.core.metapath.MetapathConstants;
+import gov.nist.secauto.metaschema.core.metapath.function.FunctionUtils;
+import gov.nist.secauto.metaschema.core.metapath.function.IArgument;
+import gov.nist.secauto.metaschema.core.metapath.function.IFunction;
+import gov.nist.secauto.metaschema.core.metapath.item.IItem;
+import gov.nist.secauto.metaschema.core.metapath.item.ISequence;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IDayTimeDurationItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.ITimeItem;
+import gov.nist.secauto.metaschema.core.util.ObjectUtils;
+
+import java.util.List;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Implements the XPath 3.1 <a href=
+ * "https://www.w3.org/TR/xpath-functions-31/#func-timezone-from-time">fn:timezone-from-time</a>
+ * function.
+ */
+public final class FnTimezoneFromTime {
+  private static final String NAME = "timezone-from-time";
+  @NonNull
+  static final IFunction SIGNATURE = IFunction.builder()
+      .name(NAME)
+      .namespace(MetapathConstants.NS_METAPATH_FUNCTIONS)
+      .deterministic()
+      .contextDependent()
+      .focusIndependent()
+      .argument(IArgument.builder()
+          .name("arg")
+          .zeroOrOne()
+          .type(ITimeItem.type())
+          .build())
+      .returnType(IDayTimeDurationItem.type())
+      .returnZeroOrOne()
+      .functionHandler(FnTimezoneFromTime::execute)
+      .build();
+
+  private FnTimezoneFromTime() {
+    // disable construction
+  }
+
+  @SuppressWarnings("unused")
+  @NonNull
+  private static ISequence<IDayTimeDurationItem> execute(@NonNull IFunction function,
+      @NonNull List<ISequence<?>> arguments,
+      @NonNull DynamicContext dynamicContext,
+      IItem focus) {
+    ITimeItem arg = FunctionUtils.asTypeOrNull(ObjectUtils.requireNonNull(arguments.get(0).getFirstItem(true)));
+
+    return arg == null || !arg.hasTimezone()
+        ? ISequence.empty()
+        : ISequence.of(arg.getOffset());
+  }
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTimezoneFromDateTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTimezoneFromDateTest.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.function.library;
+
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.dayTimeDuration;
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.sequence;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import gov.nist.secauto.metaschema.core.metapath.ExpressionTestBase;
+import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
+import gov.nist.secauto.metaschema.core.metapath.item.ISequence;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IDayTimeDurationItem;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+class FnTimezoneFromDateTest
+    extends ExpressionTestBase {
+  private static Stream<Arguments> provideValues() { // NOPMD - false positive
+    return Stream.of(
+        Arguments.of(
+            sequence(dayTimeDuration("-PT5H")),
+            "fn:timezone-from-date(meta:date('1999-05-31-05:00'))"),
+        Arguments.of(
+            sequence(dayTimeDuration("PT0S")),
+            "fn:timezone-from-date(meta:date('2000-06-12Z'))"),
+        Arguments.of(
+            sequence(),
+            "fn:timezone-from-date(meta:date('1999-05-31'))"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideValues")
+  void test(
+      @Nullable ISequence<IDayTimeDurationItem> expected,
+      @NonNull String metapath) {
+    ISequence<IDayTimeDurationItem> result = IMetapathExpression.compile(metapath)
+        .evaluate(null, newDynamicContext());
+    assertEquals(expected, result);
+  }
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTimezoneFromDateTimeTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTimezoneFromDateTimeTest.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.function.library;
+
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.dayTimeDuration;
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.sequence;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import gov.nist.secauto.metaschema.core.metapath.ExpressionTestBase;
+import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
+import gov.nist.secauto.metaschema.core.metapath.item.ISequence;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IDayTimeDurationItem;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+class FnTimezoneFromDateTimeTest
+    extends ExpressionTestBase {
+  private static Stream<Arguments> provideValues() { // NOPMD - false positive
+    return Stream.of(
+        Arguments.of(
+            sequence(dayTimeDuration("-PT5H")),
+            "fn:timezone-from-dateTime(meta:date-time('1999-05-31T13:20:00-05:00'))"),
+        Arguments.of(
+            sequence(dayTimeDuration("PT0S")),
+            "fn:timezone-from-dateTime(meta:date-time('2000-06-12T13:20:00Z'))"),
+        Arguments.of(
+            sequence(),
+            "fn:timezone-from-dateTime(meta:date-time('2004-08-27T00:00:00'))"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideValues")
+  void test(
+      @Nullable ISequence<IDayTimeDurationItem> expected,
+      @NonNull String metapath) {
+    ISequence<IDayTimeDurationItem> result = IMetapathExpression.compile(metapath)
+        .evaluate(null, newDynamicContext());
+    assertEquals(expected, result);
+  }
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTimezoneFromTimeTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTimezoneFromTimeTest.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.function.library;
+
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.dayTimeDuration;
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.sequence;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import gov.nist.secauto.metaschema.core.metapath.ExpressionTestBase;
+import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
+import gov.nist.secauto.metaschema.core.metapath.item.ISequence;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IDayTimeDurationItem;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+class FnTimezoneFromTimeTest
+    extends ExpressionTestBase {
+  private static Stream<Arguments> provideValues() { // NOPMD - false positive
+    return Stream.of(
+        Arguments.of(
+            sequence(dayTimeDuration("-PT5H")),
+            "fn:timezone-from-time(meta:time('13:20:00-05:00'))"),
+        Arguments.of(
+            sequence(),
+            "fn:timezone-from-time(meta:time('13:20:00'))"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideValues")
+  void test(
+      @Nullable ISequence<IDayTimeDurationItem> expected,
+      @NonNull String metapath) {
+    ISequence<IDayTimeDurationItem> result = IMetapathExpression.compile(metapath)
+        .evaluate(null, newDynamicContext());
+    assertEquals(expected, result);
+  }
+}


### PR DESCRIPTION
# Committer Notes

Added `timezone-from-date`, `timezone-from-dateTime`, and `timezone-from-time` Metapath functions and associated unit tests.

Partial work towards #284.

### All Submissions:

- [ ] Have you selected the correct base branch per [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) guidance?
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
