### PR TITLE
Add type utility methods to ISequence for function library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,4 +8,4 @@
 [submodule "databind-metaschema/modules"]
 	path = databind-metaschema/modules
 	url = https://github.com/metaschema-framework/metaschema-modules.git
-	branch = main
+	branch = develop

--- a/PRDs/20251206-build-cleanup/implementation-plan.md
+++ b/PRDs/20251206-build-cleanup/implementation-plan.md
@@ -150,37 +150,48 @@ Math operations in CST package.
 
 ---
 
-### PR 4: Fix FunctionUtils Deprecation (Function Library)
+### PR 4: Fix FunctionUtils Deprecation (Function Library) ✅ COMPLETED
 
 | Attribute | Value |
 |-----------|-------|
-| **Files Changed** | ~5 |
+| **Files Changed** | 5 (3 source + 1 test + 1 interface) |
 | **Risk Level** | Medium |
 | **Dependencies** | PR 3 |
 | **Target Branch** | develop |
+| **Status** | ✅ Completed 2025-12-07 |
+| **Pull Request** | [#520](https://github.com/metaschema-framework/metaschema-java/pull/520) |
 
 #### Focus
 Function library classes that use deprecated FunctionUtils methods.
 
-#### Files to Modify
+#### Files Modified
 
-| File | Line(s) | Method |
-|------|---------|--------|
-| `core/.../function/library/FnAvg.java` | 96 | `countTypes()` |
-| `core/.../function/library/FnMinMax.java` | 201, 234 | `countTypes()`, `getTypes()` |
-| `core/.../function/library/FnSum.java` | 137 | `countTypes()` |
+| File | Changes |
+|------|---------|
+| `core/.../item/ISequence.java` | Added `countTypes()` and `getItemTypes()` methods; optimized `ofCollection()` to return ISequence unchanged |
+| `core/.../function/library/FnAvg.java` | Added private `countTypes()` helper using ISequence methods |
+| `core/.../function/library/FnMinMax.java` | Replaced `FunctionUtils.countTypes()` and `getTypes()` with ISequence methods |
+| `core/.../function/library/FnSum.java` | Replaced `FunctionUtils.countTypes()` with ISequence method |
 
-#### Implementation Approach
+#### Test Files Added/Modified
 
-1. Replace `countTypes()` calls with inline type counting logic
-2. Replace `getTypes()` calls with inline type extraction
+| File | Tests | Description |
+|------|-------|-------------|
+| `core/.../metapath/ISequenceTest.java` | 9 | Tests for `countTypes()`, `getItemTypes()`, and `ofCollection()` passthrough behavior |
+
+#### Implementation Findings
+
+1. **ISequence enhancements**: Added type utility methods directly to ISequence interface for reuse across function library
+2. **Performance optimization**: `ofCollection()` now returns ISequence unchanged when input is already a sequence, avoiding unnecessary wrapping
+3. **Documentation**: Added comprehensive Javadoc documenting defensive copy behavior (or lack thereof)
 
 #### Acceptance Criteria
 
-- [ ] Tests written/updated before code changes (TDD)
-- [ ] No deprecated `FunctionUtils.countTypes()` calls
-- [ ] No deprecated `FunctionUtils.getTypes()` calls
-- [ ] All Metapath function tests pass
+- [x] Tests written/updated before code changes (TDD) - 9 new tests for ISequence methods
+- [x] No deprecated `FunctionUtils.countTypes()` calls
+- [x] No deprecated `FunctionUtils.getTypes()` calls
+- [x] All Metapath function tests pass
+- [x] New ISequence methods documented with Javadoc
 
 ---
 
@@ -415,7 +426,7 @@ Type requirement methods and remaining usages.
 | 1 | Fix finalize() deprecation | 2 | Medium | None | ✅ [#512](https://github.com/metaschema-framework/metaschema-java/pull/512) |
 | 2 | Fix @Component deprecation | 1 | Low | None | ✅ [#513](https://github.com/metaschema-framework/metaschema-java/pull/513) |
 | 3 | Fix FunctionUtils (math ops) | 11 | Medium | None | ✅ [#514](https://github.com/metaschema-framework/metaschema-java/pull/514) |
-| 4 | Fix FunctionUtils (function library) | ~5 | Medium | PR 3 | Pending |
+| 4 | Fix FunctionUtils (function library) | 5 | Medium | PR 3 | ✅ [#520](https://github.com/metaschema-framework/metaschema-java/pull/520) |
 | 5 | Fix FunctionUtils (type requirements) | ~6 | Medium | PR 4 (recommended) | Pending |
 | 6 | Fix INcNameItem deprecation | ~5 | Medium | None | Pending |
 | 7 | Javadoc: core/model | ~40-50 | Low | None | Pending |
@@ -426,7 +437,7 @@ Type requirement methods and remaining usages.
 | 12 | Javadoc: remaining | ~20-30 | Low | None | Pending |
 
 **Total Estimated PRs**: 12
-**Completed PRs**: 3
+**Completed PRs**: 4
 **Total Estimated Files**: ~250-300 (within limits when split across PRs)
 
 ## Related Issues

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnAvg.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnAvg.java
@@ -230,7 +230,7 @@ public final class FnAvg {
   private static <T extends IItem> Map<Class<? extends T>, Integer> countTypes(
       @NonNull java.util.Set<Class<? extends T>> classes,
       @NonNull Collection<? extends T> items) {
-    // Convert to List<T> for ISequence.ofCollection
+    // ISequence.ofCollection handles ISequence passthrough and List conversion
     List<T> itemList = items instanceof List
         ? (List<T>) items
         : ObjectUtils.notNull(items.stream().collect(Collectors.toList()));

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnAvg.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnAvg.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -93,7 +94,7 @@ public final class FnAvg {
 
     // tell cpd to start ignoring code - CPD-OFF
 
-    Map<Class<? extends IAnyAtomicItem>, Integer> typeCounts = FunctionUtils.countTypes(
+    Map<Class<? extends IAnyAtomicItem>, Integer> typeCounts = countTypes(
         OperationFunctions.aggregateMathTypes(),
         ObjectUtils.notNull(items));
 
@@ -210,5 +211,29 @@ public final class FnAvg {
         items,
         (BinaryOperator<INumericItem>) OperationFunctions::opNumericAdd,
         (BiFunction<INumericItem, IIntegerItem, IDecimalItem>) OperationFunctions::opNumericDivide);
+  }
+
+  /**
+   * Count the occurrences of the provided data type item classes in the
+   * collection of items.
+   *
+   * @param <T>
+   *          the base item type
+   * @param classes
+   *          the set of classes to count
+   * @param items
+   *          the items to analyze
+   * @return a mapping of class to count
+   */
+  @SuppressWarnings("unchecked")
+  @NonNull
+  private static <T extends IItem> Map<Class<? extends T>, Integer> countTypes(
+      @NonNull java.util.Set<Class<? extends T>> classes,
+      @NonNull Collection<? extends T> items) {
+    // Convert to List<T> for ISequence.ofCollection
+    List<T> itemList = items instanceof List
+        ? (List<T>) items
+        : ObjectUtils.notNull(items.stream().collect(Collectors.toList()));
+    return ISequence.ofCollection(itemList).countTypes(classes);
   }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnMinMax.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnMinMax.java
@@ -26,6 +26,7 @@ import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IUntypedAtomicItem;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -198,7 +199,7 @@ public final class FnMinMax {
   @NonNull
   private static Map<Class<? extends IAnyAtomicItem>, Integer> countItemTypes(
       @NonNull List<? extends IAnyAtomicItem> items) {
-    return FunctionUtils.countTypes(PRIMITIVE_ITEM_TYPES, items);
+    return ISequence.ofCollection(new ArrayList<>(items)).countTypes(PRIMITIVE_ITEM_TYPES);
   }
 
   @SuppressWarnings("PMD.OnlyOneReturn")
@@ -231,7 +232,7 @@ public final class FnMinMax {
         InvalidArgumentFunctionException.INVALID_ARGUMENT_TYPE,
         String.format(
             "Values must all be of a single atomic type. Found multiple types: [%s]",
-            FunctionUtils.getTypes(items).stream()
+            ISequence.ofCollection(new ArrayList<>(items)).getItemTypes().stream()
                 .map(Class::getSimpleName)
                 .collect(Collectors.joining(", "))));
   }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnMinMax.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnMinMax.java
@@ -26,7 +26,6 @@ import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IUntypedAtomicItem;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -196,10 +195,11 @@ public final class FnMinMax {
         .collect(Collectors.toList()));
   }
 
+  @SuppressWarnings("unchecked")
   @NonNull
   private static Map<Class<? extends IAnyAtomicItem>, Integer> countItemTypes(
       @NonNull List<? extends IAnyAtomicItem> items) {
-    return ISequence.ofCollection(new ArrayList<>(items)).countTypes(PRIMITIVE_ITEM_TYPES);
+    return ISequence.ofCollection((List<IAnyAtomicItem>) items).countTypes(PRIMITIVE_ITEM_TYPES);
   }
 
   @SuppressWarnings("PMD.OnlyOneReturn")
@@ -228,11 +228,13 @@ public final class FnMinMax {
     }
 
     // No valid conversion possible
+    @SuppressWarnings("unchecked")
+    List<IAnyAtomicItem> itemList = (List<IAnyAtomicItem>) items;
     throw new InvalidArgumentFunctionException(
         InvalidArgumentFunctionException.INVALID_ARGUMENT_TYPE,
         String.format(
             "Values must all be of a single atomic type. Found multiple types: [%s]",
-            ISequence.ofCollection(new ArrayList<>(items)).getItemTypes().stream()
+            ISequence.ofCollection(itemList).getItemTypes().stream()
                 .map(Class::getSimpleName)
                 .collect(Collectors.joining(", "))));
   }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSum.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSum.java
@@ -22,7 +22,6 @@ import gov.nist.secauto.metaschema.core.metapath.item.atomic.IYearMonthDurationI
 import gov.nist.secauto.metaschema.core.util.CustomCollectors;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -119,7 +118,8 @@ public final class FnSum {
    */
   @SuppressWarnings({
       "PMD.OnlyOneReturn", // readability
-      "PMD.CyclomaticComplexity" // ok
+      "PMD.CyclomaticComplexity", // ok
+      "unchecked" // safe cast for wildcard type
   })
   @Nullable
   public static IAnyAtomicItem sum(
@@ -135,7 +135,8 @@ public final class FnSum {
 
     // tell cpd to start ignoring code - CPD-OFF
 
-    Map<Class<? extends IAnyAtomicItem>, Integer> typeCounts = ISequence.ofCollection(new ArrayList<>(items))
+    Map<Class<? extends IAnyAtomicItem>, Integer> typeCounts = ISequence
+        .ofCollection((List<IAnyAtomicItem>) items)
         .countTypes(OperationFunctions.aggregateMathTypes());
 
     int count = items.size();

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSum.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSum.java
@@ -22,6 +22,7 @@ import gov.nist.secauto.metaschema.core.metapath.item.atomic.IYearMonthDurationI
 import gov.nist.secauto.metaschema.core.util.CustomCollectors;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -134,9 +135,8 @@ public final class FnSum {
 
     // tell cpd to start ignoring code - CPD-OFF
 
-    Map<Class<? extends IAnyAtomicItem>, Integer> typeCounts = FunctionUtils.countTypes(
-        OperationFunctions.aggregateMathTypes(),
-        ObjectUtils.notNull(items));
+    Map<Class<? extends IAnyAtomicItem>, Integer> typeCounts = ISequence.ofCollection(new ArrayList<>(items))
+        .countTypes(OperationFunctions.aggregateMathTypes());
 
     int count = items.size();
     int dayTimeCount = typeCounts.getOrDefault(IDayTimeDurationItem.class, 0);

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/ISequence.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/ISequence.java
@@ -18,8 +18,12 @@ import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -592,5 +596,46 @@ public interface ISequence<ITEM extends IItem> extends List<ITEM>, ICollectionVa
         : collection.isEmpty()
             ? empty()
             : new SequenceN<>(new ArrayList<>(collection));
+  }
+
+  /**
+   * Count the occurrences of items in this sequence that are instances of the
+   * provided type classes.
+   * <p>
+   * For each class in the provided set, this method counts how many items in the
+   * sequence are assignable to that class.
+   *
+   * @param <T>
+   *          the base type of the classes to count
+   * @param classes
+   *          the set of classes to count occurrences for
+   * @return a map from each class to the count of matching items
+   */
+  @NonNull
+  default <T extends IItem> Map<Class<? extends T>, Integer> countTypes(
+      @NonNull Set<Class<? extends T>> classes) {
+    Map<Class<? extends T>, Integer> retval = new HashMap<>();
+    for (ITEM item : this) {
+      Class<?> itemClass = item.getClass();
+      for (Class<? extends T> clazz : classes) {
+        if (clazz.isAssignableFrom(itemClass)) {
+          retval.compute(clazz, (cl, current) -> current == null ? 1 : current + 1);
+        }
+      }
+    }
+    return retval;
+  }
+
+  /**
+   * Get a list of the Java class types for each item in this sequence.
+   *
+   * @return a list of class types corresponding to each item in the sequence
+   */
+  @SuppressWarnings("unchecked")
+  @NonNull
+  default List<Class<? extends ITEM>> getItemTypes() {
+    return ObjectUtils.notNull(safeStream()
+        .map(item -> (Class<? extends ITEM>) item.getClass())
+        .collect(Collectors.toList()));
   }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/ISequence.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/ISequence.java
@@ -255,18 +255,27 @@ public interface ISequence<ITEM extends IItem> extends List<ITEM>, ICollectionVa
 
   /**
    * Returns an unmodifiable sequence containing the provided {@code items}.
+   * <p>
+   * If the provided collection is already an {@link ISequence}, it is returned
+   * unchanged. Otherwise, the collection is wrapped directly without making a
+   * defensive copy. If you need a sequence that is independent of the original
+   * collection, use {@link #copyOf(Collection)} instead.
    *
    * @param <ITEM_TYPE>
    *          the type of items contained in the sequence.
    * @param items
    *          the items to add to the sequence
-   * @return the new sequence
+   * @return the new sequence, or the same sequence if items is already an
+   *         {@link ISequence}
    */
+  @SuppressWarnings("unchecked")
   @NonNull
   static <ITEM_TYPE extends IItem> ISequence<ITEM_TYPE> ofCollection( // NOPMD - intentional
       @NonNull Collection<ITEM_TYPE> items) {
     ISequence<ITEM_TYPE> retval;
-    if (items.isEmpty()) {
+    if (items instanceof ISequence) {
+      retval = (ISequence<ITEM_TYPE>) items;
+    } else if (items.isEmpty()) {
       retval = empty();
     } else if (items.size() == 1) {
       retval = new SingletonSequence<>(ObjectUtils.notNull(items.iterator().next()));

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/ISequenceTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/ISequenceTest.java
@@ -11,6 +11,7 @@ import static gov.nist.secauto.metaschema.core.metapath.TestUtils.string;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -153,5 +154,16 @@ class ISequenceTest {
     assertTrue(IStringItem.class.isAssignableFrom(types.get(0)));
     assertTrue(IIntegerItem.class.isAssignableFrom(types.get(1)));
     assertTrue(IStringItem.class.isAssignableFrom(types.get(2)));
+  }
+
+  @Test
+  void testOfCollectionReturnsSequenceUnchanged() {
+    // When ofCollection receives an ISequence, it should return the same instance
+    ISequence<IAnyAtomicItem> original = ISequence.of(integer(1), integer(2));
+
+    ISequence<IAnyAtomicItem> result = ISequence.ofCollection(original);
+
+    // Should be the exact same instance, not a copy
+    assertSame(original, result);
   }
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/ISequenceTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/ISequenceTest.java
@@ -5,16 +5,28 @@
 
 package gov.nist.secauto.metaschema.core.metapath;
 
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.decimal;
 import static gov.nist.secauto.metaschema.core.metapath.TestUtils.integer;
+import static gov.nist.secauto.metaschema.core.metapath.TestUtils.string;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import gov.nist.secauto.metaschema.core.metapath.item.ISequence;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IDecimalItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IIntegerItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.INumericItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
 import gov.nist.secauto.metaschema.core.metapath.type.InvalidTypeMetapathException;
 
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 class ISequenceTest {
 
@@ -33,5 +45,113 @@ class ISequenceTest {
             () -> ISequence.of(integer(1), integer(2)).getFirstItem(true)),
         () -> assertEquals(integer(3), ISequence.of(integer(3)).getFirstItem(true)),
         () -> assertNull(ISequence.of().getFirstItem(true)));
+  }
+
+  @Test
+  void testCountTypesEmpty() {
+    ISequence<IAnyAtomicItem> sequence = ISequence.of();
+    Set<Class<? extends IAnyAtomicItem>> classes = Set.of(IStringItem.class, INumericItem.class);
+
+    Map<Class<? extends IAnyAtomicItem>, Integer> counts = sequence.countTypes(classes);
+
+    assertTrue(counts.isEmpty());
+  }
+
+  @Test
+  void testCountTypesSingleType() {
+    ISequence<IAnyAtomicItem> sequence = ISequence.of(integer(1), integer(2), integer(3));
+    Set<Class<? extends IAnyAtomicItem>> classes = Set.of(INumericItem.class);
+
+    Map<Class<? extends IAnyAtomicItem>, Integer> counts = sequence.countTypes(classes);
+
+    assertEquals(1, counts.size());
+    assertEquals(3, counts.get(INumericItem.class));
+  }
+
+  @Test
+  void testCountTypesMultipleTypes() {
+    ISequence<IAnyAtomicItem> sequence = ISequence.of(integer(1), string("test"), integer(2), decimal(3));
+    Set<Class<? extends IAnyAtomicItem>> classes = Set.of(IStringItem.class, INumericItem.class, IDecimalItem.class);
+
+    Map<Class<? extends IAnyAtomicItem>, Integer> counts = sequence.countTypes(classes);
+
+    // integer(1), integer(2), decimal(3) are all INumericItem (3 items)
+    assertEquals(3, counts.get(INumericItem.class));
+    // string("test") is IStringItem (1 item)
+    assertEquals(1, counts.get(IStringItem.class));
+    // IIntegerItem extends IDecimalItem, so all 3 numeric items (2 integers + 1
+    // decimal) match IDecimalItem
+    assertEquals(3, counts.get(IDecimalItem.class));
+  }
+
+  @Test
+  void testCountTypesInheritance() {
+    // Test that IIntegerItem items are counted as INumericItem
+    ISequence<IAnyAtomicItem> sequence = ISequence.of(integer(1), integer(2));
+    Set<Class<? extends IAnyAtomicItem>> classes = Set.of(INumericItem.class, IIntegerItem.class);
+
+    Map<Class<? extends IAnyAtomicItem>, Integer> counts = sequence.countTypes(classes);
+
+    // Both integers should count for INumericItem (parent type)
+    assertEquals(2, counts.get(INumericItem.class));
+    // Both integers should also count for IIntegerItem (exact type)
+    assertEquals(2, counts.get(IIntegerItem.class));
+  }
+
+  @Test
+  void testCountTypesNoMatch() {
+    ISequence<IAnyAtomicItem> sequence = ISequence.of(integer(1), integer(2));
+    Set<Class<? extends IAnyAtomicItem>> classes = Set.of(IStringItem.class);
+
+    Map<Class<? extends IAnyAtomicItem>, Integer> counts = sequence.countTypes(classes);
+
+    // No strings in the sequence
+    assertTrue(counts.isEmpty());
+  }
+
+  @Test
+  void testGetItemTypesEmpty() {
+    ISequence<IAnyAtomicItem> sequence = ISequence.of();
+
+    List<Class<? extends IAnyAtomicItem>> types = sequence.getItemTypes();
+
+    assertTrue(types.isEmpty());
+  }
+
+  @Test
+  void testGetItemTypesSingleItem() {
+    ISequence<IAnyAtomicItem> sequence = ISequence.of(integer(42));
+
+    List<Class<? extends IAnyAtomicItem>> types = sequence.getItemTypes();
+
+    assertEquals(1, types.size());
+    assertTrue(IIntegerItem.class.isAssignableFrom(types.get(0)));
+  }
+
+  @Test
+  void testGetItemTypesMultipleItems() {
+    ISequence<IAnyAtomicItem> sequence = ISequence.of(integer(1), string("test"), decimal(3));
+
+    List<Class<? extends IAnyAtomicItem>> types = sequence.getItemTypes();
+
+    assertEquals(3, types.size());
+    // First item is an integer
+    assertTrue(IIntegerItem.class.isAssignableFrom(types.get(0)));
+    // Second item is a string
+    assertTrue(IStringItem.class.isAssignableFrom(types.get(1)));
+    // Third item is a decimal
+    assertTrue(IDecimalItem.class.isAssignableFrom(types.get(2)));
+  }
+
+  @Test
+  void testGetItemTypesPreservesOrder() {
+    ISequence<IAnyAtomicItem> sequence = ISequence.of(string("a"), integer(1), string("b"));
+
+    List<Class<? extends IAnyAtomicItem>> types = sequence.getItemTypes();
+
+    assertEquals(3, types.size());
+    assertTrue(IStringItem.class.isAssignableFrom(types.get(0)));
+    assertTrue(IIntegerItem.class.isAssignableFrom(types.get(1)));
+    assertTrue(IStringItem.class.isAssignableFrom(types.get(2)));
   }
 }


### PR DESCRIPTION
## Summary
- Add `countTypes()` and `getItemTypes()` methods to `ISequence`
- Update `FnAvg`, `FnMinMax`, `FnSum` to use new ISequence methods
- Replace deprecated `FunctionUtils.countTypes()` and `FunctionUtils.getTypes()` calls

## Changes
1. **ISequence.java**: Add `countTypes()` to count items by type class, `getItemTypes()` to get list of item classes
2. **FnAvg.java**: Use private helper calling ISequence.countTypes()
3. **FnMinMax.java**: Replace FunctionUtils calls with ISequence methods
4. **FnSum.java**: Replace FunctionUtils.countTypes() with ISequence.countTypes()
5. **ISequenceTest.java**: Add comprehensive tests for new methods

## Test plan
- [x] All existing FnAvg, FnMinMax, FnSum tests pass
- [x] New ISequenceTest tests pass for countTypes() and getItemTypes()
- [x] Full CI build passes with `mvn clean install -PCI -Prelease`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sequence utilities to expose item-type counting and runtime type extraction.

* **Refactor**
  * Standardized internal type-counting to use the new sequence-based approach across average, sum, and min/max functions.

* **Tests**
  * Added comprehensive unit tests covering type-counting, type-extraction, order behavior, and of-collection handling.

* **Documentation**
  * Updated implementation plan, acceptance criteria, and status metadata to reflect new utilities and tests.

* **Chores**
  * Updated submodule branch configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->