### PR TITLE
Replace deprecated @Component with @Inject annotation

### DIFF
--- a/metaschema-maven-plugin/src/main/java/gov/nist/secauto/metaschema/maven/plugin/AbstractMetaschemaMojo.java
+++ b/metaschema-maven-plugin/src/main/java/gov/nist/secauto/metaschema/maven/plugin/AbstractMetaschemaMojo.java
@@ -46,8 +46,9 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
+
+import javax.inject.Inject;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.DirectoryScanner;
 import org.sonatype.plexus.build.incremental.BuildContext;
@@ -99,7 +100,7 @@ public abstract class AbstractMetaschemaMojo
   @Parameter(defaultValue = "${mojoExecution}", readonly = true)
   private MojoExecution mojoExecution;
 
-  @Component
+  @Inject
   private BuildContext buildContext;
 
   @Parameter(defaultValue = "${plugin.artifacts}", readonly = true, required = true)


### PR DESCRIPTION
## Summary

- Replaced deprecated Maven `@Component` annotation with JSR-330 `@Inject` annotation in `AbstractMetaschemaMojo` for `BuildContext` injection
- No new dependencies required - `javax.inject` is already available transitively through `maven-core`

## Files Changed

- `metaschema-maven-plugin/src/main/java/gov/nist/secauto/metaschema/maven/plugin/AbstractMetaschemaMojo.java`

## Test Plan

- [x] Verified existing integration tests pass before changes
- [x] Verified integration tests pass after changes (`Passed: 1, Failed: 0`)
- [x] Verified full CI build passes (`mvn clean install -PCI -Prelease`)
- [x] Verified no `@Component` deprecation warnings remain in build output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency injection configuration in the Maven plugin to use standard injection patterns. This maintenance change improves code consistency with no impact to functionality or user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->