### PR TITLE
Remove unnecessary empty finalize() methods from abstract classes

### DIFF
--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/AbstractContainerModelSupport.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/AbstractContainerModelSupport.java
@@ -83,11 +83,4 @@ public abstract class AbstractContainerModelSupport<
   public Map<Integer, AI> getAssemblyInstanceMap() {
     return assemblyInstances;
   }
-
-  @SuppressWarnings({ "PMD.EmptyFinalizer", "checkstyle:NoFinalizer" })
-  @Override
-  protected final void finalize() {
-    // Address SEI CERT Rule OBJ-11:
-    // https://wiki.sei.cmu.edu/confluence/display/java/OBJ11-J.+Be+wary+of+letting+constructors+throw+exceptions
-  }
 }

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/DefaultBindingContext.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/DefaultBindingContext.java
@@ -264,7 +264,15 @@ public class DefaultBindingContext implements IBindingContext {
     return ObjectUtils.asType(definition.deepCopyItem(other, parentInstance));
   }
 
+  /**
+   * Used to prevent finalizer attacks as recommended in SEI CERT Rule OBJ-11.
+   * This is needed because the class is non-final and the constructor can throw.
+   */
   @Override
+  @SuppressWarnings({
+      "PMD.EmptyFinalizer",
+      "checkstyle:NoFinalizer",
+      "deprecation" })
   protected final void finalize() {
     // Do nothing
   }

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/AbstractAbsoluteModelGenerator.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/AbstractAbsoluteModelGenerator.java
@@ -24,7 +24,6 @@ import gov.nist.secauto.metaschema.databind.model.metaschema.binding.InlineDefin
 import gov.nist.secauto.metaschema.databind.model.metaschema.binding.InlineDefineField;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Supports generating the model contents of a Metaschema instance with a
@@ -215,13 +214,5 @@ public abstract class AbstractAbsoluteModelGenerator<
         objInstance,
         fieldInlineDefinitionPosition++,
         getParent()));
-  }
-
-  @SuppressWarnings({ "PMD.EmptyFinalizer", "checkstyle:NoFinalizer" })
-  @SuppressFBWarnings(value = "FI_EMPTY", justification = "needed to avoid finalization bug")
-  @Override
-  protected final void finalize() {
-    // Address SEI CERT Rule OBJ-11:
-    // https://wiki.sei.cmu.edu/confluence/display/java/OBJ11-J.+Be+wary+of+letting+constructors+throw+exceptions
   }
 }


### PR DESCRIPTION
## Summary

- Remove empty `finalize()` methods from abstract classes that don't need SEI CERT OBJ-11 protection
- Improve documentation for the retained `finalize()` in `DefaultBindingContext`

## Changes

**Removed finalize() from:**
- `AbstractContainerModelSupport` - abstract class with non-throwing constructor
- `AbstractAbsoluteModelGenerator` - abstract class with non-throwing constructor (also removed unused import)

**Retained finalize() in:**
- `DefaultBindingContext` - non-final concrete class with a constructor that can throw; the empty finalize() is required to prevent finalizer attacks per SEI CERT Rule OBJ-11

## Rationale

Abstract classes cannot be directly instantiated, so they cannot be targets of finalizer attacks. Only non-final concrete classes with constructors that can throw exceptions need this protection.

Java 6+ only provides automatic protection if the exception is thrown *before* the Object constructor finishes. Since `DefaultBindingContext`'s constructor throws after object initialization, the explicit empty finalize() is still necessary.

## Test plan

- [x] Full build passes with `mvn clean install -PCI -Prelease`
- [x] No SpotBugs CT_CONSTRUCTOR_THROW errors
- [x] All existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized object lifecycle management and garbage collection behavior to improve system stability and maintain code quality standards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->