### PR TITLE
Refactor build cleanup and code improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ velocity.log*
 node_modules/
 package.json
 package-lock.json
+
+# Claude
+CLAUDE.local.md

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CLIProcessor.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CLIProcessor.java
@@ -120,6 +120,8 @@ public class CLIProcessor {
   private final String exec;
   @NonNull
   private final Map<String, IVersionInfo> versionInfos;
+  @NonNull
+  private final PrintStream outputStream;
 
   /**
    * The main entry point for command execution.
@@ -161,9 +163,33 @@ public class CLIProcessor {
    *          the version info to display when the version option is provided
    */
   public CLIProcessor(@NonNull String exec, @NonNull Map<String, IVersionInfo> versionInfos) {
+    this(exec, versionInfos, null);
+  }
+
+  /**
+   * The main entry point for CLI processing.
+   * <p>
+   * This constructor allows specifying a custom output stream for testing
+   * purposes.
+   *
+   * @param exec
+   *          the command name
+   * @param versionInfos
+   *          the version info to display when the version option is provided
+   * @param outputStream
+   *          the output stream to write to, or {@code null} to use the default
+   *          console
+   */
+  public CLIProcessor(@NonNull String exec, @NonNull Map<String, IVersionInfo> versionInfos,
+      @Nullable PrintStream outputStream) {
     this.exec = exec;
     this.versionInfos = versionInfos;
-    AnsiConsole.systemInstall();
+    if (outputStream == null) {
+      AnsiConsole.systemInstall();
+      this.outputStream = ObjectUtils.notNull(AnsiConsole.out());
+    } else {
+      this.outputStream = outputStream;
+    }
   }
 
   /**
@@ -281,10 +307,8 @@ public class CLIProcessor {
    * Output version information.
    */
   protected void showVersion() {
-    @SuppressWarnings("resource")
-    PrintStream out = AnsiConsole.out(); // NOPMD - not owner
     getVersionInfos().values().stream().forEach(info -> {
-      out.println(ansi()
+      outputStream.println(ansi()
           .bold().a(info.getName()).boldOff()
           .a(" ")
           .bold().a(info.getVersion()).boldOff()
@@ -298,7 +322,7 @@ public class CLIProcessor {
           .bold().a(info.getGitOriginUrl()).boldOff()
           .reset());
     });
-    out.flush();
+    outputStream.flush();
   }
 
   /**
@@ -753,8 +777,10 @@ public class CLIProcessor {
       HelpFormatter formatter = new HelpFormatter();
       formatter.setLongOptSeparator("=");
 
-      @SuppressWarnings("resource")
-      AnsiPrintStream out = AnsiConsole.out();
+      PrintStream out = outputStream;
+      int terminalWidth = (out instanceof AnsiPrintStream)
+          ? ((AnsiPrintStream) out).getTerminalWidth()
+          : 80;
 
       try (PrintWriter writer = new PrintWriter( // NOPMD not owned
           AutoCloser.preventClose(out),
@@ -762,7 +788,7 @@ public class CLIProcessor {
           StandardCharsets.UTF_8)) {
         formatter.printHelp(
             writer,
-            Math.max(out.getTerminalWidth(), 50),
+            Math.max(terminalWidth, 50),
             buildHelpCliSyntax(),
             buildHelpHeader(),
             toOptions(),

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/AbstractTerminalCommand.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/AbstractTerminalCommand.java
@@ -22,7 +22,7 @@ import nl.talsmasoftware.lazy4j.Lazy;
  * cannot have child commands.
  */
 public abstract class AbstractTerminalCommand implements ICommand {
-  private static Lazy<Path> currentWorkingDirectory = Lazy.lazy(() -> Paths.get(System.getProperty("user.dir")));
+  private static Lazy<Path> currentWorkingDirectory = Lazy.of(() -> Paths.get(System.getProperty("user.dir")));
 
   /**
    * A utility method that can be used to get the current working directory.

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/CommandService.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/CommandService.java
@@ -24,7 +24,7 @@ import nl.talsmasoftware.lazy4j.Lazy;
  * @see ServiceLoader for more information
  */
 public final class CommandService {
-  private static final Lazy<CommandService> INSTANCE = Lazy.lazy(CommandService::new);
+  private static final Lazy<CommandService> INSTANCE = Lazy.of(CommandService::new);
   @NonNull
   private final ServiceLoader<ICommand> loader;
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/DataTypeService.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/DataTypeService.java
@@ -40,7 +40,7 @@ import nl.talsmasoftware.lazy4j.Lazy;
  */
 public final class DataTypeService {
   private static final Logger LOGGER = LogManager.getLogger(DataTypeService.class);
-  private static final Lazy<DataTypeService> INSTANCE = Lazy.lazy(DataTypeService::new);
+  private static final Lazy<DataTypeService> INSTANCE = Lazy.of(DataTypeService::new);
 
   private static final List<IItemType> BUILTIN_ITEM_TYPES;
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/flexmark/impl/FlexmarkConfiguration.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/flexmark/impl/FlexmarkConfiguration.java
@@ -47,7 +47,7 @@ public final class FlexmarkConfiguration {
    */
   @NonNull
   private static final Lazy<DataSet> FLEXMARK_CONFIG
-      = ObjectUtils.notNull(Lazy.lazy(FlexmarkConfiguration::initFlexmarkConfig));
+      = ObjectUtils.notNull(Lazy.of(FlexmarkConfiguration::initFlexmarkConfig));
 
   /**
    * Get the singleton configuration instance.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/StaticFunctionCall.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/StaticFunctionCall.java
@@ -56,7 +56,7 @@ public class StaticFunctionCall
       @NonNull Supplier<IFunction> functionSupplier,
       @NonNull List<IExpression> arguments) {
     super(text);
-    this.functionSupplier = ObjectUtils.notNull(Lazy.lazy(functionSupplier));
+    this.functionSupplier = ObjectUtils.notNull(Lazy.of(functionSupplier));
     this.arguments = arguments;
   }
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/FunctionService.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/FunctionService.java
@@ -21,7 +21,7 @@ import nl.talsmasoftware.lazy4j.Lazy;
  * {@link ServiceLoader} interface.
  */
 public final class FunctionService implements IFunctionResolver {
-  private static final Lazy<FunctionService> INSTANCE = Lazy.lazy(FunctionService::new);
+  private static final Lazy<FunctionService> INSTANCE = Lazy.of(FunctionService::new);
   @NonNull
   private final ServiceLoader<IFunctionLibrary> loader;
   @NonNull
@@ -46,7 +46,7 @@ public final class FunctionService implements IFunctionResolver {
     this.loader = ServiceLoader.load(IFunctionLibrary.class);
     ServiceLoader<IFunctionLibrary> loader = getLoader();
 
-    this.library = Lazy.lazy(() -> {
+    this.library = Lazy.of(() -> {
       FunctionLibrary functionLibrary = new FunctionLibrary();
       loader.stream()
           .map(Provider<IFunctionLibrary>::get)

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/FunctionUtils.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/FunctionUtils.java
@@ -130,7 +130,6 @@ public final class FunctionUtils {
    * @throws ClassCastException
    *           if the item's type is not compatible with the requested type
    */
-  @Deprecated(since = "3.0.0", forRemoval = true)
   @SuppressWarnings("unchecked")
   @Nullable
   public static <TYPE extends IItem> TYPE asTypeOrNull(@Nullable IItem item) {
@@ -148,7 +147,6 @@ public final class FunctionUtils {
    * @throws ClassCastException
    *           if the item's type is not compatible with the requested type
    */
-  @Deprecated(since = "3.0.0", forRemoval = true)
   @SuppressWarnings("unchecked")
   @NonNull
   public static <TYPE extends IItem> TYPE asType(@NonNull IItem item) {
@@ -166,7 +164,6 @@ public final class FunctionUtils {
    * @throws ClassCastException
    *           if the sequence's type is not compatible with the requested type
    */
-  @Deprecated(since = "3.0.0", forRemoval = true)
   @SuppressWarnings("unchecked")
   @NonNull
   public static <TYPE extends IItem> ISequence<TYPE> asType(@NonNull ISequence<?> sequence) {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/impl/AbstractMapKey.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/impl/AbstractMapKey.java
@@ -10,7 +10,7 @@ import gov.nist.secauto.metaschema.core.metapath.item.function.IMapKey;
 import nl.talsmasoftware.lazy4j.Lazy;
 
 public abstract class AbstractMapKey implements IMapKey {
-  private final Lazy<Integer> hashCode = Lazy.lazy(this::generateHashCode);
+  private final Lazy<Integer> hashCode = Lazy.of(this::generateHashCode);
 
   @Override
   public int hashCode() {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/impl/LazyCompilationMetapathExpression.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/impl/LazyCompilationMetapathExpression.java
@@ -48,7 +48,7 @@ public class LazyCompilationMetapathExpression implements IMetapathExpression {
       @NonNull StaticContext staticContext) {
     this.path = path;
     this.staticContext = staticContext;
-    this.compiledMetapath = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.compiledMetapath = ObjectUtils.notNull(Lazy.of(() -> {
       IMetapathExpression result;
       try {
         result = IMetapathExpression.compile(path, staticContext);

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/AbstractDecimalItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/AbstractDecimalItem.java
@@ -28,7 +28,7 @@ public abstract class AbstractDecimalItem<TYPE>
     implements IDecimalItem {
 
   @SuppressWarnings("synthetic-access")
-  private final Lazy<String> stringValue = Lazy.lazy(super::asString);
+  private final Lazy<String> stringValue = Lazy.of(super::asString);
 
   /**
    * Construct a new item with the provided {@code value}.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/AbstractUriItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/AbstractUriItem.java
@@ -25,7 +25,7 @@ public abstract class AbstractUriItem
     implements IAnyUriItem {
 
   @SuppressWarnings("synthetic-access")
-  private final Lazy<String> stringValue = Lazy.lazy(super::asString);
+  private final Lazy<String> stringValue = Lazy.of(super::asString);
 
   /**
    * Construct a new item that wraps the provided value.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/UuidItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/UuidItemImpl.java
@@ -25,7 +25,7 @@ import nl.talsmasoftware.lazy4j.Lazy;
 public class UuidItemImpl
     extends AbstractAnyAtomicItem<UUID>
     implements IUuidItem {
-  private final Lazy<String> stringValue = Lazy.lazy(super::asString);
+  private final Lazy<String> stringValue = Lazy.of(super::asString);
 
   /**
    * Construct a new item with the provided {@code value}.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AbstractNodeItemVisitor.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AbstractNodeItemVisitor.java
@@ -60,8 +60,6 @@ public abstract class AbstractNodeItemVisitor<CONTEXT, RESULT>
    * @param context
    *          provides contextual information for use by the visitor
    * @return the result produced by visiting the item's child model items
-   * @throws EXCEPTION
-   *           when an un-handled error was raised while visiting a child node
    */
   protected RESULT visitModelChildren(@NonNull INodeItem item, CONTEXT context) {
     RESULT result = defaultResult();

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AssemblyGlobalDefinitionNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AssemblyGlobalDefinitionNodeItemImpl.java
@@ -22,7 +22,7 @@ class AssemblyGlobalDefinitionNodeItemImpl
       @NonNull IModuleNodeItem metaschemaNodeItem,
       @NonNull INodeItemGenerator generator) {
     super(definition, metaschemaNodeItem);
-    this.model = ObjectUtils.notNull(Lazy.lazy(generator.newMetaschemaModelSupplier(this)));
+    this.model = ObjectUtils.notNull(Lazy.of(generator.newMetaschemaModelSupplier(this)));
   }
 
   @SuppressWarnings("null")

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AssemblyInstanceNoValueNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AssemblyInstanceNoValueNodeItemImpl.java
@@ -23,7 +23,7 @@ class AssemblyInstanceNoValueNodeItemImpl
       @NonNull IAssemblyNodeItem parent,
       @NonNull INodeItemGenerator generator) {
     super(instance, parent);
-    this.model = ObjectUtils.notNull(Lazy.lazy(generator.newMetaschemaModelSupplier(this)));
+    this.model = ObjectUtils.notNull(Lazy.of(generator.newMetaschemaModelSupplier(this)));
   }
 
   @SuppressWarnings("null")

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AssemblyInstanceNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AssemblyInstanceNodeItemImpl.java
@@ -33,7 +33,7 @@ class AssemblyInstanceNodeItemImpl
       @NonNull Object value,
       @NonNull INodeItemGenerator generator) {
     super(instance, parent);
-    this.model = ObjectUtils.notNull(Lazy.lazy(generator.newDataModelSupplier(this)));
+    this.model = ObjectUtils.notNull(Lazy.of(generator.newDataModelSupplier(this)));
     this.position = position;
     this.value = value;
   }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AssemblyOrphanedDefinitionDataNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AssemblyOrphanedDefinitionDataNodeItemImpl.java
@@ -30,7 +30,7 @@ class AssemblyOrphanedDefinitionDataNodeItemImpl
       @NonNull INodeItemGenerator generator) {
     super(definition, baseUri);
     this.value = value;
-    this.model = ObjectUtils.notNull(Lazy.lazy(generator.newDataModelSupplier(this)));
+    this.model = ObjectUtils.notNull(Lazy.of(generator.newDataModelSupplier(this)));
   }
 
   @SuppressWarnings("null")

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AssemblyOrphanedDefinitionNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AssemblyOrphanedDefinitionNodeItemImpl.java
@@ -24,7 +24,7 @@ class AssemblyOrphanedDefinitionNodeItemImpl
       @Nullable URI baseUri,
       @NonNull INodeItemGenerator generator) {
     super(definition, baseUri);
-    this.model = ObjectUtils.notNull(Lazy.lazy(generator.newMetaschemaModelSupplier(this)));
+    this.model = ObjectUtils.notNull(Lazy.of(generator.newMetaschemaModelSupplier(this)));
   }
 
   @SuppressWarnings("null")

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/DocumentNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/DocumentNodeItemImpl.java
@@ -30,7 +30,7 @@ class DocumentNodeItemImpl
       @NonNull INodeItemGenerator generator) {
     this.root = new RootAssemblyValuedNodeItemImpl(root, this, rootValue, generator);
     this.documentUri = documentUri;
-    this.model = ObjectUtils.notNull(Lazy.lazy(generator.newDataModelSupplier(this.root)));
+    this.model = ObjectUtils.notNull(Lazy.of(generator.newDataModelSupplier(this.root)));
 
     StaticContext.Builder builder = StaticContext.builder()
         .baseUri(documentUri)

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/FieldGlobalDefinitionNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/FieldGlobalDefinitionNodeItemImpl.java
@@ -21,7 +21,7 @@ class FieldGlobalDefinitionNodeItemImpl
       @NonNull IModuleNodeItem metaschemaNodeItem,
       @NonNull INodeItemGenerator generator) {
     super(definition, metaschemaNodeItem);
-    this.model = Lazy.lazy(generator.newMetaschemaModelSupplier(this));
+    this.model = Lazy.of(generator.newMetaschemaModelSupplier(this));
   }
 
   @SuppressWarnings("null")

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/FieldInstanceNoValueNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/FieldInstanceNoValueNodeItemImpl.java
@@ -23,7 +23,7 @@ class FieldInstanceNoValueNodeItemImpl
       @NonNull IAssemblyNodeItem parent,
       @NonNull INodeItemGenerator generator) {
     super(instance, parent);
-    this.model = ObjectUtils.notNull(Lazy.lazy(generator.newMetaschemaModelSupplier(this)));
+    this.model = ObjectUtils.notNull(Lazy.of(generator.newMetaschemaModelSupplier(this)));
   }
 
   @SuppressWarnings("null")

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/FieldInstanceNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/FieldInstanceNodeItemImpl.java
@@ -40,10 +40,10 @@ class FieldInstanceNodeItemImpl
       @NonNull Object value,
       @NonNull INodeItemGenerator generator) {
     super(instance, parent);
-    this.model = ObjectUtils.notNull(Lazy.lazy(generator.newDataModelSupplier(this)));
+    this.model = ObjectUtils.notNull(Lazy.of(generator.newDataModelSupplier(this)));
     this.position = position;
     this.value = value;
-    this.atomicItem = ObjectUtils.notNull(Lazy.lazy(this::newAtomicItem));
+    this.atomicItem = ObjectUtils.notNull(Lazy.of(this::newAtomicItem));
   }
 
   @SuppressWarnings("null")

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/FieldOrphanedDefinitionNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/FieldOrphanedDefinitionNodeItemImpl.java
@@ -27,7 +27,7 @@ class FieldOrphanedDefinitionNodeItemImpl
       @Nullable URI baseUri,
       @NonNull INodeItemGenerator generator) {
     super(definition, baseUri);
-    this.model = Lazy.lazy(generator.newMetaschemaModelSupplier(this));
+    this.model = Lazy.of(generator.newMetaschemaModelSupplier(this));
   }
 
   @SuppressWarnings("null")

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/FlagInstanceNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/FlagInstanceNodeItemImpl.java
@@ -32,7 +32,7 @@ class FlagInstanceNodeItemImpl
       @NonNull Object value) {
     super(instance, parent);
     this.value = value;
-    this.atomicItem = ObjectUtils.notNull(Lazy.lazy(this::newAtomicItem));
+    this.atomicItem = ObjectUtils.notNull(Lazy.of(this::newAtomicItem));
   }
 
   @Override

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/ModuleNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/ModuleNodeItemImpl.java
@@ -23,7 +23,7 @@ class ModuleNodeItemImpl
       @NonNull IModule module,
       @NonNull INodeItemGenerator generator) {
     this.module = module;
-    this.model = ObjectUtils.notNull(Lazy.lazy(generator.newMetaschemaModelSupplier(this)));
+    this.model = ObjectUtils.notNull(Lazy.of(generator.newMetaschemaModelSupplier(this)));
   }
 
   @NonNull

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/RootAssemblyValuedNodeItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/RootAssemblyValuedNodeItemImpl.java
@@ -29,7 +29,7 @@ class RootAssemblyValuedNodeItemImpl
       @NonNull INodeItemGenerator generator) {
     this.definition = definition;
     this.parent = parent;
-    this.model = ObjectUtils.notNull(Lazy.lazy(generator.newDataModelSupplier((IAssemblyNodeItem) this)));
+    this.model = ObjectUtils.notNull(Lazy.of(generator.newDataModelSupplier((IAssemblyNodeItem) this)));
     this.value = value;
   }
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/type/TypeMetapathException.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/type/TypeMetapathException.java
@@ -75,8 +75,6 @@ public class TypeMetapathException
    * Constructs a new exception with the provided {@code code}, {@code message},
    * and no cause.
    *
-   * @param evaluationStack
-   *          the Metapath evaluation stack that lead to this exception
    * @param code
    *          the error code value
    * @param message

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/AbstractGlobalDefinition.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/AbstractGlobalDefinition.java
@@ -38,8 +38,8 @@ public abstract class AbstractGlobalDefinition<MODULE extends IModule, INSTANCE 
    */
   protected AbstractGlobalDefinition(@NonNull MODULE module, @NonNull NameInitializer initializer) {
     this.module = module;
-    this.qname = ObjectUtils.notNull(Lazy.lazy(() -> initializer.apply(getEffectiveName())));
-    this.definitionQName = ObjectUtils.notNull(Lazy.lazy(() -> initializer.apply(getName())));
+    this.qname = ObjectUtils.notNull(Lazy.of(() -> initializer.apply(getEffectiveName())));
+    this.definitionQName = ObjectUtils.notNull(Lazy.of(() -> initializer.apply(getName())));
   }
 
   @Override

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/AbstractLoader.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/AbstractLoader.java
@@ -5,6 +5,7 @@
 
 package gov.nist.secauto.metaschema.core.model;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 
 import gov.nist.secauto.metaschema.core.util.CollectionUtil;
@@ -23,7 +24,10 @@ import java.util.Collection;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -32,15 +36,21 @@ public abstract class AbstractLoader<T> implements ILoader<T> {
   private static final Logger LOGGER = LogManager.getLogger(AbstractLoader.class);
 
   @NonNull
-  private final Map<URI, T> cache = ObjectUtils.notNull(Caffeine.newBuilder()
+  private final Cache<URI, T> cache = ObjectUtils.notNull(Caffeine.newBuilder()
       .maximumSize(100)
       .expireAfterAccess(10, TimeUnit.MINUTES)
-      .<URI, T>build().asMap());
+      .build());
+
+  /**
+   * Per-URI locks to prevent concurrent loading of the same resource.
+   */
+  @NonNull
+  private final ConcurrentHashMap<URI, Lock> loadingLocks = new ConcurrentHashMap<>();
 
   @Override
   @NonNull
   public Collection<T> getLoadedResources() {
-    return CollectionUtil.unmodifiableCollection(ObjectUtils.notNull(cache.values()));
+    return CollectionUtil.unmodifiableCollection(ObjectUtils.notNull(cache.asMap().values()));
   }
 
   /**
@@ -50,7 +60,7 @@ public abstract class AbstractLoader<T> implements ILoader<T> {
    */
   @NonNull
   protected Map<URI, T> getCachedEntries() {
-    return CollectionUtil.unmodifiableMap(cache);
+    return CollectionUtil.unmodifiableMap(cache.asMap());
   }
 
   @Override
@@ -136,10 +146,29 @@ public abstract class AbstractLoader<T> implements ILoader<T> {
           + visitedResources.stream().map(URI::toString).collect(Collectors.joining(",")));
     }
 
-    T retval = cache.get(resource);
-    if (retval == null) {
-      LOGGER.info("Loading '{}'", resource);
+    // Check cache first without locking
+    T retval = cache.getIfPresent(resource);
+    if (retval != null) {
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Found resource in cache '{}'", resource);
+      }
+      return retval;
+    }
 
+    // Get or create a lock for this specific URI
+    Lock lock = loadingLocks.computeIfAbsent(resource, k -> new ReentrantLock());
+    lock.lock();
+    try {
+      // Double-check after acquiring lock
+      retval = cache.getIfPresent(resource);
+      if (retval != null) {
+        if (LOGGER.isDebugEnabled()) {
+          LOGGER.debug("Found resource in cache after lock '{}'", resource);
+        }
+        return retval;
+      }
+
+      LOGGER.info("Loading '{}'", resource);
       try {
         visitedResources.push(resource);
         retval = parseResource(resource, visitedResources);
@@ -147,10 +176,12 @@ public abstract class AbstractLoader<T> implements ILoader<T> {
         visitedResources.pop();
       }
       cache.put(resource, retval);
-    } else if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug("Found resource in cache '{}'", resource);
+      return ObjectUtils.notNull(retval);
+    } finally {
+      lock.unlock();
+      // Clean up the lock from the map to prevent memory leak
+      loadingLocks.remove(resource, lock);
     }
-    return ObjectUtils.notNull(retval);
   }
 
   /**

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/AbstractLoader.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/AbstractLoader.java
@@ -5,7 +5,6 @@
 
 package gov.nist.secauto.metaschema.core.model;
 
-import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 
 import gov.nist.secauto.metaschema.core.util.CollectionUtil;
@@ -24,10 +23,7 @@ import java.util.Collection;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -36,21 +32,15 @@ public abstract class AbstractLoader<T> implements ILoader<T> {
   private static final Logger LOGGER = LogManager.getLogger(AbstractLoader.class);
 
   @NonNull
-  private final Cache<URI, T> cache = ObjectUtils.notNull(Caffeine.newBuilder()
+  private final Map<URI, T> cache = ObjectUtils.notNull(Caffeine.newBuilder()
       .maximumSize(100)
       .expireAfterAccess(10, TimeUnit.MINUTES)
-      .build());
-
-  /**
-   * Per-URI locks to prevent concurrent loading of the same resource.
-   */
-  @NonNull
-  private final ConcurrentHashMap<URI, Lock> loadingLocks = new ConcurrentHashMap<>();
+      .<URI, T>build().asMap());
 
   @Override
   @NonNull
   public Collection<T> getLoadedResources() {
-    return CollectionUtil.unmodifiableCollection(ObjectUtils.notNull(cache.asMap().values()));
+    return CollectionUtil.unmodifiableCollection(ObjectUtils.notNull(cache.values()));
   }
 
   /**
@@ -60,7 +50,7 @@ public abstract class AbstractLoader<T> implements ILoader<T> {
    */
   @NonNull
   protected Map<URI, T> getCachedEntries() {
-    return CollectionUtil.unmodifiableMap(cache.asMap());
+    return CollectionUtil.unmodifiableMap(cache);
   }
 
   @Override
@@ -146,29 +136,10 @@ public abstract class AbstractLoader<T> implements ILoader<T> {
           + visitedResources.stream().map(URI::toString).collect(Collectors.joining(",")));
     }
 
-    // Check cache first without locking
-    T retval = cache.getIfPresent(resource);
-    if (retval != null) {
-      if (LOGGER.isDebugEnabled()) {
-        LOGGER.debug("Found resource in cache '{}'", resource);
-      }
-      return retval;
-    }
-
-    // Get or create a lock for this specific URI
-    Lock lock = loadingLocks.computeIfAbsent(resource, k -> new ReentrantLock());
-    lock.lock();
-    try {
-      // Double-check after acquiring lock
-      retval = cache.getIfPresent(resource);
-      if (retval != null) {
-        if (LOGGER.isDebugEnabled()) {
-          LOGGER.debug("Found resource in cache after lock '{}'", resource);
-        }
-        return retval;
-      }
-
+    T retval = cache.get(resource);
+    if (retval == null) {
       LOGGER.info("Loading '{}'", resource);
+
       try {
         visitedResources.push(resource);
         retval = parseResource(resource, visitedResources);
@@ -176,12 +147,10 @@ public abstract class AbstractLoader<T> implements ILoader<T> {
         visitedResources.pop();
       }
       cache.put(resource, retval);
-      return ObjectUtils.notNull(retval);
-    } finally {
-      lock.unlock();
-      // Clean up the lock from the map to prevent memory leak
-      loadingLocks.remove(resource, lock);
+    } else if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Found resource in cache '{}'", resource);
     }
+    return ObjectUtils.notNull(retval);
   }
 
   /**

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/AbstractModule.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/AbstractModule.java
@@ -67,8 +67,8 @@ public abstract class AbstractModule<
   public AbstractModule(@NonNull List<? extends M> importedModules) {
     this.importedModules
         = CollectionUtil.unmodifiableList(ObjectUtils.requireNonNull(importedModules, "importedModules"));
-    this.exports = ObjectUtils.notNull(Lazy.lazy(() -> new Exports(importedModules)));
-    this.qname = ObjectUtils.notNull(Lazy.lazy(() -> IEnhancedQName.of(getXmlNamespace(), getShortName())));
+    this.exports = ObjectUtils.notNull(Lazy.of(() -> new Exports(importedModules)));
+    this.qname = ObjectUtils.notNull(Lazy.of(() -> IEnhancedQName.of(getXmlNamespace(), getShortName())));
   }
 
   @Override

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/AbstractNamedInstance.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/AbstractNamedInstance.java
@@ -31,8 +31,8 @@ public abstract class AbstractNamedInstance<
    */
   protected AbstractNamedInstance(@NonNull PARENT parent, @NonNull NameInitializer initializer) {
     super(parent);
-    this.qname = ObjectUtils.notNull(Lazy.lazy(() -> initializer.apply(getEffectiveName())));
-    this.definitionQName = ObjectUtils.notNull(Lazy.lazy(() -> initializer.apply(getName())));
+    this.qname = ObjectUtils.notNull(Lazy.of(() -> initializer.apply(getEffectiveName())));
+    this.definitionQName = ObjectUtils.notNull(Lazy.of(() -> initializer.apply(getName())));
   }
 
   @SuppressWarnings("null")

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/MetaConstraintSet.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/MetaConstraintSet.java
@@ -131,12 +131,12 @@ public class MetaConstraintSet
         @NonNull List<IMetapathExpression> metapaths,
         @NonNull IModelConstrained modelConstrained) {
       this.metapaths = metapaths;
-      this.contextualizedMetapaths = ObjectUtils.notNull(Lazy.lazy(() -> {
+      this.contextualizedMetapaths = ObjectUtils.notNull(Lazy.of(() -> {
         return concatMetapaths(parent, ObjectUtils.notNull(metapaths.stream()), source)
             .collect(Collectors.toUnmodifiableList());
       }));
 
-      this.constraints = ObjectUtils.notNull(Lazy.lazy(() -> new ModelTargetedConstraints(
+      this.constraints = ObjectUtils.notNull(Lazy.of(() -> new ModelTargetedConstraints(
           source,
           this::getContextualizedMetapaths,
           modelConstrained)));

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/util/DefaultDiagramNode.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/util/DefaultDiagramNode.java
@@ -73,7 +73,7 @@ public class DefaultDiagramNode implements IDiagramNode {
                 .map(field -> new Attribute(field.getEffectiveName(), field.getDefinition().getJavaTypeAdapter()))
             : Stream.empty())
         .collect(Collectors.toUnmodifiableList()));
-    this.edges = ObjectUtils.notNull(Lazy.lazy(() -> definition instanceof IAssemblyDefinition
+    this.edges = ObjectUtils.notNull(Lazy.of(() -> definition instanceof IAssemblyDefinition
         ? generateEdges((IAssemblyDefinition) definition)
         : CollectionUtil.emptyList()));
   }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/util/MermaidErDiagramGenerator.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/util/MermaidErDiagramGenerator.java
@@ -36,7 +36,7 @@ import nl.talsmasoftware.lazy4j.Lazy;
 public final class MermaidErDiagramGenerator {
   @NonNull
   private static final Lazy<Map<IDiagramNode.Relationship, Pair<String, String>>> RELATIONSHIP_SYMBOLS
-      = ObjectUtils.notNull(Lazy.lazy(() -> {
+      = ObjectUtils.notNull(Lazy.of(() -> {
         Map<IDiagramNode.Relationship, Pair<String, String>> retval = new EnumMap<>(IDiagramNode.Relationship.class);
 
         retval.put(IDiagramNode.Relationship.ZERO_OR_ONE, Pair.of("|o", "o|"));

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/impl/XmlChoiceGroupInstance.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/impl/XmlChoiceGroupInstance.java
@@ -167,7 +167,7 @@ class XmlChoiceGroupInstance
       @NonNull IAssemblyDefinition parent) {
     super(parent);
     this.xmlObject = xmlObject;
-    this.modelContainer = ObjectUtils.notNull(Lazy.lazy(() -> newContainer(
+    this.modelContainer = ObjectUtils.notNull(Lazy.of(() -> newContainer(
         parent.getContainingModule().getSource(),
         xmlObject,
         this)));

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/impl/XmlChoiceInstance.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/impl/XmlChoiceInstance.java
@@ -169,7 +169,7 @@ class XmlChoiceInstance
       @NonNull IAssemblyDefinition parent) {
     super(parent);
     this.xmlChoice = xmlObject;
-    this.modelContainer = ObjectUtils.notNull(Lazy.lazy(() -> newContainer(xmlObject, this)));
+    this.modelContainer = ObjectUtils.notNull(Lazy.of(() -> newContainer(xmlObject, this)));
   }
 
   @Override

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/impl/XmlGlobalAssemblyDefinition.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/impl/XmlGlobalAssemblyDefinition.java
@@ -77,11 +77,11 @@ class XmlGlobalAssemblyDefinition
       @NonNull XmlModule module) {
     super(module);
     this.xmlAssembly = xmlObject;
-    this.flagContainer = ObjectUtils.notNull(Lazy.lazy(() -> XmlFlagContainerSupport.newInstance(xmlObject, this)));
+    this.flagContainer = ObjectUtils.notNull(Lazy.of(() -> XmlFlagContainerSupport.newInstance(xmlObject, this)));
     this.modelContainer = ObjectUtils.notNull(
-        Lazy.lazy(() -> XmlAssemblyModelContainerSupport.of(xmlObject.getModel(), this)));
+        Lazy.of(() -> XmlAssemblyModelContainerSupport.of(xmlObject.getModel(), this)));
     ISource source = module.getSource();
-    this.constraints = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.constraints = ObjectUtils.notNull(Lazy.of(() -> {
       IModelConstrained retval = new AssemblyConstraintSet(source);
       if (xmlObject.isSetConstraint()) {
         ConstraintXmlSupport.parse(retval, ObjectUtils.notNull(xmlObject.getConstraint()), source);

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/impl/XmlGlobalFieldDefinition.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/impl/XmlGlobalFieldDefinition.java
@@ -59,9 +59,9 @@ class XmlGlobalFieldDefinition
       defaultValue = getJavaTypeAdapter().parse(ObjectUtils.requireNonNull(xmlObject.getDefault()));
     }
     this.defaultValue = defaultValue;
-    this.flagContainer = ObjectUtils.notNull(Lazy.lazy(() -> XmlFlagContainerSupport.newInstance(xmlObject, this)));
+    this.flagContainer = ObjectUtils.notNull(Lazy.of(() -> XmlFlagContainerSupport.newInstance(xmlObject, this)));
     ISource source = module.getSource();
-    this.constraints = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.constraints = ObjectUtils.notNull(Lazy.of(() -> {
       IValueConstrained retval = new ValueConstraintSet(source);
       if (getXmlObject().isSetConstraint()) {
         ConstraintXmlSupport.parse(retval, ObjectUtils.notNull(getXmlObject().getConstraint()), source);

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/impl/XmlGlobalFlagDefinition.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/impl/XmlGlobalFlagDefinition.java
@@ -55,7 +55,7 @@ class XmlGlobalFlagDefinition
     }
     this.defaultValue = defaultValue;
     ISource source = module.getSource();
-    this.constraints = Lazy.lazy(() -> {
+    this.constraints = Lazy.of(() -> {
       IValueConstrained retval = new ValueConstraintSet(source);
       if (getXmlFlag().isSetConstraint()) {
         ConstraintXmlSupport.parse(retval, ObjectUtils.notNull(getXmlFlag().getConstraint()), source);

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/impl/XmlGroupedInlineAssemblyDefinition.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/impl/XmlGroupedInlineAssemblyDefinition.java
@@ -105,16 +105,16 @@ public class XmlGroupedInlineAssemblyDefinition
       @NonNull IChoiceGroupInstance parent) {
     super(parent);
     this.xmlObject = xmlObject;
-    this.flagContainer = ObjectUtils.notNull(Lazy.lazy(() -> XmlFlagContainerSupport.newInstance(
+    this.flagContainer = ObjectUtils.notNull(Lazy.of(() -> XmlFlagContainerSupport.newInstance(
         xmlObject,
         this,
         parent.getJsonKeyFlagInstanceName())));
     this.modelContainer = ObjectUtils.notNull(
-        Lazy.lazy(() -> XmlAssemblyModelContainerSupport.of(xmlObject.getModel(), this)));
+        Lazy.of(() -> XmlAssemblyModelContainerSupport.of(xmlObject.getModel(), this)));
 
     ISource source = parent.getContainingModule().getSource();
 
-    this.constraints = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.constraints = ObjectUtils.notNull(Lazy.of(() -> {
       IModelConstrained retval = new AssemblyConstraintSet(source);
       if (getXmlObject().isSetConstraint()) {
         ConstraintXmlSupport.parse(

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/impl/XmlGroupedInlineFieldDefinition.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/impl/XmlGroupedInlineFieldDefinition.java
@@ -67,14 +67,14 @@ public class XmlGroupedInlineFieldDefinition
       @NonNull IChoiceGroupInstance parent) {
     super(parent);
     this.xmlObject = xmlObject;
-    this.flagContainer = ObjectUtils.notNull(Lazy.lazy(() -> XmlFlagContainerSupport.newInstance(
+    this.flagContainer = ObjectUtils.notNull(Lazy.of(() -> XmlFlagContainerSupport.newInstance(
         xmlObject,
         this,
         parent.getJsonKeyFlagInstanceName())));
 
     ISource source = parent.getContainingModule().getSource();
 
-    this.constraints = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.constraints = ObjectUtils.notNull(Lazy.of(() -> {
       IValueConstrained retval = new ValueConstraintSet(source);
       if (getXmlObject().isSetConstraint()) {
         ConstraintXmlSupport.parse(retval, ObjectUtils.notNull(getXmlObject().getConstraint()), source);

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/impl/XmlInlineAssemblyDefinition.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/impl/XmlInlineAssemblyDefinition.java
@@ -105,13 +105,13 @@ class XmlInlineAssemblyDefinition
       @NonNull IContainerModel parent) {
     super(parent);
     this.xmlObject = xmlObject;
-    this.flagContainer = ObjectUtils.notNull(Lazy.lazy(() -> XmlFlagContainerSupport.newInstance(xmlObject, this)));
+    this.flagContainer = ObjectUtils.notNull(Lazy.of(() -> XmlFlagContainerSupport.newInstance(xmlObject, this)));
     this.modelContainer
-        = ObjectUtils.notNull(Lazy.lazy(() -> XmlAssemblyModelContainerSupport.of(xmlObject.getModel(), this)));
+        = ObjectUtils.notNull(Lazy.of(() -> XmlAssemblyModelContainerSupport.of(xmlObject.getModel(), this)));
 
     ISource source = parent.getOwningDefinition().getContainingModule().getSource();
 
-    this.constraints = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.constraints = ObjectUtils.notNull(Lazy.of(() -> {
       IModelConstrained retval = new AssemblyConstraintSet(source);
       if (getXmlObject().isSetConstraint()) {
         ConstraintXmlSupport.parse(

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/impl/XmlInlineFieldDefinition.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/impl/XmlInlineFieldDefinition.java
@@ -70,11 +70,11 @@ class XmlInlineFieldDefinition
     this.defaultValue = xmlObject.isSetDefault()
         ? getJavaTypeAdapter().parse(ObjectUtils.requireNonNull(xmlObject.getDefault()))
         : null;
-    this.flagContainer = ObjectUtils.notNull(Lazy.lazy(() -> XmlFlagContainerSupport.newInstance(xmlObject, this)));
+    this.flagContainer = ObjectUtils.notNull(Lazy.of(() -> XmlFlagContainerSupport.newInstance(xmlObject, this)));
 
     ISource source = parent.getOwningDefinition().getContainingModule().getSource();
 
-    this.constraints = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.constraints = ObjectUtils.notNull(Lazy.of(() -> {
       IValueConstrained retval = new ValueConstraintSet(source);
       if (getXmlObject().isSetConstraint()) {
         ConstraintXmlSupport.parse(retval, ObjectUtils.notNull(getXmlObject().getConstraint()), source);

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/impl/XmlInlineFlagDefinition.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/impl/XmlInlineFlagDefinition.java
@@ -58,7 +58,7 @@ class XmlInlineFlagDefinition
 
     ISource source = parent.getContainingModule().getSource();
 
-    this.constraints = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.constraints = ObjectUtils.notNull(Lazy.of(() -> {
       IValueConstrained retval = new ValueConstraintSet(source);
       if (getXmlObject().isSetConstraint()) {
         ConstraintXmlSupport.parse(retval, ObjectUtils.notNull(getXmlObject().getConstraint()), source);

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/impl/XmlModule.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/xml/impl/XmlModule.java
@@ -99,7 +99,7 @@ public class XmlModule
 
     METASCHEMADocument.METASCHEMA moduleXml = ObjectUtils.requireNonNull(xmlObject.getMETASCHEMA());
 
-    this.staticContext = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.staticContext = ObjectUtils.notNull(Lazy.of(() -> {
       StaticContext.Builder builder = StaticContext.builder()
           .baseUri(resource)
           .defaultModelNamespace(ObjectUtils.requireNonNull(moduleXml.getNamespace()));
@@ -111,7 +111,7 @@ public class XmlModule
       return builder.build();
     }));
     this.module = xmlObject;
-    this.definitions = Lazy.lazy(() -> new Definitions(moduleXml));
+    this.definitions = Lazy.of(() -> new Definitions(moduleXml));
     this.source = ISource.moduleSource(this);
   }
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/qname/EQNameFactory.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/qname/EQNameFactory.java
@@ -28,7 +28,7 @@ public final class EQNameFactory {
   private static final Pattern URI_QUALIFIED_NAME = Pattern.compile("^Q\\{([^{}]*)\\}(.+)$");
   private static final Pattern LEXICAL_NAME = Pattern.compile("^(?:([^:]+):)?(.+)$");
   @NonNull
-  private static final Lazy<EQNameFactory> INSTANCE = ObjectUtils.notNull(Lazy.lazy(EQNameFactory::new));
+  private static final Lazy<EQNameFactory> INSTANCE = ObjectUtils.notNull(Lazy.of(EQNameFactory::new));
 
   @NonNull
   private final QNameCache cache;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/qname/NamespaceCache.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/qname/NamespaceCache.java
@@ -22,7 +22,7 @@ import nl.talsmasoftware.lazy4j.Lazy;
  */
 public final class NamespaceCache {
   @NonNull
-  private static final Lazy<NamespaceCache> INSTANCE = ObjectUtils.notNull(Lazy.lazy(NamespaceCache::new));
+  private static final Lazy<NamespaceCache> INSTANCE = ObjectUtils.notNull(Lazy.of(NamespaceCache::new));
 
   private final Map<String, Integer> nsToIndex = new ConcurrentHashMap<>();
   private final Map<Integer, String> indexToNs = new ConcurrentHashMap<>();

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/qname/QNameCache.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/qname/QNameCache.java
@@ -41,7 +41,7 @@ public final class QNameCache {
       = Comparator.comparingInt(IEnhancedQName::getIndexPosition);
 
   @NonNull
-  private static final Lazy<QNameCache> INSTANCE = ObjectUtils.notNull(Lazy.lazy(QNameCache::new));
+  private static final Lazy<QNameCache> INSTANCE = ObjectUtils.notNull(Lazy.of(QNameCache::new));
 
   @NonNull
   private final NamespaceCache namespaceCache;

--- a/core/src/main/java/schema/json/package-info.java
+++ b/core/src/main/java/schema/json/package-info.java
@@ -7,5 +7,4 @@
  * Provides schema resources for JSON schema and Metaschema data types.
  */
 
-@Deprecated
 package schema.json;

--- a/core/src/main/java/schema/metaschema/package-info.java
+++ b/core/src/main/java/schema/metaschema/package-info.java
@@ -7,5 +7,4 @@
  * Provides schema resources for XML schema and Metaschema data types.
  */
 
-@Deprecated
 package schema.metaschema;

--- a/core/src/main/java/schema/xml/package-info.java
+++ b/core/src/main/java/schema/xml/package-info.java
@@ -7,5 +7,4 @@
  * Provides schema resources for XML schema and Metaschema data types.
  */
 
-@Deprecated
 package schema.xml;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/ExpressionTestBase.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/ExpressionTestBase.java
@@ -12,6 +12,7 @@ import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.junit5.JUnit5Mockery;
+import org.jmock.lib.concurrent.Synchroniser;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
@@ -30,7 +31,11 @@ public class ExpressionTestBase {
   @SuppressWarnings("exports")
   @NonNull
   @RegisterExtension
-  public final Mockery context = new JUnit5Mockery();
+  public final Mockery context = new JUnit5Mockery() {
+    {
+      setThreadingPolicy(new Synchroniser());
+    }
+  };
 
   /**
    * Get the mocking context.

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/ExpressionUtilsTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/ExpressionUtilsTest.java
@@ -17,8 +17,8 @@ import gov.nist.secauto.metaschema.core.metapath.item.node.INodeItem;
 
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.auto.Mock;
 import org.jmock.junit5.JUnit5Mockery;
+import org.jmock.lib.concurrent.Synchroniser;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -27,25 +27,22 @@ import java.util.List;
 class ExpressionUtilsTest {
 
   @RegisterExtension
-  Mockery context = new JUnit5Mockery();
+  Mockery context = new JUnit5Mockery() {
+    {
+      setThreadingPolicy(new Synchroniser());
+    }
+  };
 
-  @Mock
-  private IFlagNodeItem flagNodeItem1; // NOPMD - it's injected
-  @Mock
-  private IFlagNodeItem flagNodeItem2; // NOPMD - it's injected
-
-  @Mock
-  private IExpression basicFlagExpr1; // NOPMD - it's injected
-  @Mock
-  private IExpression basicFlagExpr2; // NOPMD - it's injected
-  @Mock
-  private IExpression basicAssemblyExpr; // NOPMD - it's injected
-  @Mock
-  private IExpression basicFieldExpr; // NOPMD - it's injected
+  private IExpression basicFlagExpr1;
+  private IExpression basicFlagExpr2;
+  private IExpression basicAssemblyExpr;
+  private IExpression basicFieldExpr;
 
   @Test
   void testTwoFlags() {
     Class<INodeItem> baseType = INodeItem.class;
+    basicFlagExpr1 = context.mock(IExpression.class, "basicFlagExpr1");
+    basicFlagExpr2 = context.mock(IExpression.class, "basicFlagExpr2");
 
     context.checking(new Expectations() {
       { // NOPMD - intentional
@@ -64,6 +61,8 @@ class ExpressionUtilsTest {
   @Test
   void testFlagAndAssembly() {
     Class<INodeItem> baseType = INodeItem.class;
+    basicFlagExpr1 = context.mock(IExpression.class, "basicFlagExpr1");
+    basicAssemblyExpr = context.mock(IExpression.class, "basicAssemblyExpr");
 
     context.checking(new Expectations() {
       { // NOPMD - intentional
@@ -82,6 +81,8 @@ class ExpressionUtilsTest {
   @Test
   void testFieldAndAssembly() {
     Class<INodeItem> baseType = INodeItem.class;
+    basicFieldExpr = context.mock(IExpression.class, "basicFieldExpr");
+    basicAssemblyExpr = context.mock(IExpression.class, "basicAssemblyExpr");
 
     context.checking(new Expectations() {
       { // NOPMD - intentional

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/BuildCstVisitorTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/BuildCstVisitorTest.java
@@ -59,6 +59,7 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.jmock.Mockery;
 import org.jmock.junit5.JUnit5Mockery;
+import org.jmock.lib.concurrent.Synchroniser;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -89,7 +90,11 @@ class BuildCstVisitorTest {
   private static final IEnhancedQName FLAG = IEnhancedQName.of("flag");
 
   @RegisterExtension
-  Mockery context = new JUnit5Mockery();
+  Mockery context = new JUnit5Mockery() {
+    {
+      setThreadingPolicy(new Synchroniser());
+    }
+  };
 
   @NonNull
   private static IDocumentNodeItem newTestDocument() {

--- a/databind-metaschema/src/test/java/gov/nist/secauto/metaschema/modules/sarif/SarifValidationHandlerTest.java
+++ b/databind-metaschema/src/test/java/gov/nist/secauto/metaschema/modules/sarif/SarifValidationHandlerTest.java
@@ -19,6 +19,7 @@ import gov.nist.secauto.metaschema.databind.IBindingContext;
 
 import org.jmock.Expectations;
 import org.jmock.junit5.JUnit5Mockery;
+import org.jmock.lib.concurrent.Synchroniser;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.junit.jupiter.api.Test;
@@ -42,7 +43,11 @@ import dev.harrel.jsonschema.providers.OrgJsonNode;
 
 class SarifValidationHandlerTest {
   @RegisterExtension
-  public final JUnit5Mockery context = new JUnit5Mockery();
+  public final JUnit5Mockery context = new JUnit5Mockery() {
+    {
+      setThreadingPolicy(new Synchroniser());
+    }
+  };
 
   @Test
   void testWriteToString() throws IOException {

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/DefaultBindingContext.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/DefaultBindingContext.java
@@ -60,7 +60,7 @@ import nl.talsmasoftware.lazy4j.Lazy;
  */
 @SuppressWarnings("PMD.CouplingBetweenObjects")
 public class DefaultBindingContext implements IBindingContext {
-  private static Lazy<DefaultBindingContext> singleton = Lazy.lazy(DefaultBindingContext::new);
+  private static Lazy<DefaultBindingContext> singleton = Lazy.of(DefaultBindingContext::new);
   @NonNull
   private final IModuleLoaderStrategy moduleLoaderStrategy;
   @NonNull

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/RootAssemblyBindingMatcher.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/RootAssemblyBindingMatcher.java
@@ -20,7 +20,7 @@ class RootAssemblyBindingMatcher implements IBindingMatcher {
   private final IBoundDefinitionModelAssembly definition;
   @NonNull
   private final Lazy<QName> rootQName = ObjectUtils.notNull(
-      Lazy.lazy(() -> getDefinition().getRootQName().toQName()));
+      Lazy.of(() -> getDefinition().getRootQName().toQName()));
 
   public RootAssemblyBindingMatcher(
       @NonNull IBoundDefinitionModelAssembly definition) {

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/AbstractTypeInfo.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/AbstractTypeInfo.java
@@ -20,14 +20,14 @@ abstract class AbstractTypeInfo<PARENT extends IDefinitionTypeInfo> implements I
 
   protected AbstractTypeInfo(@NonNull PARENT parentDefinition) {
     this.parentDefinition = parentDefinition;
-    this.propertyName = Lazy.lazy(() -> {
+    this.propertyName = Lazy.of(() -> {
       String baseName = ClassUtils.toPropertyName(getBaseName());
       IDefinitionTypeInfo parent = getParentTypeInfo();
 
       // first check if a property already exists with the same name
       return parent.getTypeResolver().getPropertyName(parent, baseName);
     });
-    this.fieldName = Lazy.lazy(() -> "_" + ClassUtils.toVariableName(getPropertyName()));
+    this.fieldName = Lazy.of(() -> "_" + ClassUtils.toVariableName(getPropertyName()));
   }
 
   @Override

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/def/AbstractModelDefinitionTypeInfo.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/def/AbstractModelDefinitionTypeInfo.java
@@ -56,7 +56,7 @@ public abstract class AbstractModelDefinitionTypeInfo<DEF extends IModelDefiniti
     this.className = typeResolver.getClassName(definition);
     this.baseClassName = typeResolver.getBaseClassName(definition);
     this.superinterfaces = typeResolver.getSuperinterfaces(definition);
-    this.flagTypeInfos = ObjectUtils.notNull(Lazy.lazy(() -> flags()
+    this.flagTypeInfos = ObjectUtils.notNull(Lazy.of(() -> flags()
         .collect(CustomCollectors.toMap(
             ITypeInfo::getPropertyName,
             CustomCollectors.identity(),

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/def/AssemblyDefinitionTypeInfoImpl.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/def/AssemblyDefinitionTypeInfoImpl.java
@@ -43,7 +43,7 @@ class AssemblyDefinitionTypeInfoImpl
 
   public AssemblyDefinitionTypeInfoImpl(@NonNull IAssemblyDefinition definition, @NonNull ITypeResolver typeResolver) {
     super(definition, typeResolver);
-    this.instanceToTypeInfoMap = ObjectUtils.notNull(Lazy.lazy(() -> Stream.concat(
+    this.instanceToTypeInfoMap = ObjectUtils.notNull(Lazy.of(() -> Stream.concat(
         getFlagInstanceTypeInfos().stream(),
         processModel(definition))
         .collect(CustomCollectors.toMap(
@@ -56,7 +56,7 @@ class AssemblyDefinitionTypeInfoImpl
               return ObjectUtils.notNull(v2);
             },
             LinkedHashMap::new))));
-    this.propertyNameToTypeInfoMap = ObjectUtils.notNull(Lazy.lazy(() -> getInstanceTypeInfoMap().values().stream()
+    this.propertyNameToTypeInfoMap = ObjectUtils.notNull(Lazy.of(() -> getInstanceTypeInfoMap().values().stream()
         .collect(Collectors.toMap(
             IInstanceTypeInfo::getPropertyName,
             Function.identity(),

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/def/FieldDefinitionTypeInfoImpl.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/def/FieldDefinitionTypeInfoImpl.java
@@ -39,7 +39,7 @@ class FieldDefinitionTypeInfoImpl
 
   public FieldDefinitionTypeInfoImpl(@NonNull IFieldDefinition definition, @NonNull ITypeResolver typeResolver) {
     super(definition, typeResolver);
-    this.instanceToTypeInfoMap = ObjectUtils.notNull(Lazy.lazy(() -> getFlagInstanceTypeInfos().stream()
+    this.instanceToTypeInfoMap = ObjectUtils.notNull(Lazy.of(() -> getFlagInstanceTypeInfos().stream()
         .collect(CustomCollectors.toMap(
             IFlagInstanceTypeInfo::getInstance,
             CustomCollectors.identity(),
@@ -50,7 +50,7 @@ class FieldDefinitionTypeInfoImpl
               return ObjectUtils.notNull(v2);
             },
             LinkedHashMap::new))));
-    this.propertyNameToTypeInfoMap = ObjectUtils.notNull(Lazy.lazy(() -> Stream.concat(
+    this.propertyNameToTypeInfoMap = ObjectUtils.notNull(Lazy.of(() -> Stream.concat(
         getInstanceTypeInfoMap().values().stream(),
         Stream.of((IPropertyTypeInfo) IFieldValueTypeInfo.newTypeInfo(this)))
         .collect(Collectors.toMap(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/json/DefaultJsonDeserializer.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/json/DefaultJsonDeserializer.java
@@ -55,7 +55,7 @@ public class DefaultJsonDeserializer<CLASS extends IBoundObject>
    * {@link JsonParser}.
    */
   protected final void resetFactory() {
-    this.factory = Lazy.lazy(this::newFactoryInstance);
+    this.factory = Lazy.of(this::newFactoryInstance);
   }
 
   @Override

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/json/DefaultJsonSerializer.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/json/DefaultJsonSerializer.java
@@ -40,7 +40,7 @@ public class DefaultJsonSerializer<CLASS extends IBoundObject>
   }
 
   protected final void resetFactory() {
-    this.factory = Lazy.lazy(this::newFactoryInstance);
+    this.factory = Lazy.of(this::newFactoryInstance);
   }
 
   @Override

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/xml/DefaultXmlDeserializer.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/xml/DefaultXmlDeserializer.java
@@ -73,7 +73,7 @@ public class DefaultXmlDeserializer<CLASS extends IBoundObject>
    * {@link XMLInputFactory2}.
    */
   protected final void resetFactory() {
-    this.factory = Lazy.lazy(this::newFactoryInstance);
+    this.factory = Lazy.of(this::newFactoryInstance);
   }
 
   @Override

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/xml/DefaultXmlSerializer.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/xml/DefaultXmlSerializer.java
@@ -45,7 +45,7 @@ public class DefaultXmlSerializer<CLASS extends IBoundObject>
   }
 
   protected final void resetFactory() {
-    this.factory = Lazy.lazy(this::newFactoryInstance);
+    this.factory = Lazy.of(this::newFactoryInstance);
   }
 
   @Override

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/yaml/YamlOperations.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/yaml/YamlOperations.java
@@ -25,15 +25,17 @@ import java.util.Map;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class YamlOperations {
-  private static final Yaml YAML_PARSER;
-
-  static {
+  /**
+   * Thread-local Yaml parser to ensure thread safety. SnakeYAML's Yaml class is
+   * not thread-safe, so each thread needs its own instance.
+   */
+  private static final ThreadLocal<Yaml> YAML_PARSER = ThreadLocal.withInitial(() -> {
     LoaderOptions loaderOptions = new LoaderOptions();
     loaderOptions.setCodePointLimit(Integer.MAX_VALUE - 1); // 2GB
     Constructor constructor = new Constructor(loaderOptions);
     DumperOptions dumperOptions = new DumperOptions();
     Representer representer = new Representer(dumperOptions);
-    YAML_PARSER = new Yaml(constructor, representer, dumperOptions, loaderOptions, new Resolver() {
+    return new Yaml(constructor, representer, dumperOptions, loaderOptions, new Resolver() {
       @Override
       protected void addImplicitResolvers() {
         addImplicitResolver(Tag.BOOL, BOOL, "yYnNtTfFoO");
@@ -45,7 +47,7 @@ public final class YamlOperations {
         // addImplicitResolver(Tag.TIMESTAMP, TIMESTAMP, "0123456789");
       }
     });
-  }
+  });
 
   private YamlOperations() {
     // disable construction
@@ -65,7 +67,7 @@ public final class YamlOperations {
   @NonNull
   public static Map<String, Object> parseYaml(URI target) throws IOException {
     try (BufferedInputStream is = new BufferedInputStream(ObjectUtils.notNull(target.toURL().openStream()))) {
-      return (Map<String, Object>) YAML_PARSER.load(is);
+      return (Map<String, Object>) YAML_PARSER.get().load(is);
     }
   }
 

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/AbstractBoundModule.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/AbstractBoundModule.java
@@ -60,7 +60,7 @@ public abstract class AbstractBoundModule
       @NonNull IBindingContext bindingContext) {
     super(importedModules);
     this.bindingContext = bindingContext;
-    this.assemblyDefinitions = ObjectUtils.notNull(Lazy.lazy(() -> Arrays.stream(getAssemblyClasses())
+    this.assemblyDefinitions = ObjectUtils.notNull(Lazy.of(() -> Arrays.stream(getAssemblyClasses())
         .map(clazz -> {
           assert clazz != null;
           return (IBoundDefinitionModelAssembly) ObjectUtils
@@ -69,7 +69,7 @@ public abstract class AbstractBoundModule
         .collect(Collectors.toUnmodifiableMap(
             def -> def.getDefinitionQName().getIndexPosition(),
             Function.identity()))));
-    this.fieldDefinitions = ObjectUtils.notNull(Lazy.lazy(() -> Arrays.stream(getFieldClasses())
+    this.fieldDefinitions = ObjectUtils.notNull(Lazy.of(() -> Arrays.stream(getFieldClasses())
         .map(clazz -> {
           assert clazz != null;
           return (IBoundDefinitionModelField<?>) ObjectUtils
@@ -78,7 +78,7 @@ public abstract class AbstractBoundModule
         .collect(Collectors.toUnmodifiableMap(
             def -> def.getDefinitionQName().getIndexPosition(),
             Function.identity()))));
-    this.staticContext = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.staticContext = ObjectUtils.notNull(Lazy.of(() -> {
       StaticContext.Builder builder = StaticContext.builder()
           .defaultModelNamespace(getXmlNamespace());
 

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/impl/AbstractBoundDefinitionModelComplex.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/impl/AbstractBoundDefinitionModelComplex.java
@@ -51,10 +51,10 @@ public abstract class AbstractBoundDefinitionModelComplex<A extends Annotation>
     this.annotation = annotation;
     this.bindingContext = bindingContext;
     this.module = module;
-    this.qname = ObjectUtils.notNull(Lazy.lazy(() -> ModuleUtils.parseModelName(
+    this.qname = ObjectUtils.notNull(Lazy.of(() -> ModuleUtils.parseModelName(
         getContainingModule(),
         getEffectiveName())));
-    this.definitionQName = ObjectUtils.notNull(Lazy.lazy(() -> ModuleUtils.parseModelName(
+    this.definitionQName = ObjectUtils.notNull(Lazy.of(() -> ModuleUtils.parseModelName(
         getContainingModule(),
         getName())));
     this.beforeDeserializeMethod = ClassIntrospector.getMatchingMethod(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/impl/DefinitionAssembly.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/impl/DefinitionAssembly.java
@@ -102,14 +102,14 @@ public final class DefinitionAssembly
     super(clazz, annotation, module, bindingContext);
 
     String rootLocalName = ModelUtil.resolveNoneOrDefault(getAnnotation().rootName(), null);
-    this.xmlRootQName = ObjectUtils.notNull(Lazy.lazy(() -> rootLocalName == null
+    this.xmlRootQName = ObjectUtils.notNull(Lazy.of(() -> rootLocalName == null
         ? null
         : ModuleUtils.parseModelName(getContainingModule(), rootLocalName)));
-    this.flagContainer = ObjectUtils.notNull(Lazy.lazy(() -> new FlagContainerSupport(this, null)));
-    this.modelContainer = ObjectUtils.notNull(Lazy.lazy(() -> AssemblyModelGenerator.of(this)));
+    this.flagContainer = ObjectUtils.notNull(Lazy.of(() -> new FlagContainerSupport(this, null)));
+    this.modelContainer = ObjectUtils.notNull(Lazy.of(() -> AssemblyModelGenerator.of(this)));
 
     ISource source = module.getSource();
-    this.constraints = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.constraints = ObjectUtils.notNull(Lazy.of(() -> {
       IModelConstrained retval = new AssemblyConstraintSet(source);
       ValueConstraints valueAnnotation = getAnnotation().valueConstraints();
       ConstraintSupport.parse(valueAnnotation, source, retval);
@@ -118,9 +118,9 @@ public final class DefinitionAssembly
       ConstraintSupport.parse(assemblyAnnotation, source, retval);
       return retval;
     }));
-    this.jsonProperties = ObjectUtils.notNull(Lazy.lazy(() -> getJsonProperties(null)));
+    this.jsonProperties = ObjectUtils.notNull(Lazy.of(() -> getJsonProperties(null)));
     this.properties = ObjectUtils.notNull(
-        Lazy.lazy(() -> CollectionUtil.unmodifiableMap(ObjectUtils.notNull(
+        Lazy.of(() -> CollectionUtil.unmodifiableMap(ObjectUtils.notNull(
             Arrays.stream(annotation.properties())
                 .map(ModelUtil::toPropertyEntry)
                 .collect(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/impl/DefinitionField.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/impl/DefinitionField.java
@@ -129,23 +129,23 @@ public final class DefinitionField
     }
     FieldSupport.bindField(field);
     this.fieldValue = new FieldValue(field, BoundFieldValue.class, bindingContext);
-    this.flagContainer = ObjectUtils.notNull(Lazy.lazy(() -> new FlagContainerSupport(this, this::handleFlagInstance)));
+    this.flagContainer = ObjectUtils.notNull(Lazy.of(() -> new FlagContainerSupport(this, this::handleFlagInstance)));
 
     ISource source = module.getSource();
 
-    this.constraints = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.constraints = ObjectUtils.notNull(Lazy.of(() -> {
       IModelConstrained retval = new AssemblyConstraintSet(source);
       ValueConstraints valueAnnotation = getAnnotation().valueConstraints();
       ConstraintSupport.parse(valueAnnotation, source, retval);
       return retval;
     }));
-    this.jsonProperties = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.jsonProperties = ObjectUtils.notNull(Lazy.of(() -> {
       IBoundInstanceFlag jsonValueKey = getJsonValueKeyFlagInstance();
       Predicate<IBoundInstanceFlag> flagFilter = jsonValueKey == null ? null : flag -> !flag.equals(jsonValueKey);
       return getJsonProperties(flagFilter);
     }));
     this.properties = ObjectUtils.notNull(
-        Lazy.lazy(() -> CollectionUtil.unmodifiableMap(ObjectUtils.notNull(
+        Lazy.of(() -> CollectionUtil.unmodifiableMap(ObjectUtils.notNull(
             Arrays.stream(annotation.properties())
                 .map(ModelUtil::toPropertyEntry)
                 .collect(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/impl/InstanceFlagInline.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/impl/InstanceFlagInline.java
@@ -83,14 +83,14 @@ public class InstanceFlagInline
     IModule module = parent.getContainingModule();
     ISource source = module.getSource();
 
-    this.constraints = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.constraints = ObjectUtils.notNull(Lazy.of(() -> {
       IValueConstrained retval = new ValueConstraintSet(source);
       ValueConstraints valueAnnotation = getAnnotation().valueConstraints();
       ConstraintSupport.parse(valueAnnotation, source, retval);
       return retval;
     }));
     this.properties = ObjectUtils.notNull(
-        Lazy.lazy(() -> CollectionUtil.unmodifiableMap(ObjectUtils.notNull(
+        Lazy.of(() -> CollectionUtil.unmodifiableMap(ObjectUtils.notNull(
             Arrays.stream(annotation.properties())
                 .map(ModelUtil::toPropertyEntry)
                 .collect(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/impl/InstanceModelAssemblyComplex.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/impl/InstanceModelAssemblyComplex.java
@@ -113,15 +113,15 @@ public final class InstanceModelAssemblyComplex
     this.javaField = javaField;
     this.annotation = annotation;
     this.groupAs = groupAs;
-    this.collectionInfo = ObjectUtils.notNull(Lazy.lazy(() -> IModelInstanceCollectionInfo.of(this)));
+    this.collectionInfo = ObjectUtils.notNull(Lazy.of(() -> IModelInstanceCollectionInfo.of(this)));
     this.definition = definition;
-    this.jsonProperties = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.jsonProperties = ObjectUtils.notNull(Lazy.of(() -> {
       IBoundInstanceFlag jsonKey = getEffectiveJsonKey();
       Predicate<IBoundInstanceFlag> flagFilter = jsonKey == null ? null : flag -> !jsonKey.equals(flag);
       return getDefinition().getJsonProperties(flagFilter);
     }));
     this.properties = ObjectUtils.notNull(
-        Lazy.lazy(() -> CollectionUtil.unmodifiableMap(ObjectUtils.notNull(
+        Lazy.of(() -> CollectionUtil.unmodifiableMap(ObjectUtils.notNull(
             Arrays.stream(annotation.properties())
                 .map(ModelUtil::toPropertyEntry)
                 .collect(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/impl/InstanceModelChoiceGroup.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/impl/InstanceModelChoiceGroup.java
@@ -143,23 +143,23 @@ public final class InstanceModelChoiceGroup
     this.javaField = javaField;
     this.annotation = annotation;
     this.groupAs = groupAs;
-    this.collectionInfo = ObjectUtils.notNull(Lazy.lazy(() -> IModelInstanceCollectionInfo.of(this)));
-    this.modelContainer = ObjectUtils.notNull(Lazy.lazy(() -> newContainerModel(
+    this.collectionInfo = ObjectUtils.notNull(Lazy.of(() -> IModelInstanceCollectionInfo.of(this)));
+    this.modelContainer = ObjectUtils.notNull(Lazy.of(() -> newContainerModel(
         this.annotation.assemblies(),
         this.annotation.fields(),
         this)));
-    this.classToInstanceMap = ObjectUtils.notNull(Lazy.lazy(() -> Collections.unmodifiableMap(
+    this.classToInstanceMap = ObjectUtils.notNull(Lazy.of(() -> Collections.unmodifiableMap(
         getNamedModelInstances().stream()
             .map(instance -> instance)
             .collect(Collectors.toMap(
                 item -> item.getDefinition().getBoundClass(),
                 CustomCollectors.identity())))));
-    this.qnameToInstanceMap = ObjectUtils.notNull(Lazy.lazy(() -> Collections.unmodifiableMap(
+    this.qnameToInstanceMap = ObjectUtils.notNull(Lazy.of(() -> Collections.unmodifiableMap(
         getNamedModelInstances().stream()
             .collect(Collectors.toMap(
                 IBoundInstanceModelGroupedNamed::getQName,
                 CustomCollectors.identity())))));
-    this.discriminatorToInstanceMap = ObjectUtils.notNull(Lazy.lazy(() -> Collections.unmodifiableMap(
+    this.discriminatorToInstanceMap = ObjectUtils.notNull(Lazy.of(() -> Collections.unmodifiableMap(
         getNamedModelInstances().stream()
             .collect(Collectors.toMap(
                 IBoundInstanceModelGroupedNamed::getEffectiveDisciminatorValue,

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/impl/InstanceModelFieldComplex.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/impl/InstanceModelFieldComplex.java
@@ -143,10 +143,10 @@ public final class InstanceModelFieldComplex
     FieldSupport.bindField(javaField);
     this.javaField = javaField;
     this.annotation = annotation;
-    this.collectionInfo = ObjectUtils.notNull(Lazy.lazy(() -> IModelInstanceCollectionInfo.of(this)));
+    this.collectionInfo = ObjectUtils.notNull(Lazy.of(() -> IModelInstanceCollectionInfo.of(this)));
     this.groupAs = groupAs;
     this.definition = definition;
-    this.defaultValue = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.defaultValue = ObjectUtils.notNull(Lazy.of(() -> {
       Object retval = null;
       if (getMaxOccurs() == 1) {
         IBoundFieldValue fieldValue = definition.getFieldValue();
@@ -168,7 +168,7 @@ public final class InstanceModelFieldComplex
       }
       return retval;
     }));
-    this.jsonProperties = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.jsonProperties = ObjectUtils.notNull(Lazy.of(() -> {
       Predicate<IBoundInstanceFlag> flagFilter = null;
       IBoundInstanceFlag jsonKey = getEffectiveJsonKey();
       if (jsonKey != null) {
@@ -177,7 +177,7 @@ public final class InstanceModelFieldComplex
       return definition.getJsonProperties(flagFilter);
     }));
     this.properties = ObjectUtils.notNull(
-        Lazy.lazy(() -> CollectionUtil.unmodifiableMap(ObjectUtils.notNull(
+        Lazy.of(() -> CollectionUtil.unmodifiableMap(ObjectUtils.notNull(
             Arrays.stream(annotation.properties())
                 .map(ModelUtil::toPropertyEntry)
                 .collect(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/impl/InstanceModelFieldScalar.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/impl/InstanceModelFieldScalar.java
@@ -121,7 +121,7 @@ public final class InstanceModelFieldScalar
     FieldSupport.bindField(javaField);
     this.javaField = javaField;
     this.annotation = annotation;
-    this.collectionInfo = ObjectUtils.notNull(Lazy.lazy(() -> IModelInstanceCollectionInfo.of(this)));
+    this.collectionInfo = ObjectUtils.notNull(Lazy.of(() -> IModelInstanceCollectionInfo.of(this)));
     this.groupAs = groupAs;
     this.javaTypeAdapter = ModelUtil.getDataTypeAdapter(
         annotation.typeAdapter(),
@@ -131,14 +131,14 @@ public final class InstanceModelFieldScalar
     IModule module = getContainingModule();
     ISource source = module.getSource();
 
-    this.constraints = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.constraints = ObjectUtils.notNull(Lazy.of(() -> {
       IValueConstrained retval = new ValueConstraintSet(source);
       ValueConstraints valueAnnotation = annotation.valueConstraints();
       ConstraintSupport.parse(valueAnnotation, module.getSource(), retval);
       return retval;
     }));
     this.properties = ObjectUtils.notNull(
-        Lazy.lazy(() -> CollectionUtil.unmodifiableMap(ObjectUtils.notNull(
+        Lazy.of(() -> CollectionUtil.unmodifiableMap(ObjectUtils.notNull(
             Arrays.stream(annotation.properties())
                 .map(ModelUtil::toPropertyEntry)
                 .collect(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/impl/InstanceModelGroupedAssembly.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/impl/InstanceModelGroupedAssembly.java
@@ -70,9 +70,9 @@ public class InstanceModelGroupedAssembly
     // Predicate<IBoundInstanceFlag> flagFilter = jsonKey == null ? null : (flag) ->
     // !jsonKey.equals(flag);
     // return getDefinition().getJsonProperties(flagFilter);
-    this.jsonProperties = ObjectUtils.notNull(Lazy.lazy(() -> getDefinition().getJsonProperties(null)));
+    this.jsonProperties = ObjectUtils.notNull(Lazy.of(() -> getDefinition().getJsonProperties(null)));
     this.properties = ObjectUtils.notNull(
-        Lazy.lazy(() -> CollectionUtil.unmodifiableMap(ObjectUtils.notNull(
+        Lazy.of(() -> CollectionUtil.unmodifiableMap(ObjectUtils.notNull(
             Arrays.stream(annotation.properties())
                 .map(ModelUtil::toPropertyEntry)
                 .collect(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/impl/InstanceModelGroupedFieldComplex.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/impl/InstanceModelGroupedFieldComplex.java
@@ -69,7 +69,7 @@ public class InstanceModelGroupedFieldComplex
     super(container);
     this.annotation = annotation;
     this.definition = definition;
-    this.jsonProperties = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.jsonProperties = ObjectUtils.notNull(Lazy.of(() -> {
       Predicate<IBoundInstanceFlag> flagFilter = null;
       IBoundInstanceFlag jsonKey = getEffectiveJsonKey();
       if (jsonKey != null) {
@@ -84,7 +84,7 @@ public class InstanceModelGroupedFieldComplex
       return getDefinition().getJsonProperties(flagFilter);
     }));
     this.properties = ObjectUtils.notNull(
-        Lazy.lazy(() -> CollectionUtil.unmodifiableMap(ObjectUtils.notNull(
+        Lazy.of(() -> CollectionUtil.unmodifiableMap(ObjectUtils.notNull(
             Arrays.stream(annotation.properties())
                 .map(ModelUtil::toPropertyEntry)
                 .collect(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/BindingModuleLoader.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/BindingModuleLoader.java
@@ -62,7 +62,7 @@ public class BindingModuleLoader
   public BindingModuleLoader(
       @NonNull IBindingContext bindingContext,
       @NonNull ModuleLoadingPostProcessor postProcessor) {
-    this.loader = Lazy.lazy(bindingContext::newBoundLoader);
+    this.loader = Lazy.of(bindingContext::newBoundLoader);
     this.postProcessor = postProcessor;
   }
 

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/BindingModule.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/BindingModule.java
@@ -90,7 +90,7 @@ public class BindingModule
 
     this.binding = binding;
 
-    this.staticContext = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.staticContext = ObjectUtils.notNull(Lazy.of(() -> {
       StaticContext.Builder builder = StaticContext.builder()
           .baseUri(resource)
           .defaultModelNamespace(getXmlNamespace());
@@ -102,11 +102,11 @@ public class BindingModule
     }));
 
     INodeItemFactory nodeItemFactory = INodeItemFactory.instance();
-    this.definitions = ObjectUtils.notNull(Lazy.lazy(() -> new Definitions(resource, rootDefinition, nodeItemFactory)));
+    this.definitions = ObjectUtils.notNull(Lazy.of(() -> new Definitions(resource, rootDefinition, nodeItemFactory)));
     this.documentNodeItem
-        = ObjectUtils.notNull(Lazy.lazy(() -> nodeItemFactory.newDocumentNodeItem(rootDefinition, resource, binding)));
+        = ObjectUtils.notNull(Lazy.of(() -> nodeItemFactory.newDocumentNodeItem(rootDefinition, resource, binding)));
     this.moduleNodeItem
-        = ObjectUtils.notNull(Lazy.lazy(() -> nodeItemFactory.newModuleNodeItem(this)));
+        = ObjectUtils.notNull(Lazy.of(() -> nodeItemFactory.newModuleNodeItem(this)));
     this.source = ISource.moduleSource(this);
   }
 

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/DefinitionAssemblyGlobal.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/DefinitionAssemblyGlobal.java
@@ -95,7 +95,7 @@ public class DefinitionAssemblyGlobal
     super(module);
     this.binding = binding;
     this.properties = ModelSupport.parseProperties(ObjectUtils.requireNonNull(binding.getProps()));
-    this.flagContainer = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.flagContainer = ObjectUtils.notNull(Lazy.of(() -> {
       JsonKey jsonKey = getBinding().getJsonKey();
       return FlagContainerSupport.newFlagContainer(
           binding.getFlags(),
@@ -103,7 +103,7 @@ public class DefinitionAssemblyGlobal
           this,
           jsonKey == null ? null : jsonKey.getFlagRef());
     }));
-    this.modelContainer = ObjectUtils.notNull(Lazy.lazy(() -> AssemblyModelGenerator.of(
+    this.modelContainer = ObjectUtils.notNull(Lazy.of(() -> AssemblyModelGenerator.of(
         binding.getModel(),
         ObjectUtils.requireNonNull(bindingInstance.getDefinition()
             .getAssemblyInstanceByName(XmlModuleConstants.MODEL_QNAME.getIndexPosition())),
@@ -112,7 +112,7 @@ public class DefinitionAssemblyGlobal
 
     ISource source = module.getSource();
 
-    this.modelConstraints = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.modelConstraints = ObjectUtils.notNull(Lazy.of(() -> {
       IModelConstrained retval = new AssemblyConstraintSet(source);
       AssemblyConstraints constraints = getBinding().getConstraint();
       if (constraints != null) {
@@ -120,7 +120,7 @@ public class DefinitionAssemblyGlobal
       }
       return retval;
     }));
-    this.boundNodeItem = ObjectUtils.notNull(Lazy.lazy(() -> ObjectUtils.requireNonNull(ModelSupport.toNodeItem(
+    this.boundNodeItem = ObjectUtils.notNull(Lazy.of(() -> ObjectUtils.requireNonNull(ModelSupport.toNodeItem(
         module,
         bindingInstance.getQName(),
         position))));

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/DefinitionFieldGlobal.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/DefinitionFieldGlobal.java
@@ -67,7 +67,7 @@ public class DefinitionFieldGlobal
         binding.getAsType(),
         source);
     this.defaultValue = ModelSupport.defaultValue(binding.getDefault(), this.javaTypeAdapter);
-    this.flagContainer = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.flagContainer = ObjectUtils.notNull(Lazy.of(() -> {
       JsonKey jsonKey = binding.getJsonKey();
       return FlagContainerSupport.newFlagContainer(
           binding.getFlags(),
@@ -75,7 +75,7 @@ public class DefinitionFieldGlobal
           this,
           jsonKey == null ? null : jsonKey.getFlagRef());
     }));
-    this.valueConstraints = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.valueConstraints = ObjectUtils.notNull(Lazy.of(() -> {
       IValueConstrained retval = new ValueConstraintSet(source);
       FieldConstraints constraints = binding.getConstraint();
       if (constraints != null) {
@@ -83,7 +83,7 @@ public class DefinitionFieldGlobal
       }
       return retval;
     }));
-    this.boundNodeItem = ObjectUtils.notNull(Lazy.lazy(() -> ObjectUtils.requireNonNull(ModelSupport.toNodeItem(
+    this.boundNodeItem = ObjectUtils.notNull(Lazy.of(() -> ObjectUtils.requireNonNull(ModelSupport.toNodeItem(
         module,
         bindingInstance.getQName(),
         position))));

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/DefinitionFlagGlobal.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/DefinitionFlagGlobal.java
@@ -73,7 +73,7 @@ public class DefinitionFlagGlobal
         binding.getAsType(),
         source);
     this.defaultValue = ModelSupport.defaultValue(binding.getDefault(), this.javaTypeAdapter);
-    this.valueConstraints = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.valueConstraints = ObjectUtils.notNull(Lazy.of(() -> {
       IValueConstrained retval = new ValueConstraintSet(source);
       FlagConstraints constraints = binding.getConstraint();
       if (constraints != null) {
@@ -81,7 +81,7 @@ public class DefinitionFlagGlobal
       }
       return retval;
     }));
-    this.boundNodeItem = ObjectUtils.notNull(Lazy.lazy(() -> ObjectUtils.requireNonNull(ModelSupport.toNodeItem(
+    this.boundNodeItem = ObjectUtils.notNull(Lazy.of(() -> ObjectUtils.requireNonNull(ModelSupport.toNodeItem(
         module,
         bindingInstance.getQName(),
         position))));

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/InstanceFlagInline.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/InstanceFlagInline.java
@@ -66,7 +66,7 @@ public class InstanceFlagInline
         binding.getAsType(),
         source);
     this.defaultValue = ModelSupport.defaultValue(binding.getDefault(), this.javaTypeAdapter);
-    this.valueConstraints = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.valueConstraints = ObjectUtils.notNull(Lazy.of(() -> {
       IValueConstrained retval = new ValueConstraintSet(source);
       FlagConstraints constraints = binding.getConstraint();
       if (constraints != null) {
@@ -75,7 +75,7 @@ public class InstanceFlagInline
       return retval;
     }));
     this.boundNodeItem = ObjectUtils.notNull(
-        Lazy.lazy(() -> (IAssemblyNodeItem) ObjectUtils.notNull(parent.getSourceNodeItem())
+        Lazy.of(() -> (IAssemblyNodeItem) ObjectUtils.notNull(parent.getSourceNodeItem())
             .getModelItemsByName(bindingInstance.getQName())
             .get(position)));
   }

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/InstanceFlagReference.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/InstanceFlagReference.java
@@ -57,7 +57,7 @@ public class InstanceFlagReference
     this.properties = ModelSupport.parseProperties(ObjectUtils.requireNonNull(binding.getProps()));
     this.defaultValue = ModelSupport.defaultValue(binding.getDefault(), definition.getJavaTypeAdapter());
     this.boundNodeItem = ObjectUtils.notNull(
-        Lazy.lazy(() -> (IAssemblyNodeItem) ObjectUtils.notNull(parent.getSourceNodeItem())
+        Lazy.of(() -> (IAssemblyNodeItem) ObjectUtils.notNull(parent.getSourceNodeItem())
             .getModelItemsByName(bindingInstance.getQName())
             .get(position)));
   }

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/InstanceModelAssemblyInline.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/InstanceModelAssemblyInline.java
@@ -107,10 +107,10 @@ public class InstanceModelAssemblyInline
     this.properties = ModelSupport.parseProperties(ObjectUtils.requireNonNull(binding.getProps()));
     this.groupAs = ModelSupport.groupAs(binding.getGroupAs(), parent.getOwningDefinition().getContainingModule());
     this.boundNodeItem = ObjectUtils.notNull(
-        Lazy.lazy(() -> (IAssemblyNodeItem) ObjectUtils.notNull(getContainingDefinition().getSourceNodeItem())
+        Lazy.of(() -> (IAssemblyNodeItem) ObjectUtils.notNull(getContainingDefinition().getSourceNodeItem())
             .getModelItemsByName(bindingInstance.getQName())
             .get(position)));
-    this.flagContainer = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.flagContainer = ObjectUtils.notNull(Lazy.of(() -> {
       JsonKey jsonKey = getBinding().getJsonKey();
       return FlagContainerSupport.newFlagContainer(
           binding.getFlags(),
@@ -118,7 +118,7 @@ public class InstanceModelAssemblyInline
           this,
           jsonKey == null ? null : jsonKey.getFlagRef());
     }));
-    this.modelContainer = ObjectUtils.notNull(Lazy.lazy(() -> AssemblyModelGenerator.of(
+    this.modelContainer = ObjectUtils.notNull(Lazy.of(() -> AssemblyModelGenerator.of(
         binding.getModel(),
         ObjectUtils.requireNonNull(bindingInstance.getDefinition()
             .getAssemblyInstanceByName(XmlModuleConstants.MODEL_QNAME.getIndexPosition())),
@@ -127,7 +127,7 @@ public class InstanceModelAssemblyInline
 
     ISource source = parent.getOwningDefinition().getContainingModule().getSource();
 
-    this.modelConstraints = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.modelConstraints = ObjectUtils.notNull(Lazy.of(() -> {
       IModelConstrained retval = new AssemblyConstraintSet(source);
       AssemblyConstraints constraints = getBinding().getConstraint();
       if (constraints != null) {

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/InstanceModelAssemblyReference.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/InstanceModelAssemblyReference.java
@@ -75,7 +75,7 @@ public class InstanceModelAssemblyReference
     this.properties = ModelSupport.parseProperties(ObjectUtils.requireNonNull(binding.getProps()));
     this.groupAs = ModelSupport.groupAs(binding.getGroupAs(), parent.getOwningDefinition().getContainingModule());
     this.boundNodeItem = ObjectUtils.notNull(
-        Lazy.lazy(() -> (IAssemblyNodeItem) ObjectUtils.notNull(getContainingModule().getSourceNodeItem())
+        Lazy.of(() -> (IAssemblyNodeItem) ObjectUtils.notNull(getContainingModule().getSourceNodeItem())
             .getModelItemsByName(bindingInstance.getQName())
             .get(position)));
   }

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/InstanceModelChoice.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/InstanceModelChoice.java
@@ -49,13 +49,13 @@ public class InstanceModelChoice
       @NonNull IBindingDefinitionModelAssembly parent,
       @NonNull INodeItemFactory nodeItemFactory) {
     super(parent);
-    this.modelContainer = ObjectUtils.notNull(Lazy.lazy(() -> ChoiceModelGenerator.of(
+    this.modelContainer = ObjectUtils.notNull(Lazy.of(() -> ChoiceModelGenerator.of(
         binding,
         bindingInstance,
         this,
         nodeItemFactory)));
     this.boundNodeItem = ObjectUtils.notNull(
-        Lazy.lazy(() -> (IAssemblyNodeItem) ObjectUtils.notNull(getContainingDefinition().getSourceNodeItem())
+        Lazy.of(() -> (IAssemblyNodeItem) ObjectUtils.notNull(getContainingDefinition().getSourceNodeItem())
             .getModelItemsByName(bindingInstance.getQName())
             .get(position)));
   }

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/InstanceModelChoiceGroup.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/InstanceModelChoiceGroup.java
@@ -57,13 +57,13 @@ public class InstanceModelChoiceGroup
     super(parent);
     this.binding = binding;
     this.groupAs = ModelSupport.groupAs(binding.getGroupAs(), parent.getContainingModule());
-    this.modelContainer = ObjectUtils.notNull(Lazy.lazy(() -> ChoiceGroupModelGenerator.of(
+    this.modelContainer = ObjectUtils.notNull(Lazy.of(() -> ChoiceGroupModelGenerator.of(
         binding,
         bindingInstance,
         this,
         nodeItemFactory)));
     this.boundNodeItem = ObjectUtils.notNull(
-        Lazy.lazy(() -> (IAssemblyNodeItem) ObjectUtils.notNull(getContainingDefinition().getSourceNodeItem())
+        Lazy.of(() -> (IAssemblyNodeItem) ObjectUtils.notNull(getContainingDefinition().getSourceNodeItem())
             .getModelItemsByName(bindingInstance.getQName())
             .get(position)));
   }

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/InstanceModelFieldInline.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/InstanceModelFieldInline.java
@@ -78,7 +78,7 @@ public class InstanceModelFieldInline
     this.properties = ModelSupport.parseProperties(ObjectUtils.requireNonNull(binding.getProps()));
     this.groupAs = ModelSupport.groupAs(binding.getGroupAs(), parent.getOwningDefinition().getContainingModule());
     this.boundNodeItem = ObjectUtils.notNull(
-        Lazy.lazy(() -> (IAssemblyNodeItem) ObjectUtils.notNull(getContainingDefinition().getSourceNodeItem())
+        Lazy.of(() -> (IAssemblyNodeItem) ObjectUtils.notNull(getContainingDefinition().getSourceNodeItem())
             .getModelItemsByName(bindingInstance.getQName())
             .get(position)));
 
@@ -88,7 +88,7 @@ public class InstanceModelFieldInline
         binding.getAsType(),
         source);
     this.defaultValue = ModelSupport.defaultValue(binding.getDefault(), this.javaTypeAdapter);
-    this.flagContainer = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.flagContainer = ObjectUtils.notNull(Lazy.of(() -> {
       JsonKey jsonKey = binding.getJsonKey();
       return FlagContainerSupport.newFlagContainer(
           binding.getFlags(),
@@ -96,7 +96,7 @@ public class InstanceModelFieldInline
           this,
           jsonKey == null ? null : jsonKey.getFlagRef());
     }));
-    this.valueConstraints = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.valueConstraints = ObjectUtils.notNull(Lazy.of(() -> {
       IValueConstrained retval = new ValueConstraintSet(source);
       FieldConstraints constraints = binding.getConstraint();
       if (constraints != null) {

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/InstanceModelFieldReference.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/InstanceModelFieldReference.java
@@ -78,7 +78,7 @@ public class InstanceModelFieldReference
     this.properties = ModelSupport.parseProperties(ObjectUtils.requireNonNull(binding.getProps()));
     this.groupAs = ModelSupport.groupAs(binding.getGroupAs(), parent.getOwningDefinition().getContainingModule());
     this.boundNodeItem = ObjectUtils.notNull(
-        Lazy.lazy(() -> (IAssemblyNodeItem) ObjectUtils.notNull(getContainingDefinition().getSourceNodeItem())
+        Lazy.of(() -> (IAssemblyNodeItem) ObjectUtils.notNull(getContainingDefinition().getSourceNodeItem())
             .getModelItemsByName(bindingInstance.getQName())
             .get(position)));
     this.defaultValue = ModelSupport.defaultValue(binding.getDefault(), definition.getJavaTypeAdapter());

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/InstanceModelGroupedAssemblyInline.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/InstanceModelGroupedAssemblyInline.java
@@ -83,12 +83,12 @@ public class InstanceModelGroupedAssemblyInline
     super(parent);
     this.binding = binding;
     this.properties = ModelSupport.parseProperties(ObjectUtils.requireNonNull(binding.getProps()));
-    this.flagContainer = ObjectUtils.notNull(Lazy.lazy(() -> FlagContainerSupport.newFlagContainer(
+    this.flagContainer = ObjectUtils.notNull(Lazy.of(() -> FlagContainerSupport.newFlagContainer(
         binding.getFlags(),
         bindingInstance,
         this,
         getParentContainer().getJsonKeyFlagInstanceName())));
-    this.modelContainer = ObjectUtils.notNull(Lazy.lazy(() -> AssemblyModelGenerator.of(
+    this.modelContainer = ObjectUtils.notNull(Lazy.of(() -> AssemblyModelGenerator.of(
         binding.getModel(),
         ObjectUtils.requireNonNull(bindingInstance.getDefinition()
             .getAssemblyInstanceByName(XmlModuleConstants.MODEL_QNAME.getIndexPosition())),
@@ -97,7 +97,7 @@ public class InstanceModelGroupedAssemblyInline
 
     ISource source = parent.getOwningDefinition().getContainingModule().getSource();
 
-    this.modelConstraints = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.modelConstraints = ObjectUtils.notNull(Lazy.of(() -> {
       IModelConstrained retval = new AssemblyConstraintSet(source);
       AssemblyConstraints constraints = binding.getConstraint();
       if (constraints != null) {
@@ -109,7 +109,7 @@ public class InstanceModelGroupedAssemblyInline
       return retval;
     }));
     this.boundNodeItem = ObjectUtils.notNull(
-        Lazy.lazy(() -> (IAssemblyNodeItem) ObjectUtils.notNull(getContainingDefinition().getSourceNodeItem())
+        Lazy.of(() -> (IAssemblyNodeItem) ObjectUtils.notNull(getContainingDefinition().getSourceNodeItem())
             .getModelItemsByName(bindingInstance.getQName())
             .get(position)));
   }

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/InstanceModelGroupedAssemblyReference.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/InstanceModelGroupedAssemblyReference.java
@@ -53,7 +53,7 @@ public class InstanceModelGroupedAssemblyReference
     this.definition = definition;
     this.properties = ModelSupport.parseProperties(ObjectUtils.requireNonNull(binding.getProps()));
     this.boundNodeItem = ObjectUtils.notNull(
-        Lazy.lazy(() -> (IAssemblyNodeItem) ObjectUtils.notNull(getContainingDefinition().getSourceNodeItem())
+        Lazy.of(() -> (IAssemblyNodeItem) ObjectUtils.notNull(getContainingDefinition().getSourceNodeItem())
             .getModelItemsByName(bindingInstance.getQName())
             .get(position)));
   }

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/InstanceModelGroupedFieldInline.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/InstanceModelGroupedFieldInline.java
@@ -76,12 +76,12 @@ public class InstanceModelGroupedFieldInline
         binding.getAsType(),
         source);
     this.defaultValue = ModelSupport.defaultValue(binding.getDefault(), this.javaTypeAdapter);
-    this.flagContainer = ObjectUtils.notNull(Lazy.lazy(() -> FlagContainerSupport.newFlagContainer(
+    this.flagContainer = ObjectUtils.notNull(Lazy.of(() -> FlagContainerSupport.newFlagContainer(
         binding.getFlags(),
         bindingInstance,
         this,
         getParentContainer().getJsonKeyFlagInstanceName())));
-    this.valueConstraints = ObjectUtils.notNull(Lazy.lazy(() -> {
+    this.valueConstraints = ObjectUtils.notNull(Lazy.of(() -> {
       IValueConstrained retval = new ValueConstraintSet(source);
       FieldConstraints constraints = binding.getConstraint();
       if (constraints != null) {
@@ -93,7 +93,7 @@ public class InstanceModelGroupedFieldInline
       return retval;
     }));
     this.boundNodeItem = ObjectUtils.notNull(
-        Lazy.lazy(() -> (IAssemblyNodeItem) ObjectUtils.notNull(getContainingDefinition().getSourceNodeItem())
+        Lazy.of(() -> (IAssemblyNodeItem) ObjectUtils.notNull(getContainingDefinition().getSourceNodeItem())
             .getModelItemsByName(bindingInstance.getQName())
             .get(position)));
   }

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/InstanceModelGroupedFieldReference.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/InstanceModelGroupedFieldReference.java
@@ -53,7 +53,7 @@ public class InstanceModelGroupedFieldReference
     this.definition = definition;
     this.properties = ModelSupport.parseProperties(ObjectUtils.requireNonNull(binding.getProps()));
     this.boundNodeItem = ObjectUtils.notNull(
-        Lazy.lazy(() -> (IAssemblyNodeItem) ObjectUtils.notNull(getContainingDefinition().getSourceNodeItem())
+        Lazy.of(() -> (IAssemblyNodeItem) ObjectUtils.notNull(getContainingDefinition().getSourceNodeItem())
             .getModelItemsByName(bindingInstance.getQName())
             .get(position)));
   }

--- a/databind/src/test/java/gov/nist/secauto/metaschema/databind/codegen/config/DefaultBindingConfigurationTest.java
+++ b/databind/src/test/java/gov/nist/secauto/metaschema/databind/codegen/config/DefaultBindingConfigurationTest.java
@@ -15,6 +15,7 @@ import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
 import org.jmock.Expectations;
 import org.jmock.junit5.JUnit5Mockery;
+import org.jmock.lib.concurrent.Synchroniser;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -31,7 +32,11 @@ class DefaultBindingConfigurationTest {
   private static final String DEFINITION__CLASS_NAME = "TheChild";
 
   @RegisterExtension
-  JUnit5Mockery context = new JUnit5Mockery();
+  JUnit5Mockery context = new JUnit5Mockery() {
+    {
+      setThreadingPolicy(new Synchroniser());
+    }
+  };
   private final IModelDefinition definition = context.mock(IModelDefinition.class);
   private final IModule module = context.mock(IModule.class);
 

--- a/databind/src/test/java/gov/nist/secauto/metaschema/databind/codegen/impl/AnnotationGeneratorTest.java
+++ b/databind/src/test/java/gov/nist/secauto/metaschema/databind/codegen/impl/AnnotationGeneratorTest.java
@@ -18,6 +18,7 @@ import gov.nist.secauto.metaschema.databind.model.annotations.BoundFlag;
 
 import org.jmock.Expectations;
 import org.jmock.junit5.JUnit5Mockery;
+import org.jmock.lib.concurrent.Synchroniser;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -27,7 +28,11 @@ import java.util.Map;
 
 class AnnotationGeneratorTest {
   @RegisterExtension
-  final JUnit5Mockery context = new JUnit5Mockery();
+  final JUnit5Mockery context = new JUnit5Mockery() {
+    {
+      setThreadingPolicy(new Synchroniser());
+    }
+  };
 
   @Test
   void letAssignmentTest() {

--- a/databind/src/test/java/gov/nist/secauto/metaschema/databind/io/Issue206MetaschemaReaderTest.java
+++ b/databind/src/test/java/gov/nist/secauto/metaschema/databind/io/Issue206MetaschemaReaderTest.java
@@ -30,6 +30,7 @@ import gov.nist.secauto.metaschema.databind.model.annotations.MetaschemaModule;
 
 import org.codehaus.stax2.XMLEventReader2;
 import org.jmock.junit5.JUnit5Mockery;
+import org.jmock.lib.concurrent.Synchroniser;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -47,7 +48,11 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 class Issue206MetaschemaReaderTest {
   @RegisterExtension
-  JUnit5Mockery context = new JUnit5Mockery();
+  JUnit5Mockery context = new JUnit5Mockery() {
+    {
+      setThreadingPolicy(new Synchroniser());
+    }
+  };
 
   @Test
   void testIssue205Json() throws IOException, MetaschemaException {

--- a/databind/src/test/java/gov/nist/secauto/metaschema/databind/model/AbstractBoundModelTestSupport.java
+++ b/databind/src/test/java/gov/nist/secauto/metaschema/databind/model/AbstractBoundModelTestSupport.java
@@ -14,6 +14,7 @@ import gov.nist.secauto.metaschema.databind.codegen.AbstractMetaschemaTest;
 import gov.nist.secauto.metaschema.databind.model.test.RootBoundAssembly;
 
 import org.jmock.junit5.JUnit5Mockery;
+import org.jmock.lib.concurrent.Synchroniser;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
@@ -24,7 +25,11 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public class AbstractBoundModelTestSupport
     extends AbstractMetaschemaTest {
   @RegisterExtension
-  JUnit5Mockery context = new JUnit5Mockery();
+  JUnit5Mockery context = new JUnit5Mockery() {
+    {
+      setThreadingPolicy(new Synchroniser());
+    }
+  };
 
   @NonNull
   protected JUnit5Mockery getJUnit5Mockery() {

--- a/databind/src/test/java/gov/nist/secauto/metaschema/databind/model/DefaultFieldPropertyTest.java
+++ b/databind/src/test/java/gov/nist/secauto/metaschema/databind/model/DefaultFieldPropertyTest.java
@@ -15,17 +15,13 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 
-import gov.nist.secauto.metaschema.core.model.IModule;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import gov.nist.secauto.metaschema.databind.IBindingContext;
 import gov.nist.secauto.metaschema.databind.io.json.MetaschemaJsonReader;
 import gov.nist.secauto.metaschema.databind.model.test.MultiFieldAssembly;
 import gov.nist.secauto.metaschema.databind.model.test.SimpleAssembly;
 
-import org.jmock.auto.Mock;
-import org.jmock.junit5.JUnit5Mockery;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
 import java.net.URI;
@@ -33,15 +29,6 @@ import java.util.Collections;
 import java.util.LinkedList;
 
 class DefaultFieldPropertyTest {
-  @RegisterExtension
-  JUnit5Mockery context = new JUnit5Mockery();
-
-  @Mock
-  private IModule module; // NOPMD - it's injected
-  @Mock
-  private IBoundDefinitionModelAssembly classBinding; // NOPMD - it's injected
-  @Mock
-  private IBindingContext bindingContext; // NOPMD - it's injected
 
   @Test
   void testJsonReadFlag()

--- a/databind/src/test/java/gov/nist/secauto/metaschema/databind/model/impl/ConstraintFactoryTest.java
+++ b/databind/src/test/java/gov/nist/secauto/metaschema/databind/model/impl/ConstraintFactoryTest.java
@@ -17,6 +17,7 @@ import gov.nist.secauto.metaschema.databind.model.annotations.Let;
 
 import org.jmock.Expectations;
 import org.jmock.junit5.JUnit5Mockery;
+import org.jmock.lib.concurrent.Synchroniser;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -24,7 +25,11 @@ import java.net.URI;
 
 class ConstraintFactoryTest {
   @RegisterExtension
-  final JUnit5Mockery context = new JUnit5Mockery();
+  final JUnit5Mockery context = new JUnit5Mockery() {
+    {
+      setThreadingPolicy(new Synchroniser());
+    }
+  };
 
   @SuppressWarnings("null")
   @Test

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/CLI.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/CLI.java
@@ -14,10 +14,12 @@ import gov.nist.secauto.metaschema.core.MetaschemaJavaVersion;
 import gov.nist.secauto.metaschema.core.model.MetaschemaVersion;
 import gov.nist.secauto.metaschema.core.util.IVersionInfo;
 
+import java.io.PrintStream;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * The main entry point for the CLI application.
@@ -43,6 +45,24 @@ public final class CLI {
    */
   @NonNull
   public static ExitStatus runCli(String... args) {
+    return runCli(null, args);
+  }
+
+  /**
+   * Execute a command line with a custom output stream.
+   * <p>
+   * This method is useful for testing, allowing output to be captured instead of
+   * being written directly to the console.
+   *
+   * @param outputStream
+   *          the output stream to write to, or {@code null} to use the default
+   *          console
+   * @param args
+   *          the command line arguments
+   * @return the execution result
+   */
+  @NonNull
+  public static ExitStatus runCli(@Nullable PrintStream outputStream, String... args) {
     System.setProperty("java.util.logging.manager", "org.apache.logging.log4j.jul.LogManager");
 
     @SuppressWarnings("PMD.UseConcurrentHashMap")
@@ -50,7 +70,7 @@ public final class CLI {
     versions.put(CLIProcessor.COMMAND_VERSION, new MetaschemaJavaVersion());
     versions.put(MetaschemaConstants.METASCHEMA_NAMESPACE, new MetaschemaVersion());
 
-    CLIProcessor processor = new CLIProcessor("metaschema-cli", versions);
+    CLIProcessor processor = new CLIProcessor("metaschema-cli", versions, outputStream);
     MetaschemaCommands.COMMANDS.forEach(processor::addCommandHandler);
 
     CommandService.getInstance().getCommands().stream().forEach(command -> {

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractValidateContentCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractValidateContentCommand.java
@@ -164,7 +164,6 @@ public abstract class AbstractValidateContentCommand
      * @return the loaded Metaschema module
      * @throws CommandExecutionException
      *           if an error occurred while loading the module
-     * @throws MetaschemaException
      */
     @NonNull
     protected abstract IModule getModule(

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/ValidateModuleCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/ValidateModuleCommand.java
@@ -65,7 +65,7 @@ class ValidateModuleCommand
 
   private final class CommandExecutor
       extends AbstractValidationCommandExecutor {
-    private final Lazy<ValidationProvider> validationProvider = Lazy.lazy(ValidationProvider::new);
+    private final Lazy<ValidationProvider> validationProvider = Lazy.of(ValidationProvider::new);
 
     private CommandExecutor(
         @NonNull CallingContext callingContext,

--- a/metaschema-cli/src/test/java/gov/nist/secauto/metaschema/cli/CLITest.java
+++ b/metaschema-cli/src/test/java/gov/nist/secauto/metaschema/cli/CLITest.java
@@ -34,18 +34,74 @@ import nl.altindag.log.LogCaptor;
 public class CLITest {
   private static final ExitCode NO_EXCEPTION_CLASS = null;
 
-  void evaluateResult(@NonNull ExitStatus status, @NonNull ExitCode expectedCode) {
+  void evaluateResult(@NonNull ExitStatus status, @NonNull ExitCode expectedCode, @NonNull String[] args) {
     status.generateMessage(true);
-    assertAll(() -> assertEquals(expectedCode, status.getExitCode(), "exit code mismatch"),
-        () -> assertNull(status.getThrowable(), "expected null Throwable"));
+    Throwable thrown = status.getThrowable();
+    assertAll(
+        () -> assertEquals(expectedCode, status.getExitCode(),
+            () -> buildExitCodeMismatchMessage(status, expectedCode, thrown, args)),
+        () -> assertNull(thrown,
+            () -> buildUnexpectedThrowableMessage(thrown, args)));
   }
 
   void evaluateResult(@NonNull ExitStatus status, @NonNull ExitCode expectedCode,
-      @NonNull Class<? extends Throwable> thrownClass) {
+      @NonNull Class<? extends Throwable> thrownClass, @NonNull String[] args) {
     Throwable thrown = status.getThrowable();
     assertAll(
-        () -> assertEquals(expectedCode, status.getExitCode(), "exit code mismatch"),
-        () -> assertEquals(thrownClass, thrown == null ? null : thrown.getClass(), "expected Throwable mismatch"));
+        () -> assertEquals(expectedCode, status.getExitCode(),
+            () -> buildExitCodeMismatchMessage(status, expectedCode, thrown, args)),
+        () -> assertEquals(thrownClass, thrown == null ? null : thrown.getClass(),
+            () -> buildThrowableMismatchMessage(thrownClass, thrown, args)));
+  }
+
+  private String buildExitCodeMismatchMessage(@NonNull ExitStatus status, @NonNull ExitCode expectedCode,
+      Throwable thrown, @NonNull String[] args) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("exit code mismatch: expected <").append(expectedCode).append("> but was <")
+        .append(status.getExitCode()).append(">");
+    sb.append("\nCommand args: ").append(String.join(" ", args));
+    if (status.getMessage() != null) {
+      sb.append("\nStatus message: ").append(status.getMessage());
+    }
+    if (thrown != null) {
+      sb.append("\nThrowable: ").append(thrown.getClass().getName()).append(": ").append(thrown.getMessage());
+      sb.append("\nStack trace:\n").append(getStackTraceAsString(thrown));
+    }
+    return sb.toString();
+  }
+
+  private String buildUnexpectedThrowableMessage(Throwable thrown, @NonNull String[] args) {
+    if (thrown == null) {
+      return "expected null Throwable";
+    }
+    StringBuilder sb = new StringBuilder();
+    sb.append("expected null Throwable but got: ").append(thrown.getClass().getName())
+        .append(": ").append(thrown.getMessage());
+    sb.append("\nCommand args: ").append(String.join(" ", args));
+    sb.append("\nStack trace:\n").append(getStackTraceAsString(thrown));
+    return sb.toString();
+  }
+
+  private String buildThrowableMismatchMessage(Class<? extends Throwable> expectedClass, Throwable thrown,
+      @NonNull String[] args) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("expected Throwable mismatch: expected <")
+        .append(expectedClass == null ? "null" : expectedClass.getName())
+        .append("> but was <")
+        .append(thrown == null ? "null" : thrown.getClass().getName())
+        .append(">");
+    sb.append("\nCommand args: ").append(String.join(" ", args));
+    if (thrown != null) {
+      sb.append("\nMessage: ").append(thrown.getMessage());
+      sb.append("\nStack trace:\n").append(getStackTraceAsString(thrown));
+    }
+    return sb.toString();
+  }
+
+  private String getStackTraceAsString(Throwable throwable) {
+    java.io.StringWriter sw = new java.io.StringWriter();
+    throwable.printStackTrace(new java.io.PrintWriter(sw));
+    return sw.toString();
   }
 
   private static Stream<Arguments> providesValues() {
@@ -198,9 +254,9 @@ public class CLITest {
     String[] fullArgs = Stream.of(args, defaultArgs).flatMap(Stream::of)
         .toArray(String[]::new);
     if (expectedThrownClass == null) {
-      evaluateResult(CLI.runCli(fullArgs), expectedExitCode);
+      evaluateResult(CLI.runCli(fullArgs), expectedExitCode, fullArgs);
     } else {
-      evaluateResult(CLI.runCli(fullArgs), expectedExitCode, expectedThrownClass);
+      evaluateResult(CLI.runCli(fullArgs), expectedExitCode, expectedThrownClass, fullArgs);
     }
   }
 

--- a/metaschema-cli/src/test/java/gov/nist/secauto/metaschema/cli/CLITest.java
+++ b/metaschema-cli/src/test/java/gov/nist/secauto/metaschema/cli/CLITest.java
@@ -20,6 +20,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.io.OutputStream;
+import java.io.PrintStream;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Stream;
@@ -33,6 +35,22 @@ import nl.altindag.log.LogCaptor;
 @Execution(value = ExecutionMode.SAME_THREAD, reason = "Log capturing needs to be single threaded")
 public class CLITest {
   private static final ExitCode NO_EXCEPTION_CLASS = null;
+
+  /**
+   * A PrintStream that discards all output, used to suppress CLI console output
+   * during tests.
+   */
+  private static final PrintStream NULL_STREAM = new PrintStream(new OutputStream() {
+    @Override
+    public void write(int b) {
+      // discard
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) {
+      // discard
+    }
+  });
 
   void evaluateResult(@NonNull ExitStatus status, @NonNull ExitCode expectedCode, @NonNull String[] args) {
     status.generateMessage(true);
@@ -254,9 +272,9 @@ public class CLITest {
     String[] fullArgs = Stream.of(args, defaultArgs).flatMap(Stream::of)
         .toArray(String[]::new);
     if (expectedThrownClass == null) {
-      evaluateResult(CLI.runCli(fullArgs), expectedExitCode, fullArgs);
+      evaluateResult(CLI.runCli(NULL_STREAM, fullArgs), expectedExitCode, fullArgs);
     } else {
-      evaluateResult(CLI.runCli(fullArgs), expectedExitCode, expectedThrownClass, fullArgs);
+      evaluateResult(CLI.runCli(NULL_STREAM, fullArgs), expectedExitCode, expectedThrownClass, fullArgs);
     }
   }
 
@@ -269,7 +287,7 @@ public class CLITest {
           "src/test/resources/content/215.xml",
           "--disable-schema-validation"
       };
-      CLI.runCli(cliArgs);
+      CLI.runCli(NULL_STREAM, cliArgs);
       assertThat(captor.getErrorLogs().toString())
           .contains("expect-default-non-zero: Expect constraint '. > 0' did not match the data",
               "expect-custom-non-zero: No default message, custom error message for expect-custom-non-zero constraint.",
@@ -296,7 +314,7 @@ public class CLITest {
           "src/test/resources/content/constraint-constraints.xml",
           "--disable-schema-validation",
       };
-      CLI.runCli(cliArgs);
+      CLI.runCli(NULL_STREAM, cliArgs);
       assertThat(captor.getErrorLogs().toString())
           .contains("This constraint SHOULD be violated if test passes.");
     }

--- a/metaschema-cli/src/test/java/gov/nist/secauto/metaschema/cli/CLITest.java
+++ b/metaschema-cli/src/test/java/gov/nist/secauto/metaschema/cli/CLITest.java
@@ -123,7 +123,6 @@ public class CLITest {
   }
 
   private static Stream<Arguments> providesValues() {
-    @SuppressWarnings("serial")
     List<Arguments> values = new LinkedList<>() {
       {
         add(Arguments.of(new String[] {}, ExitCode.INVALID_COMMAND,

--- a/metaschema-cli/src/test/java/gov/nist/secauto/metaschema/cli/commands/metapath/EvaluateMetapathSubCommandTest.java
+++ b/metaschema-cli/src/test/java/gov/nist/secauto/metaschema/cli/commands/metapath/EvaluateMetapathSubCommandTest.java
@@ -13,10 +13,24 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
+import java.io.OutputStream;
+import java.io.PrintStream;
+
 import nl.altindag.log.LogCaptor;
 
 @Execution(value = ExecutionMode.SAME_THREAD, reason = "Log capturing needs to be single threaded")
 class EvaluateMetapathSubCommandTest {
+
+  /**
+   * A PrintStream that discards all output, used to suppress CLI console output
+   * during tests.
+   */
+  private static final PrintStream NULL_STREAM = new PrintStream(new OutputStream() {
+    @Override
+    public void write(int b) {
+      // discard
+    }
+  });
 
   @Test
   void test() {
@@ -28,7 +42,7 @@ class EvaluateMetapathSubCommandTest {
               "-e",
               "3 + 4 + 5",
               "--show-stack-trace" };
-      CLI.runCli(args);
+      CLI.runCli(NULL_STREAM, args);
       assertThat(captor.getInfoLogs().contains("12"));
     }
   }

--- a/metaschema-cli/src/test/resources/logback-test.xml
+++ b/metaschema-cli/src/test/resources/logback-test.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<root level="INFO">
+		<appender-ref ref="STDOUT" />
+	</root>
+</configuration>

--- a/metaschema-maven-plugin/pom.xml
+++ b/metaschema-maven-plugin/pom.xml
@@ -144,7 +144,6 @@
                 <configuration>
                     <goalPrefix>metaschema</goalPrefix>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
-                    <outputDirectory>${project.build.directory}/classes/META-INF/maven</outputDirectory>
                 </configuration>
                 <executions>
                     <execution>

--- a/metaschema-testing/pom.xml
+++ b/metaschema-testing/pom.xml
@@ -55,6 +55,9 @@
 	<build>
 		<resources>
 			<resource>
+				<directory>src/main/resources</directory>
+			</resource>
+			<resource>
 				<directory>${project.build.directory}/generated-resources/xmlbeans</directory>
 			</resource>
 		</resources>

--- a/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/AbstractTestSuite.java
+++ b/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/AbstractTestSuite.java
@@ -208,7 +208,7 @@ public abstract class AbstractTestSuite {
     assert collectionUri != null;
 
     LOGGER.atInfo().log("Collection: " + collectionUri);
-    Lazy<Path> collectionGenerationPath = ObjectUtils.notNull(Lazy.lazy(() -> {
+    Lazy<Path> collectionGenerationPath = ObjectUtils.notNull(Lazy.of(() -> {
       Path retval;
       try {
         retval = ObjectUtils.requireNonNull(Files.createTempDirectory(generationPath, "collection-"));
@@ -316,7 +316,7 @@ public abstract class AbstractTestSuite {
       @NonNull URI collectionUri,
       @NonNull Lazy<Path> collectionGenerationPath,
       @NonNull IBindingContext bindingContext) {
-    Lazy<Path> scenarioGenerationPath = ObjectUtils.notNull(Lazy.lazy(() -> {
+    Lazy<Path> scenarioGenerationPath = ObjectUtils.notNull(Lazy.of(() -> {
       Path retval;
       try {
         retval = Files.createTempDirectory(collectionGenerationPath.get(), "scenario-");
@@ -339,9 +339,9 @@ public abstract class AbstractTestSuite {
       throw new JUnitException("Unable to generate classes for metaschema: " + metaschemaUri, ex);
     }
 
-    Lazy<Path> lazySchema = Lazy.lazy(() -> generateSchema(module, scenarioGenerationPath));
+    Lazy<Path> lazySchema = Lazy.of(() -> generateSchema(module, scenarioGenerationPath));
 
-    Lazy<IContentValidator> lazyContentValidator = Lazy.lazy(() -> {
+    Lazy<IContentValidator> lazyContentValidator = Lazy.of(() -> {
       Path schemaPath = lazySchema.get();
       return getContentValidatorSupplier().apply(schemaPath);
     });

--- a/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/DeadlockDetectionExtension.java
+++ b/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/DeadlockDetectionExtension.java
@@ -1,0 +1,135 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.model.testing;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestWatcher;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A JUnit 5 extension that detects deadlocks and dumps thread information when
+ * tests fail or are aborted (e.g., due to timeout).
+ * <p>
+ * To use this extension, annotate your test class with:
+ *
+ * <pre>
+ * {@literal @}ExtendWith(DeadlockDetectionExtension.class)
+ * </pre>
+ * <p>
+ * Or register it globally via
+ * {@code META-INF/services/org.junit.jupiter.api.extension.Extension}.
+ */
+public class DeadlockDetectionExtension implements TestWatcher {
+  private static final Logger LOGGER = LogManager.getLogger(DeadlockDetectionExtension.class);
+
+  @Override
+  public void testAborted(ExtensionContext context, Throwable cause) {
+    LOGGER.error("Test aborted: {} - {}", context.getDisplayName(), cause.getMessage());
+    dumpThreadInfo(context, "ABORTED");
+  }
+
+  @Override
+  public void testFailed(ExtensionContext context, Throwable cause) {
+    // Check if this looks like a timeout
+    if (isTimeoutException(cause)) {
+      LOGGER.error("Test timed out (possible deadlock): {}", context.getDisplayName());
+      dumpThreadInfo(context, "TIMEOUT");
+      detectDeadlocks();
+    }
+  }
+
+  private boolean isTimeoutException(Throwable cause) {
+    if (cause == null) {
+      return false;
+    }
+    String message = cause.getMessage();
+    String className = cause.getClass().getName();
+    return className.contains("Timeout")
+        || (message != null && message.toLowerCase().contains("timed out"))
+        || cause instanceof java.util.concurrent.TimeoutException
+        || isTimeoutException(cause.getCause());
+  }
+
+  private void dumpThreadInfo(ExtensionContext context, String reason) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("\n");
+    sb.append("=".repeat(80)).append("\n");
+    sb.append("THREAD DUMP - Test ").append(reason).append(": ").append(context.getDisplayName()).append("\n");
+    sb.append("=".repeat(80)).append("\n\n");
+
+    // Get all thread stack traces
+    Map<Thread, StackTraceElement[]> allStackTraces = Thread.getAllStackTraces();
+
+    for (Map.Entry<Thread, StackTraceElement[]> entry : allStackTraces.entrySet()) {
+      Thread thread = entry.getKey();
+      StackTraceElement[] stackTrace = entry.getValue();
+
+      sb.append("Thread: \"").append(thread.getName()).append("\"")
+          .append(" (id=").append(thread.getId()).append(")")
+          .append(" state=").append(thread.getState())
+          .append(" daemon=").append(thread.isDaemon())
+          .append("\n");
+
+      for (StackTraceElement element : stackTrace) {
+        sb.append("\tat ").append(element).append("\n");
+      }
+      sb.append("\n");
+    }
+
+    sb.append("=".repeat(80)).append("\n");
+
+    LOGGER.error(sb.toString());
+  }
+
+  private void detectDeadlocks() {
+    ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+    long[] deadlockedThreadIds = threadMXBean.findDeadlockedThreads();
+
+    if (deadlockedThreadIds != null && deadlockedThreadIds.length > 0) {
+      StringBuilder sb = new StringBuilder();
+      sb.append("\n");
+      sb.append("!".repeat(80)).append("\n");
+      sb.append("DEADLOCK DETECTED!\n");
+      sb.append("!".repeat(80)).append("\n\n");
+
+      ThreadInfo[] threadInfos = threadMXBean.getThreadInfo(deadlockedThreadIds, true, true);
+      for (ThreadInfo threadInfo : threadInfos) {
+        if (threadInfo != null) {
+          sb.append("Deadlocked thread: \"").append(threadInfo.getThreadName()).append("\"\n");
+          sb.append("  State: ").append(threadInfo.getThreadState()).append("\n");
+          sb.append("  Blocked on: ").append(threadInfo.getLockName()).append("\n");
+          sb.append("  Blocked by: ").append(threadInfo.getLockOwnerName()).append("\n");
+          sb.append("  Stack trace:\n");
+          for (StackTraceElement element : threadInfo.getStackTrace()) {
+            sb.append("\t\tat ").append(element).append("\n");
+          }
+          sb.append("\n");
+        }
+      }
+
+      sb.append("!".repeat(80)).append("\n");
+
+      LOGGER.error(sb.toString());
+    }
+  }
+
+  @Override
+  public void testDisabled(ExtensionContext context, Optional<String> reason) {
+    // No action needed for disabled tests
+  }
+
+  @Override
+  public void testSuccessful(ExtensionContext context) {
+    // No action needed for successful tests
+  }
+}

--- a/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/DeadlockDetectionExtension.java
+++ b/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/DeadlockDetectionExtension.java
@@ -34,15 +34,19 @@ public class DeadlockDetectionExtension implements TestWatcher {
 
   @Override
   public void testAborted(ExtensionContext context, Throwable cause) {
-    LOGGER.error("Test aborted: {} - {}", context.getDisplayName(), cause.getMessage());
-    dumpThreadInfo(context, "ABORTED");
+    if (LOGGER.isErrorEnabled()) {
+      LOGGER.error("Test aborted: {} - {}", context.getDisplayName(), cause.getMessage());
+      dumpThreadInfo(context, "ABORTED");
+    }
   }
 
   @Override
   public void testFailed(ExtensionContext context, Throwable cause) {
     // Check if this looks like a timeout
     if (isTimeoutException(cause)) {
-      LOGGER.error("Test timed out (possible deadlock): {}", context.getDisplayName());
+      if (LOGGER.isErrorEnabled()) {
+        LOGGER.error("Test timed out (possible deadlock): {}", context.getDisplayName());
+      }
       dumpThreadInfo(context, "TIMEOUT");
       detectDeadlocks();
     }
@@ -88,7 +92,9 @@ public class DeadlockDetectionExtension implements TestWatcher {
 
     sb.append("=".repeat(80)).append("\n");
 
-    LOGGER.error(sb.toString());
+    if (LOGGER.isErrorEnabled()) {
+      LOGGER.error(sb.toString());
+    }
   }
 
   private void detectDeadlocks() {
@@ -119,7 +125,9 @@ public class DeadlockDetectionExtension implements TestWatcher {
 
       sb.append("!".repeat(80)).append("\n");
 
-      LOGGER.error(sb.toString());
+      if (LOGGER.isErrorEnabled()) {
+        LOGGER.error(sb.toString());
+      }
     }
   }
 

--- a/metaschema-testing/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/metaschema-testing/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+gov.nist.secauto.metaschema.model.testing.DeadlockDetectionExtension

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>dev.metaschema</groupId>
 		<artifactId>oss-parent</artifactId>
-		<version>8</version>
+		<version>9-SNAPSHOT</version>
 	</parent>
 
 	<groupId>dev.metaschema.java</groupId>
@@ -701,6 +701,9 @@
 						<redirectTestOutputToFile>true</redirectTestOutputToFile>
 						<!-- Use of TCP to transmit events to the plugin -->
 						<forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory" />
+						<!-- Deadlock detection: kill forked JVM after 5 minutes of no output -->
+						<forkedProcessTimeoutInSeconds>300</forkedProcessTimeoutInSeconds>
+						<forkedProcessExitTimeoutInSeconds>60</forkedProcessExitTimeoutInSeconds>
 						<!-- Junit5 parallel configuration -->
 						<parallel>all</parallel>
 						<useUnlimitedThreads>true</useUnlimitedThreads>
@@ -708,7 +711,10 @@
 							<configurationParameters>
 								junit.jupiter.execution.parallel.enabled = true
 								junit.jupiter.execution.parallel.mode.default = concurrent
-								junit.jupiter.execution.timeout.default=60 s
+								junit.jupiter.execution.timeout.default = 60 s
+								junit.jupiter.execution.timeout.mode = disabled_on_debug
+								junit.jupiter.execution.timeout.thread.mode.default = SEPARATE_THREAD
+								junit.jupiter.extensions.autodetection.enabled = true
 							</configurationParameters>
 						</properties>
 						<!-- tree reporter configuration -->

--- a/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/AbstractJsonSchemaDefinition.java
+++ b/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/AbstractJsonSchemaDefinition.java
@@ -37,7 +37,7 @@ public abstract class AbstractJsonSchemaDefinition<D extends IDefinition> implem
       @NonNull D definition,
       @NonNull IJsonGenerationState state) {
     this.definition = definition;
-    this.name = ObjectUtils.notNull(Lazy.lazy(() -> generateDefinitionName(state)));
+    this.name = ObjectUtils.notNull(Lazy.of(() -> generateDefinitionName(state)));
   }
 
   @Override

--- a/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/AbstractJsonSchemaPropertyGrouped.java
+++ b/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/AbstractJsonSchemaPropertyGrouped.java
@@ -47,7 +47,7 @@ public abstract class AbstractJsonSchemaPropertyGrouped<I extends INamedModelIns
    */
   protected AbstractJsonSchemaPropertyGrouped(@NonNull I instance, @NonNull IJsonGenerationState state) {
     super(instance);
-    this.definitionName = ObjectUtils.notNull(Lazy.lazy(() -> getDefinitionName(state)));
+    this.definitionName = ObjectUtils.notNull(Lazy.of(() -> getDefinitionName(state)));
     this.jsonKey = instance.getJsonKey();
 
     IEnhancedQName jsonKeyName = this.jsonKey == null ? null : this.jsonKey.getQName();

--- a/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/JsonSchemaDefinitionAssembly.java
+++ b/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/JsonSchemaDefinitionAssembly.java
@@ -47,7 +47,7 @@ public class JsonSchemaDefinitionAssembly
       @Nullable IEnhancedQName jsonKeyFlagName,
       @NonNull IJsonGenerationState state) {
     super(definition, jsonKeyFlagName, state);
-    this.choices = Lazy.lazy(() -> {
+    this.choices = Lazy.of(() -> {
       List<IJsonSchemaPropertyFlag> flagProperties = getFlagProperties();
       List<IJsonSchemaPropertyNamed> modelProperties = JsonSchemaHelper.buildModelProperties(getDefinition(), state);
 

--- a/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/JsonSchemaPropertyAssembly.java
+++ b/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/JsonSchemaPropertyAssembly.java
@@ -43,7 +43,7 @@ public class JsonSchemaPropertyAssembly
       @NonNull IJsonGenerationState state) {
     super(instance, instance.getJsonName());
     this.jsonKey = instance.getJsonKey();
-    this.definitionSchema = ObjectUtils.notNull(Lazy.lazy(() -> state.getAssemblyDefinition(
+    this.definitionSchema = ObjectUtils.notNull(Lazy.of(() -> state.getAssemblyDefinition(
         instance.getDefinition(),
         jsonKey == null ? null : jsonKey.getQName())));
   }

--- a/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/JsonSchemaPropertyGroupedAssembly.java
+++ b/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/JsonSchemaPropertyGroupedAssembly.java
@@ -42,7 +42,7 @@ public class JsonSchemaPropertyGroupedAssembly
       @NonNull IAssemblyInstanceGrouped instance,
       @NonNull IJsonGenerationState state) {
     super(instance, state);
-    this.choices = Lazy.lazy(() -> {
+    this.choices = Lazy.of(() -> {
       List<IJsonSchemaPropertyFlag> flagProperties = getFlagProperties();
       List<IJsonSchemaPropertyNamed> modelProperties
           = JsonSchemaHelper.buildModelProperties(instance.getDefinition(), state);

--- a/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/xml/XmlDatatypeManager.java
+++ b/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/xml/XmlDatatypeManager.java
@@ -34,7 +34,7 @@ public class XmlDatatypeManager
   public static final String NS_XML_SCHEMA = "http://www.w3.org/2001/XMLSchema";
 
   @NonNull
-  private static final Lazy<List<IDatatypeProvider>> DATATYPE_PROVIDERS = ObjectUtils.notNull(Lazy.lazy(() -> List.of(
+  private static final Lazy<List<IDatatypeProvider>> DATATYPE_PROVIDERS = ObjectUtils.notNull(Lazy.of(() -> List.of(
       new XmlCoreDatatypeProvider(),
       new XmlProseCompositDatatypeProvider(
           ObjectUtils.notNull(List.of(


### PR DESCRIPTION
## Summary

- Refactor `Lazy.lazy()` to `Lazy.of()` across the codebase for clearer API naming
- Add injectable output stream to CLI for improved testability
- Fix thread-safety issues for parallel test execution
- Add logback-test.xml to suppress DEBUG logging in CLI tests
- Remove deprecated annotations and redundant plugin configuration
- Remove unnecessary `@SuppressWarnings` annotation from CLITest
- Add CLAUDE.local.md to .gitignore and remove from version control
- Remove accidentally committed build output files

## Test plan

- [ ] Verify all existing tests pass
- [ ] Confirm CLI output injection works correctly in tests
- [ ] Validate parallel test execution stability