### PR TITLE
Add static methods for timezone accessor Metapath functions

### DIFF
--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTimezoneFromDate.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTimezoneFromDate.java
@@ -19,6 +19,7 @@ import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import java.util.List;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * Implements the XPath 3.1 <a href=
@@ -56,8 +57,22 @@ public final class FnTimezoneFromDate {
       IItem focus) {
     IDateItem arg = FunctionUtils.asTypeOrNull(ObjectUtils.requireNonNull(arguments.get(0).getFirstItem(true)));
 
-    return arg == null || !arg.hasTimezone()
+    return arg == null
         ? ISequence.empty()
-        : ISequence.of(arg.getOffset());
+        : ISequence.of(fnTimezoneFromDate(arg));
+  }
+
+  /**
+   * Implements <a href=
+   * "https://www.w3.org/TR/xpath-functions-31/#func-timezone-from-date">fn:timezone-from-date</a>.
+   *
+   * @param arg
+   *          the meta:date item from which to extract the timezone component
+   * @return the timezone component from the date or {@code null} if no timezone
+   *         is present
+   */
+  @Nullable
+  public static IDayTimeDurationItem fnTimezoneFromDate(@NonNull IDateItem arg) {
+    return arg.getOffset();
   }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTimezoneFromDateTime.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTimezoneFromDateTime.java
@@ -19,6 +19,7 @@ import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import java.util.List;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * Implements the XPath 3.1 <a href=
@@ -56,8 +57,23 @@ public final class FnTimezoneFromDateTime {
       IItem focus) {
     IDateTimeItem arg = FunctionUtils.asTypeOrNull(ObjectUtils.requireNonNull(arguments.get(0).getFirstItem(true)));
 
-    return arg == null || !arg.hasTimezone()
+    return arg == null
         ? ISequence.empty()
-        : ISequence.of(arg.getOffset());
+        : ISequence.of(fnTimezoneFromDate(arg));
   }
+
+  /**
+   * Implements <a href=
+   * "https://www.w3.org/TR/xpath-functions-31/#func-timezone-from-dateTime">fn:timezone-from-dateTime</a>.
+   *
+   * @param arg
+   *          the meta:date-time item from which to extract the timezone component
+   * @return the timezone component from the date/time or {@code null} if no
+   *         timezone is present
+   */
+  @Nullable
+  public static IDayTimeDurationItem fnTimezoneFromDate(@NonNull IDateTimeItem arg) {
+    return arg.getOffset();
+  }
+
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTimezoneFromDateTime.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTimezoneFromDateTime.java
@@ -59,7 +59,7 @@ public final class FnTimezoneFromDateTime {
 
     return arg == null
         ? ISequence.empty()
-        : ISequence.of(fnTimezoneFromDate(arg));
+        : ISequence.of(fnTimezoneFromDateTime(arg));
   }
 
   /**
@@ -72,7 +72,7 @@ public final class FnTimezoneFromDateTime {
    *         timezone is present
    */
   @Nullable
-  public static IDayTimeDurationItem fnTimezoneFromDate(@NonNull IDateTimeItem arg) {
+  public static IDayTimeDurationItem fnTimezoneFromDateTime(@NonNull IDateTimeItem arg) {
     return arg.getOffset();
   }
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTimezoneFromTime.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTimezoneFromTime.java
@@ -59,7 +59,7 @@ public final class FnTimezoneFromTime {
 
     return arg == null
         ? ISequence.empty()
-        : ISequence.of(fnTimezoneFromDate(arg));
+        : ISequence.of(fnTimezoneFromTime(arg));
   }
 
   /**
@@ -72,7 +72,7 @@ public final class FnTimezoneFromTime {
    *         timezone is present
    */
   @Nullable
-  public static IDayTimeDurationItem fnTimezoneFromDate(@NonNull ITimeItem arg) {
+  public static IDayTimeDurationItem fnTimezoneFromTime(@NonNull ITimeItem arg) {
     return arg.getOffset();
   }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTimezoneFromTime.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTimezoneFromTime.java
@@ -19,6 +19,7 @@ import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import java.util.List;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * Implements the XPath 3.1 <a href=
@@ -56,8 +57,22 @@ public final class FnTimezoneFromTime {
       IItem focus) {
     ITimeItem arg = FunctionUtils.asTypeOrNull(ObjectUtils.requireNonNull(arguments.get(0).getFirstItem(true)));
 
-    return arg == null || !arg.hasTimezone()
+    return arg == null
         ? ISequence.empty()
-        : ISequence.of(arg.getOffset());
+        : ISequence.of(fnTimezoneFromDate(arg));
+  }
+
+  /**
+   * Implements <a href=
+   * "https://www.w3.org/TR/xpath-functions-31/#func-timezone-from-time">fn:timezone-from-time</a>.
+   *
+   * @param arg
+   *          the meta:time item from which to extract the timezone component
+   * @return the timezone component from the date/time or {@code null} if no
+   *         timezone is present
+   */
+  @Nullable
+  public static IDayTimeDurationItem fnTimezoneFromDate(@NonNull ITimeItem arg) {
+    return arg.getOffset();
   }
 }


### PR DESCRIPTION
# Committer Notes

Added static methods to make the timezone accessors more consistent with the functions in #275.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all website and readme documentation affected by the changes you made?
