### PR TITLE
Fix class initialization deadlock in AbstractArrayItem and AbstractMapItem

### DIFF
--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/impl/AbstractArrayItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/impl/AbstractArrayItem.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import nl.talsmasoftware.lazy4j.Lazy;
 
 /**
  * The base class for {@link IArrayItem} implementations, that provides an
@@ -35,12 +36,19 @@ public abstract class AbstractArrayItem<ITEM extends ICollectionValue>
     implements IArrayItem<ITEM>, IFeatureCollectionFunctionItem {
   @NonNull
   private static final IEnhancedQName QNAME = IEnhancedQName.of("array");
+  /**
+   * The function arguments, lazily initialized to prevent class initialization
+   * deadlock when multiple threads trigger class loading simultaneously.
+   */
   @NonNull
-  private static final List<IArgument> ARGUMENTS = ObjectUtils.notNull(List.of(
-      IArgument.builder().name("position").type(IIntegerItem.type()).one().build()));
-
+  private static final Lazy<List<IArgument>> ARGUMENTS = ObjectUtils.notNull(Lazy.of(() -> ObjectUtils.notNull(List.of(
+      IArgument.builder().name("position").type(IIntegerItem.type()).one().build()))));
+  /**
+   * An empty array item singleton, lazily initialized to prevent class
+   * initialization deadlock.
+   */
   @NonNull
-  private static final IArrayItem<?> EMPTY = new ArrayItemN<>();
+  private static final Lazy<IArrayItem<?>> EMPTY = ObjectUtils.notNull(Lazy.of(ArrayItemN::new));
 
   /**
    * Get an immutable array item that is empty.
@@ -52,7 +60,7 @@ public abstract class AbstractArrayItem<ITEM extends ICollectionValue>
   @SuppressWarnings("unchecked")
   @NonNull
   public static <T extends ICollectionValue> IArrayItem<T> empty() {
-    return (IArrayItem<T>) EMPTY;
+    return (IArrayItem<T>) EMPTY.get();
   }
 
   @Override
@@ -62,7 +70,7 @@ public abstract class AbstractArrayItem<ITEM extends ICollectionValue>
 
   @Override
   public List<IArgument> getArguments() {
-    return ARGUMENTS;
+    return ARGUMENTS.get();
   }
 
   @Override

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/impl/AbstractMapItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/impl/AbstractMapItem.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import nl.talsmasoftware.lazy4j.Lazy;
 
 /**
  * The base class for {@link IMapItem} implementations, that provide an
@@ -43,13 +44,18 @@ public abstract class AbstractMapItem<VALUE extends ICollectionValue>
   @NonNull
   private static final IEnhancedQName QNAME = IEnhancedQName.of("map");
   /**
-   * The function arguments.
+   * The function arguments, lazily initialized to prevent class initialization
+   * deadlock when multiple threads trigger class loading simultaneously.
    */
   @NonNull
-  private static final List<IArgument> ARGUMENTS = ObjectUtils.notNull(List.of(
-      IArgument.builder().name("key").type(IAnyAtomicItem.type()).one().build()));
+  private static final Lazy<List<IArgument>> ARGUMENTS = ObjectUtils.notNull(Lazy.of(() -> ObjectUtils.notNull(List.of(
+      IArgument.builder().name("key").type(IAnyAtomicItem.type()).one().build()))));
+  /**
+   * An empty map item singleton, lazily initialized to prevent class
+   * initialization deadlock.
+   */
   @NonNull
-  private static final IMapItem<?> EMPTY = new MapItemN<>();
+  private static final Lazy<IMapItem<?>> EMPTY = ObjectUtils.notNull(Lazy.of(MapItemN::new));
 
   /**
    * Get an immutable map item that is empty.
@@ -62,7 +68,7 @@ public abstract class AbstractMapItem<VALUE extends ICollectionValue>
   @SuppressWarnings("unchecked")
   @NonNull
   public static <V extends ICollectionValue> IMapItem<V> empty() {
-    return (IMapItem<V>) EMPTY;
+    return (IMapItem<V>) EMPTY.get();
   }
 
   @Override
@@ -72,7 +78,7 @@ public abstract class AbstractMapItem<VALUE extends ICollectionValue>
 
   @Override
   public List<IArgument> getArguments() {
-    return ARGUMENTS;
+    return ARGUMENTS.get();
   }
 
   @Override


### PR DESCRIPTION
## Summary

- Convert static field initializers in `AbstractArrayItem` and `AbstractMapItem` to use lazy initialization via `Lazy<T>`
- This prevents class initialization deadlock when JUnit 5's `SEPARATE_THREAD` timeout mode causes concurrent class loading from multiple threads

## Problem

The deadlock occurred because:
1. Static `ARGUMENTS` field initialization called `IIntegerItem.type()` / `IAnyAtomicItem.type()`
2. This triggered initialization of other classes
3. When multiple threads competed for class locks during parallel test execution, they could deadlock
4. JUnit 5's timeout thread (in `SEPARATE_THREAD` mode) could trigger class initialization simultaneously with the test thread

## Solution

Convert the problematic static fields to use `Lazy<>` pattern:
- `ARGUMENTS` field now uses `Lazy<List<IArgument>>`
- `EMPTY` singleton now uses `Lazy<IArrayItem<?>>`/`Lazy<IMapItem<?>>`

This defers initialization until first use within a single thread context, preventing the deadlock.

## Test plan

- [x] Verified `ArraySizeTest`, `MapSizeTest`, `MapContainsTest` pass with `forkCount=4`
- [x] Verified compilation succeeds
- [x] Tested with parallel test execution

Fixes #515

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized static initialization patterns in array and map item handling to improve startup performance and reduce memory overhead through deferred resource allocation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->