### PR TITLE
Handle let statements in the XmlMetaConstrainLoader

### DIFF
--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/XmlMetaConstraintLoader.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/XmlMetaConstraintLoader.java
@@ -193,6 +193,7 @@ public class XmlMetaConstraintLoader
      *          the definition to apply the constraints to.
      */
     protected void applyTo(@NonNull IDefinition definition) {
+      getLetExpressions().values().forEach(definition::addLetExpression);
       getAllowedValuesConstraints().forEach(definition::addConstraint);
       getMatchesConstraints().forEach(definition::addConstraint);
       getIndexHasKeyConstraints().forEach(definition::addConstraint);


### PR DESCRIPTION
# Committer Notes

Added missing support for processing let statements in the XMLMetaConstraintLoader.

This is part of a solution for metaschema-framework/liboscal-java#112.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all website and readme documentation affected by the changes you made?
