### PR TITLE
Fix FunctionUtils deprecation in math operations

### DIFF
--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/math/AbstractBasicArithmeticExpression.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/math/AbstractBasicArithmeticExpression.java
@@ -126,8 +126,8 @@ public abstract class AbstractBasicArithmeticExpression
 
     if (typeStrategies == null) {
       return operationAsNumeric(
-          FunctionUtils.toNumeric(left),
-          FunctionUtils.toNumeric(right));
+          FunctionUtils.castToNumeric(left),
+          FunctionUtils.castToNumeric(right));
     }
 
     // Find matching strategy for subtrahend type

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/math/IntegerDivision.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/math/IntegerDivision.java
@@ -11,6 +11,7 @@ import gov.nist.secauto.metaschema.core.metapath.cst.IExpressionVisitor;
 import gov.nist.secauto.metaschema.core.metapath.function.FunctionUtils;
 import gov.nist.secauto.metaschema.core.metapath.function.impl.OperationFunctions;
 import gov.nist.secauto.metaschema.core.metapath.item.ISequence;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IIntegerItem;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.INumericItem;
 
@@ -55,10 +56,10 @@ public class IntegerDivision
 
   @Override
   protected ISequence<? extends IIntegerItem> evaluate(DynamicContext dynamicContext, ISequence<?> focus) {
-    INumericItem dividend = FunctionUtils.toNumericOrNull(
-        ISequence.of(getLeft().accept(dynamicContext, focus).atomize()).getFirstItem(true));
-    INumericItem divisor = FunctionUtils.toNumericOrNull(
-        ISequence.of(getRight().accept(dynamicContext, focus).atomize()).getFirstItem(true));
+    IAnyAtomicItem leftItem = ISequence.of(getLeft().accept(dynamicContext, focus).atomize()).getFirstItem(true);
+    IAnyAtomicItem rightItem = ISequence.of(getRight().accept(dynamicContext, focus).atomize()).getFirstItem(true);
+    INumericItem dividend = leftItem == null ? null : FunctionUtils.castToNumeric(leftItem);
+    INumericItem divisor = rightItem == null ? null : FunctionUtils.castToNumeric(rightItem);
 
     return resultOrEmpty(dividend, divisor);
   }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/math/Modulo.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/math/Modulo.java
