### PR TITLE
Filter previously applied constraints at the context level

### DIFF
--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/ExternalConstraintsModulePostProcessor.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/ExternalConstraintsModulePostProcessor.java
@@ -7,7 +7,6 @@ package gov.nist.secauto.metaschema.core.model.constraint;
 
 import gov.nist.secauto.metaschema.core.metapath.item.node.IModuleNodeItem;
 import gov.nist.secauto.metaschema.core.metapath.item.node.INodeItemFactory;
-import gov.nist.secauto.metaschema.core.model.IDefinition;
 import gov.nist.secauto.metaschema.core.model.IModule;
 import gov.nist.secauto.metaschema.core.model.IModuleLoader;
 import gov.nist.secauto.metaschema.core.model.constraint.impl.ConstraintComposingVisitor;
@@ -15,9 +14,7 @@ import gov.nist.secauto.metaschema.core.model.xml.ModuleLoader;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -32,8 +29,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public class ExternalConstraintsModulePostProcessor implements IModuleLoader.IModulePostProcessor {
   @NonNull
   private final List<IConstraintSet> registeredConstraintSets;
-  @NonNull
-  private final Set<IDefinition> previouslyTargetedDefinitions;
 
   /**
    * Create a new post processor.
@@ -48,7 +43,6 @@ public class ExternalConstraintsModulePostProcessor implements IModuleLoader.IMo
             set.getImportedConstraintSets().stream()))
         .distinct()
         .collect(Collectors.toUnmodifiableList()));
-    this.previouslyTargetedDefinitions = new HashSet<>();
   }
 
   /**
@@ -67,8 +61,7 @@ public class ExternalConstraintsModulePostProcessor implements IModuleLoader.IMo
 
     for (IConstraintSet set : getRegisteredConstraintSets()) {
       assert set != null;
-      previouslyTargetedDefinitions.addAll(
-          set.applyConstraintsForModule(moduleItem, previouslyTargetedDefinitions, visitor));
+      set.applyConstraintsForModule(moduleItem, visitor);
     }
   }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/IConstraintSet.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/IConstraintSet.java
@@ -6,12 +6,10 @@
 package gov.nist.secauto.metaschema.core.model.constraint;
 
 import gov.nist.secauto.metaschema.core.metapath.item.node.IModuleNodeItem;
-import gov.nist.secauto.metaschema.core.model.IDefinition;
 import gov.nist.secauto.metaschema.core.model.IModelElementVisitor;
 import gov.nist.secauto.metaschema.core.model.ISource;
 
 import java.util.Collection;
-import java.util.Set;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -46,15 +44,10 @@ public interface IConstraintSet {
    *
    * @param moduleItem
    *          the module node item to apply applicable constraints to
-   * @param previouslyTargetedDefinitions
-   *          the set of definitions previously targeted for this constraint set
    * @param visitor
    *          the visitor used to apply constraints to target definitions
-   * @return the set of definitions targeted
    */
-  @NonNull
-  Set<IDefinition> applyConstraintsForModule(
+  void applyConstraintsForModule(
       @NonNull IModuleNodeItem moduleItem,
-      @NonNull Set<IDefinition> previouslyTargetedDefinitions,
       @NonNull IModelElementVisitor<ITargetedConstraints, Void> visitor);
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/MetaConstraintSet.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/MetaConstraintSet.java
@@ -16,7 +16,6 @@ import gov.nist.secauto.metaschema.core.model.IDefinition;
 import gov.nist.secauto.metaschema.core.model.IModelElementVisitor;
 import gov.nist.secauto.metaschema.core.model.IModule;
 import gov.nist.secauto.metaschema.core.model.ISource;
-import gov.nist.secauto.metaschema.core.util.CollectionUtil;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
 import org.apache.logging.log4j.LogManager;
@@ -71,15 +70,12 @@ public class MetaConstraintSet
   }
 
   @Override
-  public Set<IDefinition> applyConstraintsForModule(
+  public void applyConstraintsForModule(
       IModuleNodeItem moduleItem,
-      Set<IDefinition> previouslyTargetedDefinitions,
       IModelElementVisitor<ITargetedConstraints, Void> visitor) {
 
-    Set<IDefinition> targetedDefinitions = new HashSet<>();
     for (IConstraintSet imported : imports) {
-      targetedDefinitions.addAll(
-          imported.applyConstraintsForModule(moduleItem, previouslyTargetedDefinitions, visitor));
+      imported.applyConstraintsForModule(moduleItem, visitor);
     }
 
     IModule module = moduleItem.getModule();
@@ -92,15 +88,12 @@ public class MetaConstraintSet
     // generate a dynamic context using the external constraint set's static context
     DynamicContext dynamicContext = new DynamicContext(getSource().getStaticContext());
     for (Context context : contexts) {
-      targetedDefinitions.addAll(
-          context.applyConstraintsForModule(
-              moduleItem,
-              previouslyTargetedDefinitions,
-              dynamicContext,
-              visitor,
-              ISequence.of(moduleItem)));
+      context.applyConstraintsForModule(
+          moduleItem,
+          dynamicContext,
+          visitor,
+          ISequence.of(moduleItem));
     }
-    return CollectionUtil.unmodifiableSet(targetedDefinitions);
   }
 
   /**
@@ -116,6 +109,8 @@ public class MetaConstraintSet
     private final List<Context> childContexts = new LinkedList<>();
     @NonNull
     private final Lazy<ITargetedConstraints> constraints;
+    @NonNull
+    private final Set<IDefinition> previouslyTargetedDefinitions = new HashSet<>();
 
     /**
      * Construct a new context.
@@ -176,15 +171,11 @@ public class MetaConstraintSet
       return ObjectUtils.notNull(contextualizedMetapaths.get());
     }
 
-    Set<IDefinition> applyConstraintsForModule(
+    void applyConstraintsForModule(
         @NonNull IModuleNodeItem moduleItem,
-        @NonNull Set<IDefinition> previouslyTargetedDefinitions,
         @NonNull DynamicContext dynamicContext,
         @NonNull IModelElementVisitor<ITargetedConstraints, Void> visitor,
         @NonNull ISequence<? extends INodeItem> contextItems) {
-
-      Set<IDefinition> retval = new HashSet<>();
-
       ISequence<? extends IDefinitionNodeItem<?, ?>> targetedItems = ISequence.of(ObjectUtils.notNull(
           contextItems.stream()
               .flatMap(item -> getMetapaths().stream()
@@ -205,18 +196,16 @@ public class MetaConstraintSet
       definitions.forEach(definition -> {
         definition.accept(visitor, getConstraints());
       });
-      retval.addAll(definitions);
+      previouslyTargetedDefinitions.addAll(definitions);
 
       // process child contexts, which will be applied depth first
       for (Context childContext : childContexts) {
-        retval.addAll(childContext.applyConstraintsForModule(
+        childContext.applyConstraintsForModule(
             moduleItem,
-            previouslyTargetedDefinitions,
             dynamicContext,
             visitor,
-            targetedItems));
+            targetedItems);
       }
-      return CollectionUtil.unmodifiableSet(retval);
     }
 
     @NonNull

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/ScopedConstraintSet.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/ScopedConstraintSet.java
@@ -45,6 +45,8 @@ public class ScopedConstraintSet implements IConstraintSet {
   private final Set<IConstraintSet> importedConstraintSets;
   @NonNull
   private final Map<IEnhancedQName, List<IScopedContraints>> scopedContraints;
+  @NonNull
+  private final Set<IDefinition> previouslyTargetedDefinitions = new HashSet<>();
 
   /**
    * Construct a new constraint set.
@@ -99,9 +101,8 @@ public class ScopedConstraintSet implements IConstraintSet {
   }
 
   @Override
-  public Set<IDefinition> applyConstraintsForModule(
+  public void applyConstraintsForModule(
       IModuleNodeItem moduleItem,
-      Set<IDefinition> previouslyTargetedDefinitions,
       IModelElementVisitor<ITargetedConstraints, Void> visitor) {
     IEnhancedQName qname = moduleItem.getModule().getQName();
     List<IScopedContraints> scopes = getScopedContraints().getOrDefault(qname, CollectionUtil.emptyList());
@@ -142,8 +143,7 @@ public class ScopedConstraintSet implements IConstraintSet {
         definition.accept(visitor, constraints);
       }
     }
-
-    return CollectionUtil.unmodifiableSet(ObjectUtils.notNull(definitionConstraints.keySet()));
+    previouslyTargetedDefinitions.addAll(ObjectUtils.notNull(definitionConstraints.keySet()));
   }
 
   private static boolean filterNonDefinitionItem(IItem item, @NonNull IMetapathExpression metapath) {


### PR DESCRIPTION
# Committer Notes

Localized duplicate constraint application to the constraint context instead of at the post-processor. This should fix a bug where the old behavior is causing some contexts to be ignored.

### All Submissions:

- [ ] Have you selected the correct base branch per [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) guidance?
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/metaschema-java/blob/main/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/metaschema-java/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
