### PR TITLE
Emphasize PR requirement to target develop branch in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,8 @@ mvn -pl core test -Dtest=FnCountTest#testCount
 ## Git Workflow
 
 - Repository: https://github.com/metaschema-framework/metaschema-java
-- New PRs target the `develop` branch
+- **All PRs MUST be created from a personal fork** (BLOCKING - required by CONTRIBUTING.md)
+- **All PRs MUST target the `develop` branch** (BLOCKING - required by CONTRIBUTING.md)
 - Clone with submodules: `git clone --recurse-submodules`
 - All changes require PR review (CODEOWNERS enforced)
 - Squash non-relevant commits before submitting PR (BLOCKING)


### PR DESCRIPTION
## Summary
Mark the develop branch requirement as BLOCKING and reference CONTRIBUTING.md to ensure all PRs follow the required git workflow.

## Changes
Update Git Workflow section to emphasize that all PRs MUST target the `develop` branch, marking it as a blocking requirement per CONTRIBUTING.md.

## Test plan
- Documentation only change, no tests required