### PR TITLE
Upgrade maven-surefire-junit5-tree-reporter to 1.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -690,7 +690,14 @@
 						<dependency>
 							<groupId>me.fabriciorby</groupId>
 							<artifactId>maven-surefire-junit5-tree-reporter</artifactId>
-							<version>1.4.0</version>
+							<!--
+								Version compatibility note:
+								- v1.5.1 is compatible with maven-surefire-plugin up to 3.5.3
+								- v1.5.1 is NOT compatible with maven-surefire-plugin 3.5.4+
+								- When upgrading surefire to 3.5.4+, upgrade tree-reporter to 2.x
+								See: https://github.com/fabriciorby/maven-surefire-junit5-tree-reporter/issues/68
+							-->
+							<version>1.5.1</version>
 						</dependency>
 					</dependencies>
 					<configuration>


### PR DESCRIPTION
## Summary
- Upgrade maven-surefire-junit5-tree-reporter from 1.4.0 to 1.5.1

## Problem
The test output was showing repeated `Index: X, Size: 1` error messages due to an `IndexOutOfBoundsException` in the tree reporter's `TreePrinter.printClass` method. While tests still passed, the error output was confusing and occasionally caused issues with test reporting.

## Solution
Upgrade to version 1.5.1 which includes fixes for:
- Null pointer exceptions during printing
- Out-of-bounds errors during test result printing ([v1.5.1 release notes](https://github.com/fabriciorby/maven-surefire-junit5-tree-reporter/releases/tag/v1.5.1))

## Test plan
- [x] Run core module tests - all 4154 tests pass
- [x] Verify `Index: X, Size: 1` errors no longer appear in output
- [x] Verify tree-style test output still displays correctly

Resolves #515

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure dependency (maven-surefire-junit5-tree-reporter) to 1.5.1.
  * Added compatibility guidance: 1.5.1 works with maven-surefire-plugin up to 3.5.3; upgrade the tree-reporter to 2.x when moving surefire to 3.5.4+.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->