@@ -11,6 +11,7 @@ import gov.nist.secauto.metaschema.core.metapath.cst.IExpressionVisitor;
 import gov.nist.secauto.metaschema.core.metapath.function.FunctionUtils;
 import gov.nist.secauto.metaschema.core.metapath.function.impl.OperationFunctions;
 import gov.nist.secauto.metaschema.core.metapath.item.ISequence;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.INumericItem;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -56,8 +57,10 @@ public class Modulo
 
   @Override
   protected ISequence<? extends INumericItem> evaluate(DynamicContext dynamicContext, ISequence<?> focus) {
-    INumericItem dividend = FunctionUtils.toNumeric(getLeft().accept(dynamicContext, focus), true);
-    INumericItem divisor = FunctionUtils.toNumeric(getRight().accept(dynamicContext, focus), true);
+    IAnyAtomicItem leftItem = ISequence.of(getLeft().accept(dynamicContext, focus).atomize()).getFirstItem(true);
+    IAnyAtomicItem rightItem = ISequence.of(getRight().accept(dynamicContext, focus).atomize()).getFirstItem(true);
+    INumericItem dividend = leftItem == null ? null : FunctionUtils.castToNumeric(leftItem);
+    INumericItem divisor = rightItem == null ? null : FunctionUtils.castToNumeric(rightItem);
     return resultOrEmpty(dividend, divisor);
   }
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/math/Multiplication.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/math/Multiplication.java
@@ -157,9 +157,9 @@ public class Multiplication
       }
     } else {
       // handle as numeric
-      INumericItem left = FunctionUtils.toNumeric(leftItem);
+      INumericItem left = FunctionUtils.castToNumeric(leftItem);
       if (rightItem instanceof INumericItem) {
-        INumericItem right = FunctionUtils.toNumeric(rightItem);
+        INumericItem right = FunctionUtils.castToNumeric(rightItem);
         retval = OperationFunctions.opNumericMultiply(left, right);
       } else if (rightItem instanceof IYearMonthDurationItem) {
         retval = OperationFunctions.opMultiplyYearMonthDuration((IYearMonthDurationItem) rightItem, left);

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/math/Negate.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/math/Negate.java
@@ -13,6 +13,7 @@ import gov.nist.secauto.metaschema.core.metapath.cst.IExpressionVisitor;
 import gov.nist.secauto.metaschema.core.metapath.function.FunctionUtils;
 import gov.nist.secauto.metaschema.core.metapath.function.impl.OperationFunctions;
 import gov.nist.secauto.metaschema.core.metapath.item.ISequence;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.INumericItem;
 
 import java.util.List;
@@ -61,8 +62,8 @@ public class Negate
 
   @Override
   protected ISequence<? extends INumericItem> evaluate(DynamicContext dynamicContext, ISequence<?> focus) {
-    INumericItem item = FunctionUtils.toNumericOrNull(
-        ISequence.of(getChild().accept(dynamicContext, focus).atomize()).getFirstItem(true));
+    IAnyAtomicItem atomicItem = ISequence.of(getChild().accept(dynamicContext, focus).atomize()).getFirstItem(true);
+    INumericItem item = atomicItem == null ? null : FunctionUtils.castToNumeric(atomicItem);
     if (item != null) {
       item = OperationFunctions.opNumericUnaryMinus(item);
     }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/FunctionUtils.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/FunctionUtils.java
@@ -95,11 +95,7 @@ public final class FunctionUtils {
   @Deprecated(since = "3.0.0", forRemoval = true)
   @NonNull
   public static INumericItem toNumeric(@NonNull IAnyAtomicItem item) {
-    try {
-      return IDecimalItem.cast(item);
-    } catch (InvalidValueForCastFunctionException ex) {
-      throw new InvalidTypeMetapathException(item, ex.getLocalizedMessage(), ex);
-    }
+    return castToNumeric(item);
   }
 
   /**
@@ -111,10 +107,35 @@ public final class FunctionUtils {
    * @return the numeric item value
    * @throws TypeMetapathException
    *           if the item cannot be cast to a numeric value
+   * @deprecated Use {@link #castToNumeric(IAnyAtomicItem)} with null checking
+   *             instead
    */
+  @Deprecated(since = "3.0.0", forRemoval = true)
   @Nullable
   public static INumericItem toNumericOrNull(@Nullable IAnyAtomicItem item) {
-    return item == null ? null : toNumeric(item);
+    return item == null ? null : castToNumeric(item);
+  }
+
+  /**
+   * Casts the provided item value to a {@link INumericItem} value.
+   * <p>
+   * This method wraps {@link INumericItem#cast(IAnyAtomicItem)} and converts
+   * {@link InvalidValueForCastFunctionException} to
+   * {@link InvalidTypeMetapathException} for consistent exception handling.
+   *
+   * @param item
+   *          the value to cast
+   * @return the numeric item value
+   * @throws InvalidTypeMetapathException
+   *           if the item cannot be cast to a numeric value
+   */
+  @NonNull
+  public static INumericItem castToNumeric(@NonNull IAnyAtomicItem item) {
+    try {
+      return INumericItem.cast(item);
+    } catch (InvalidValueForCastFunctionException ex) {
+      throw new InvalidTypeMetapathException(item, ex.getLocalizedMessage(), ex);
+    }
   }
 
   /**

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/INumericItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/INumericItem.java
@@ -43,6 +43,9 @@ public interface INumericItem extends IAnyAtomicItem {
 
   /**
    * Cast the provided type to this item type.
+   * <p>
+   * Per XPath 3.1, boolean values are cast as: {@code true} → 1, {@code false} →
+   * 0.
    *
    * @param item
    *          the item to cast
@@ -53,14 +56,21 @@ public interface INumericItem extends IAnyAtomicItem {
    */
   @NonNull
   static INumericItem cast(@NonNull IAnyAtomicItem item) {
-    try {
-      return item instanceof INumericItem
-          ? (INumericItem) item
-          : IDecimalItem.valueOf(item.asString());
-    } catch (IllegalStateException | InvalidTypeMetapathException ex) {
-      // asString can throw IllegalStateException exception
-      throw new InvalidValueForCastFunctionException(ex);
+    INumericItem retval;
+    if (item instanceof INumericItem) {
+      retval = (INumericItem) item;
+    } else if (item instanceof IBooleanItem) {
+      // XPath 3.1: boolean true -> 1, false -> 0
+      retval = IIntegerItem.valueOf(((IBooleanItem) item).toBoolean());
+    } else {
+      try {
+        retval = IDecimalItem.valueOf(item.asString());
+      } catch (IllegalStateException | InvalidTypeMetapathException ex) {
+        // asString can throw IllegalStateException exception
+        throw new InvalidValueForCastFunctionException(ex);
+      }
     }
+    return retval;
   }
 
   /**

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/math/IntegerDivisionTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/math/IntegerDivisionTest.java
@@ -59,7 +59,9 @@ public class IntegerDivisionTest
   private static Stream<Arguments> provideInvalidValues() {
     return Stream.of(
         // Invalid type for idiv - strings cannot be cast to numeric
-        Arguments.of("'abc' idiv 2"));
+        Arguments.of("'abc' idiv 2"),
+        // Division by zero
+        Arguments.of("5 idiv 0"));
   }
 
   @ParameterizedTest

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/math/IntegerDivisionTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/math/IntegerDivisionTest.java
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.cst.math;
+
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.integer;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import gov.nist.secauto.metaschema.core.metapath.ExpressionTestBase;
+import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
+import gov.nist.secauto.metaschema.core.metapath.MetapathException;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Tests for the IntegerDivision (idiv) operation.
+ */
+public class IntegerDivisionTest
+    extends ExpressionTestBase {
+
+  private static Stream<Arguments> provideValues() {
+    return Stream.of(
+        // Basic integer division
+        Arguments.of(integer(2), "5 idiv 2"),
+        Arguments.of(integer(2), "4 idiv 2"),
+        Arguments.of(integer(1), "5 idiv 3"),
+        Arguments.of(integer(0), "0 idiv 5"),
+        Arguments.of(integer(0), "1 idiv 5"),
+        // Negative numbers
+        Arguments.of(integer(-2), "-5 idiv 2"),
+        Arguments.of(integer(-2), "5 idiv -2"),
+        Arguments.of(integer(2), "-5 idiv -2"),
+        // Decimal operands (truncated to integer result)
+        Arguments.of(integer(2), "5.5 idiv 2.5"),
+        Arguments.of(integer(2), "5.9 idiv 2.1"),
+        // Mixed integer and decimal
+        Arguments.of(integer(2), "5.5 idiv 2"),
+        Arguments.of(integer(2), "5 idiv 2.25"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideValues")
+  void testExpression(@NonNull IAnyAtomicItem expected, @NonNull String metapath) {
+    IAnyAtomicItem result = IMetapathExpression.compile(metapath)
+        .evaluateAs(null, IMetapathExpression.ResultType.ITEM, newDynamicContext());
+    assertEquals(expected, result);
+  }
+
+  private static Stream<Arguments> provideInvalidValues() {
+    return Stream.of(
+        // Invalid type for idiv - strings cannot be cast to numeric
+        Arguments.of("'abc' idiv 2"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideInvalidValues")
+  void testInvalidExpression(@NonNull String metapath) {
+    IMetapathExpression expr = IMetapathExpression.compile(metapath);
+    assertThrows(MetapathException.class, () -> {
+      expr.evaluateAs(null, IMetapathExpression.ResultType.ITEM, newDynamicContext());
+    });
+  }
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/math/ModuloTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/math/ModuloTest.java
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.cst.math;
+
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.decimal;
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.integer;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import gov.nist.secauto.metaschema.core.metapath.ExpressionTestBase;
+import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
+import gov.nist.secauto.metaschema.core.metapath.MetapathException;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Tests for the Modulo (mod) operation.
+ */
+public class ModuloTest
+    extends ExpressionTestBase {
+
+  private static Stream<Arguments> provideValues() {
+    return Stream.of(
+        // Integer modulo
+        Arguments.of(integer(1), "5 mod 2"),
+        Arguments.of(integer(0), "4 mod 2"),
+        Arguments.of(integer(2), "5 mod 3"),
+        Arguments.of(integer(0), "0 mod 5"),
+        // Negative numbers
+        Arguments.of(integer(-1), "-5 mod 2"),
+        Arguments.of(integer(1), "5 mod -2"),
+        Arguments.of(integer(-1), "-5 mod -2"),
+        // Decimal modulo
+        Arguments.of(decimal("0.5"), "5.5 mod 2.5"),
+        Arguments.of(decimal("0.0"), "5.0 mod 2.5"),
+        // Mixed integer and decimal
+        Arguments.of(decimal("1.5"), "5.5 mod 2"),
+        Arguments.of(decimal("0.5"), "5 mod 2.25"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideValues")
+  void testExpression(@NonNull IAnyAtomicItem expected, @NonNull String metapath) {
+    IAnyAtomicItem result = IMetapathExpression.compile(metapath)
+        .evaluateAs(null, IMetapathExpression.ResultType.ITEM, newDynamicContext());
+    assertEquals(expected, result);
+  }
+
+  private static Stream<Arguments> provideInvalidValues() {
+    return Stream.of(
+        // Invalid type for modulo - strings cannot be cast to numeric
+        Arguments.of("'abc' mod 2"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideInvalidValues")
+  void testInvalidExpression(@NonNull String metapath) {
+    IMetapathExpression expr = IMetapathExpression.compile(metapath);
+    assertThrows(MetapathException.class, () -> {
+      expr.evaluateAs(null, IMetapathExpression.ResultType.ITEM, newDynamicContext());
+    });
+  }
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/math/ModuloTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/math/ModuloTest.java
@@ -59,7 +59,9 @@ public class ModuloTest
   private static Stream<Arguments> provideInvalidValues() {
     return Stream.of(
         // Invalid type for modulo - strings cannot be cast to numeric
-        Arguments.of("'abc' mod 2"));
+        Arguments.of("'abc' mod 2"),
+        // Division by zero
+        Arguments.of("5 mod 0"));
   }
 
   @ParameterizedTest

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/math/NegateTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/math/NegateTest.java
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.cst.math;
+
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.decimal;
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.integer;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import gov.nist.secauto.metaschema.core.metapath.ExpressionTestBase;
+import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
+import gov.nist.secauto.metaschema.core.metapath.MetapathException;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Tests for the Negate (unary minus) operation.
+ */
+public class NegateTest
+    extends ExpressionTestBase {
+
+  private static Stream<Arguments> provideValues() {
+    return Stream.of(
+        // Negate positive integers
+        Arguments.of(integer(-5), "-5"),
+        Arguments.of(integer(-1), "-1"),
+        Arguments.of(integer(0), "-0"),
+        // Negate negative integers (double negation)
+        Arguments.of(integer(5), "--5"),
+        Arguments.of(integer(5), "- -5"),
+        // Negate positive decimals
+        Arguments.of(decimal("-5.5"), "-5.5"),
+        Arguments.of(decimal("-1.0"), "-1.0"),
+        // Negate negative decimals
+        Arguments.of(decimal("5.5"), "--5.5"),
+        // Negate expressions
+        Arguments.of(integer(-7), "-(3 + 4)"),
+        Arguments.of(integer(-1), "-(5 - 4)"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideValues")
+  void testExpression(@NonNull IAnyAtomicItem expected, @NonNull String metapath) {
+    IAnyAtomicItem result = IMetapathExpression.compile(metapath)
+        .evaluateAs(null, IMetapathExpression.ResultType.ITEM, newDynamicContext());
+    assertEquals(expected, result);
+  }
+
+  private static Stream<Arguments> provideInvalidValues() {
+    return Stream.of(
+        // Invalid type for negation - strings cannot be cast to numeric
+        Arguments.of("-'abc'"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideInvalidValues")
+  void testInvalidExpression(@NonNull String metapath) {
+    IMetapathExpression expr = IMetapathExpression.compile(metapath);
+    assertThrows(MetapathException.class, () -> {
+      expr.evaluateAs(null, IMetapathExpression.ResultType.ITEM, newDynamicContext());
+    });
+  }
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/NumericCastSymmetryTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/NumericCastSymmetryTest.java
@@ -9,6 +9,7 @@ import static gov.nist.secauto.metaschema.core.metapath.TestUtils.decimal;
 import static gov.nist.secauto.metaschema.core.metapath.TestUtils.integer;
 import static gov.nist.secauto.metaschema.core.metapath.TestUtils.string;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import gov.nist.secauto.metaschema.core.metapath.function.InvalidValueForCastFunctionException;
@@ -113,6 +114,6 @@ public class NumericCastSymmetryTest {
   void testNumericPassthrough(@NonNull INumericItem input, @NonNull String description) {
     // INumericItem.cast should return the same instance for already-numeric items
     INumericItem result = INumericItem.cast(input);
-    assertEquals(input, result, "INumericItem.cast should return equivalent value for: " + description);
+    assertSame(input, result, "INumericItem.cast should return same instance for: " + description);
   }
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/NumericCastSymmetryTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/NumericCastSymmetryTest.java
@@ -1,0 +1,118 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.item.atomic;
+
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.decimal;
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.integer;
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.string;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import gov.nist.secauto.metaschema.core.metapath.function.InvalidValueForCastFunctionException;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Tests to verify that IDecimalItem.cast() and INumericItem.cast() produce
+ * equivalent results for the same inputs, ensuring behavioral symmetry.
+ */
+public class NumericCastSymmetryTest {
+
+  /**
+   * Test cases where both cast methods should succeed and produce equivalent
+   * numeric values.
+   */
+  private static Stream<Arguments> provideValidCastInputs() {
+    return Stream.of(
+        // Integer inputs
+        Arguments.of(integer(0), "zero integer"),
+        Arguments.of(integer(1), "positive integer"),
+        Arguments.of(integer(-1), "negative integer"),
+        Arguments.of(integer(12345), "large positive integer"),
+        Arguments.of(integer(-12345), "large negative integer"),
+        // Decimal inputs
+        Arguments.of(decimal("0.0"), "zero decimal"),
+        Arguments.of(decimal("1.5"), "positive decimal"),
+        Arguments.of(decimal("-1.5"), "negative decimal"),
+        Arguments.of(decimal("123.456"), "large positive decimal"),
+        Arguments.of(decimal("-123.456"), "large negative decimal"),
+        // String inputs that represent valid numbers
+        Arguments.of(string("0"), "string zero"),
+        Arguments.of(string("123"), "string integer"),
+        Arguments.of(string("-456"), "string negative integer"),
+        Arguments.of(string("1.5"), "string decimal"),
+        Arguments.of(string("-2.5"), "string negative decimal"),
+        // Boolean inputs
+        Arguments.of(IBooleanItem.TRUE, "boolean true"),
+        Arguments.of(IBooleanItem.FALSE, "boolean false"));
+  }
+
+  @ParameterizedTest(name = "{1}")
+  @MethodSource("provideValidCastInputs")
+  void testCastSymmetry(@NonNull IAnyAtomicItem input, @NonNull String description) {
+    // Cast using IDecimalItem.cast
+    IDecimalItem decimalResult = IDecimalItem.cast(input);
+
+    // Cast using INumericItem.cast
+    INumericItem numericResult = INumericItem.cast(input);
+
+    // Both should produce equivalent numeric values (using compareTo for
+    // scale-independent comparison)
+    assertEquals(
+        0,
+        decimalResult.asDecimal().compareTo(numericResult.asDecimal()),
+        "IDecimalItem.cast and INumericItem.cast should produce same numeric value for: " + description);
+  }
+
+  /**
+   * Test cases where cast should fail for both methods.
+   */
+  private static Stream<Arguments> provideInvalidCastInputs() {
+    return Stream.of(
+        Arguments.of(string("abc"), "non-numeric string"),
+        Arguments.of(string(""), "empty string"),
+        Arguments.of(string("1.2.3"), "invalid number format"));
+  }
+
+  @ParameterizedTest(name = "{1}")
+  @MethodSource("provideInvalidCastInputs")
+  void testInvalidCastSymmetry(@NonNull IAnyAtomicItem input, @NonNull String description) {
+    // Both should throw InvalidValueForCastFunctionException
+    assertThrows(
+        InvalidValueForCastFunctionException.class,
+        () -> IDecimalItem.cast(input),
+        "IDecimalItem.cast should throw for: " + description);
+
+    assertThrows(
+        InvalidValueForCastFunctionException.class,
+        () -> INumericItem.cast(input),
+        "INumericItem.cast should throw for: " + description);
+  }
+
+  /**
+   * Test that numeric items are returned efficiently (identity check for already
+   * numeric items).
+   */
+  private static Stream<Arguments> provideNumericInputs() {
+    return Stream.of(
+        Arguments.of(integer(42), "integer item"),
+        Arguments.of(decimal("3.14"), "decimal item"));
+  }
+
+  @ParameterizedTest(name = "{1}")
+  @MethodSource("provideNumericInputs")
+  void testNumericPassthrough(@NonNull INumericItem input, @NonNull String description) {
+    // INumericItem.cast should return the same instance for already-numeric items
+    INumericItem result = INumericItem.cast(input);
+    assertEquals(input, result, "INumericItem.cast should return equivalent value for: " + description);
+  }
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/NumericCastSymmetryTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/NumericCastSymmetryTest.java
@@ -81,7 +81,8 @@ public class NumericCastSymmetryTest {
     return Stream.of(
         Arguments.of(string("abc"), "non-numeric string"),
         Arguments.of(string(""), "empty string"),
-        Arguments.of(string("1.2.3"), "invalid number format"));
+        Arguments.of(string("1.2.3"), "invalid number format"),
+        Arguments.of(string("   "), "whitespace-only string"));
   }
 
   @ParameterizedTest(name = "{1}")


### PR DESCRIPTION
## Summary
- Add non-deprecated `castToNumeric()` method that wraps `INumericItem.cast()` and preserves exception behavior (`InvalidValueForCastFunctionException` → `InvalidTypeMetapathException`)
- Deprecate `toNumericOrNull()` for consistency with other deprecated methods
- Replace deprecated `toNumeric()` calls in math operations: `AbstractBasicArithmeticExpression`, `IntegerDivision`, `Modulo`, `Negate`, `Multiplication`
- Fix `INumericItem.cast()` to handle boolean inputs per XPath 3.1 spec (`true` → 1, `false` → 0)
- Add comprehensive tests for numeric operations and cast symmetry (58 new tests)

## Test plan
- [x] Run unit tests for modified math operations (ModuloTest, IntegerDivisionTest, NegateTest)
- [x] Run NumericCastSymmetryTest to verify IDecimalItem.cast() and INumericItem.cast() produce equivalent results
- [x] Run all numeric-related tests (159 tests pass)
- [x] Verify no new deprecation warnings introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Boolean values cast to numeric (true→1, false→0).
  * New numeric-cast utility to standardize operand coercion.

* **Bug Fixes**
  * More consistent type coercion and explicit null-handling in arithmetic operations.
  * Improved error translation for invalid numeric conversions.

* **Tests**
  * Added coverage for integer division, modulo, negation, and numeric-cast symmetry.

* **Documentation**
  * Added guidance recommending the new numeric-cast utility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->