### PR TITLE
Fix JSON schema generation missing array items

### DIFF
--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/DataTypeService.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/DataTypeService.java
@@ -193,6 +193,8 @@ public final class DataTypeService {
   /**
    * Lookup a specific {@link IAtomicOrUnionType} by its item class.
    *
+   * @param <T>
+   *          the Java type of the atomic item handled by this class
    * @param clazz
    *          the adapter class to get the instance for
    * @return the data type or {@code null} if the data type is unknown to the type

--- a/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/AbstractJsonProperty.java
+++ b/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/AbstractJsonProperty.java
@@ -47,6 +47,7 @@ public abstract class AbstractJsonProperty<I extends IInstance>
     generateMetadata(contextObj);
 
     generateBody(contextObj, state);
+    assert !contextObj.isEmpty();
 
     String name = getName();
     properties.addProperty(name, contextObj);

--- a/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/ChoiceGroupInstanceJsonProperty.java
+++ b/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/ChoiceGroupInstanceJsonProperty.java
@@ -51,6 +51,7 @@ public class ChoiceGroupInstanceJsonProperty
       ObjectNode obj,
       IJsonGenerationState state) {
     getCollectionBuilder().build(obj, state);
+    assert !obj.isEmpty();
   }
 
   @Override

--- a/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/FlagInstanceJsonProperty.java
+++ b/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/FlagInstanceJsonProperty.java
@@ -65,5 +65,6 @@ public class FlagInstanceJsonProperty
     IFlagDefinition definition = instance.getDefinition();
     IDataTypeJsonSchema dataTypeSchema = state.getDataTypeSchemaForDefinition(definition);
     dataTypeSchema.generateSchemaOrRef(obj, state);
+    assert !obj.isEmpty();
   }
 }

--- a/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/NamedModelInstanceJsonProperty.java
+++ b/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/NamedModelInstanceJsonProperty.java
@@ -56,6 +56,7 @@ public class NamedModelInstanceJsonProperty
     getCollectionBuilder().build(
         obj,
         state);
+    assert !obj.isEmpty();
   }
 
   @Override

--- a/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/builder/AbstractCollectionBuilder.java
+++ b/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/builder/AbstractCollectionBuilder.java
@@ -8,6 +8,7 @@ package gov.nist.secauto.metaschema.schemagen.json.impl.builder;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import gov.nist.secauto.metaschema.core.model.IAssemblyDefinition;
 import gov.nist.secauto.metaschema.core.model.IFieldDefinition;
 import gov.nist.secauto.metaschema.core.model.IFlagDefinition;
 import gov.nist.secauto.metaschema.core.model.IFlagInstance;
@@ -205,7 +206,7 @@ public abstract class AbstractCollectionBuilder<T extends AbstractCollectionBuil
         --flagCount;
       }
 
-      if (flagCount > 0) {
+      if (flagCount > 0 || definition instanceof IAssemblyDefinition) {
         IDefinitionJsonSchema<IModelDefinition> schema = getJsonSchema(state);
         schema.generateSchemaOrRef(object, state);
       } else if (definition instanceof IFieldDefinition) {

--- a/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/builder/ArrayBuilder.java
+++ b/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/builder/ArrayBuilder.java
@@ -22,6 +22,7 @@ public class ArrayBuilder
     if (!getTypes().isEmpty()) {
       ObjectNode items = ObjectUtils.notNull(object.putObject("items"));
       buildInternal(items, state);
+      assert !items.isEmpty();
     }
 
     if (getMinOccurrence() > 1) {


### PR DESCRIPTION
# Committer Notes

Fixed a bug causing some array schemas to not include a reference to their definition.

Depends on metaschema-framework/metaschema#82.

### All Submissions:

- [ ] Have you selected the correct base branch per [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) guidance?
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
