### PR TITLE
Replace deprecated FunctionUtils type-checking methods with inline logic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,18 @@ metaschema-framework (parent)
 - **datatype/** - Data type adapters for Metaschema types
 - **mdm/** - Metaschema Document Model node items
 
+### Metapath and XPath 3.1
+
+Metapath is an implementation of XPath 3.1. The [XPath 3.1 specification](https://www.w3.org/TR/xpath-31/) and [XPath Functions 3.1](https://www.w3.org/TR/xpath-functions-31/) should be used as the authoritative behavioral reference when:
+- Implementing new Metapath functions
+- Fixing bugs in existing function implementations
+- Understanding expected error handling behavior
+
+**When behavior differs from the spec**: If you discover that the current Metapath implementation differs from the XPath 3.1 specification, raise this as a clarification to the user before making changes. Consider:
+- Whether the deviation is intentional (Metaschema-specific extension)
+- The risk of changing behavior that existing code may depend on
+- Whether tests need to be added to verify spec-compliant behavior
+
 ### Generated Code
 
 Code generation occurs during Maven build:

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/IMetapathExpression.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/IMetapathExpression.java
@@ -35,8 +35,16 @@ public interface IMetapathExpression extends IExpression {
      * The result is expected to be a {@link BigDecimal} value.
      */
     NUMBER(BigDecimal.class, sequence -> {
-      INumericItem numeric = FunctionUtils.toNumeric(sequence, true);
-      return numeric == null ? null : numeric.asDecimal();
+      IItem item = sequence.getFirstItem(true);
+      if (item == null) {
+        return null;
+      }
+      IAnyAtomicItem atomicItem = ISequence.getFirstItem(item.atomize(), true);
+      if (atomicItem == null) {
+        throw new InvalidTypeMetapathException(item, "Unable to cast to numeric: atomization returned null");
+      }
+      INumericItem numeric = FunctionUtils.castToNumeric(atomicItem);
+      return numeric.asDecimal();
     }),
     /**
      * The result is expected to be a {@link String} value.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnBaseUri.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnBaseUri.java
@@ -85,7 +85,7 @@ public final class FnBaseUri {
       // Per XPath 3.1: If the context item is not a node, type error [err:XPTY0004]
       throw new InvalidTypeMetapathException(
           focus,
-          String.format("Expected type '%s', but the node was type '%s'.",
+          String.format("Expected type '%s', but the item was type '%s'.",
               INodeItem.class.getName(),
               focus.getClass().getName()));
     }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnBaseUri.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnBaseUri.java
@@ -5,6 +5,7 @@
 
 package gov.nist.secauto.metaschema.core.metapath.function.library;
 
+import gov.nist.secauto.metaschema.core.metapath.ContextAbsentDynamicMetapathException;
 import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
 import gov.nist.secauto.metaschema.core.metapath.MetapathConstants;
 import gov.nist.secauto.metaschema.core.metapath.function.FunctionUtils;
@@ -75,10 +76,13 @@ public final class FnBaseUri {
       IItem focus) {
     INodeItem nodeItem;
     if (focus == null) {
-      nodeItem = null;
+      // Per XPath 3.1: If the context item is absent, dynamic error [err:XPDY0002]
+      throw new ContextAbsentDynamicMetapathException(
+          "The context item is absent for fn:base-uri()");
     } else if (focus instanceof INodeItem) {
       nodeItem = (INodeItem) focus;
     } else {
+      // Per XPath 3.1: If the context item is not a node, type error [err:XPTY0004]
       throw new InvalidTypeMetapathException(
           focus,
           String.format("Expected type '%s', but the node was type '%s'.",

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnBaseUri.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnBaseUri.java
@@ -14,6 +14,7 @@ import gov.nist.secauto.metaschema.core.metapath.item.IItem;
 import gov.nist.secauto.metaschema.core.metapath.item.ISequence;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyUriItem;
 import gov.nist.secauto.metaschema.core.metapath.item.node.INodeItem;
+import gov.nist.secauto.metaschema.core.metapath.type.InvalidTypeMetapathException;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
 import java.net.URI;
@@ -72,8 +73,19 @@ public final class FnBaseUri {
       @NonNull List<ISequence<?>> arguments,
       @NonNull DynamicContext dynamicContext,
       IItem focus) {
-    return ISequence.of(fnBaseUri(
-        FunctionUtils.requireTypeOrNull(INodeItem.class, focus)));
+    INodeItem nodeItem;
+    if (focus == null) {
+      nodeItem = null;
+    } else if (focus instanceof INodeItem) {
+      nodeItem = (INodeItem) focus;
+    } else {
+      throw new InvalidTypeMetapathException(
+          focus,
+          String.format("Expected type '%s', but the node was type '%s'.",
+              INodeItem.class.getName(),
+              focus.getClass().getName()));
+    }
+    return ISequence.of(fnBaseUri(nodeItem));
   }
 
   @SuppressWarnings("unused")

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnBaseUri.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnBaseUri.java
@@ -85,7 +85,7 @@ public final class FnBaseUri {
       // Per XPath 3.1: If the context item is not a node, type error [err:XPTY0004]
       throw new InvalidTypeMetapathException(
           focus,
-          String.format("Expected type '%s', but the item was type '%s'.",
+          String.format("Expected type '%s', but the context item was type '%s'.",
               INodeItem.class.getName(),
               focus.getClass().getName()));
     }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnData.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnData.java
@@ -14,6 +14,7 @@ import gov.nist.secauto.metaschema.core.metapath.item.IItem;
 import gov.nist.secauto.metaschema.core.metapath.item.ISequence;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem;
 import gov.nist.secauto.metaschema.core.metapath.item.node.INodeItem;
+import gov.nist.secauto.metaschema.core.metapath.type.InvalidTypeMetapathException;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
 import java.util.List;
@@ -67,14 +68,18 @@ public final class FnData {
       @NonNull DynamicContext dynamicContext,
       IItem focus) {
 
-    INodeItem item = FunctionUtils.requireTypeOrNull(INodeItem.class, focus);
-
     ISequence<IAnyAtomicItem> retval;
-    if (item == null) {
+    if (focus == null) {
       retval = ISequence.empty();
-    } else {
-      IAnyAtomicItem data = item.toAtomicItem();
+    } else if (focus instanceof INodeItem) {
+      IAnyAtomicItem data = ((INodeItem) focus).toAtomicItem();
       retval = ISequence.of(data);
+    } else {
+      throw new InvalidTypeMetapathException(
+          focus,
+          String.format("Expected type '%s', but the node was type '%s'.",
+              INodeItem.class.getName(),
+              focus.getClass().getName()));
     }
     return retval;
   }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnData.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnData.java
@@ -13,8 +13,6 @@ import gov.nist.secauto.metaschema.core.metapath.function.IFunction;
 import gov.nist.secauto.metaschema.core.metapath.item.IItem;
 import gov.nist.secauto.metaschema.core.metapath.item.ISequence;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem;
-import gov.nist.secauto.metaschema.core.metapath.item.node.INodeItem;
-import gov.nist.secauto.metaschema.core.metapath.type.InvalidTypeMetapathException;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
 import java.util.List;
@@ -67,21 +65,13 @@ public final class FnData {
       @NonNull List<ISequence<?>> arguments,
       @NonNull DynamicContext dynamicContext,
       IItem focus) {
-
-    ISequence<IAnyAtomicItem> retval;
-    if (focus == null) {
-      retval = ISequence.empty();
-    } else if (focus instanceof INodeItem) {
-      IAnyAtomicItem data = ((INodeItem) focus).toAtomicItem();
-      retval = ISequence.of(data);
-    } else {
-      throw new InvalidTypeMetapathException(
-          focus,
-          String.format("Expected type '%s', but the node was type '%s'.",
-              INodeItem.class.getName(),
-              focus.getClass().getName()));
-    }
-    return retval;
+    // Per XPath 3.1 spec, fn:data() atomizes the context item:
+    // - Atomic values pass through unchanged
+    // - Nodes are replaced with their typed values
+    // - Arrays are flattened
+    return focus == null
+        ? ISequence.empty()
+        : ISequence.of(focus.atomize());
   }
 
   @SuppressWarnings("unused")

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDocumentUri.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDocumentUri.java
@@ -15,6 +15,7 @@ import gov.nist.secauto.metaschema.core.metapath.item.ISequence;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyUriItem;
 import gov.nist.secauto.metaschema.core.metapath.item.node.IDocumentNodeItem;
 import gov.nist.secauto.metaschema.core.metapath.item.node.INodeItem;
+import gov.nist.secauto.metaschema.core.metapath.type.InvalidTypeMetapathException;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
 import java.util.List;
@@ -69,11 +70,24 @@ public final class FnDocumentUri {
       @NonNull DynamicContext dynamicContext,
       IItem focus) {
 
-    INodeItem item = FunctionUtils.requireTypeOrNull(INodeItem.class, focus);
-
-    return item instanceof IDocumentNodeItem
-        ? ISequence.of(fnDocumentUri((IDocumentNodeItem) item))
-        : ISequence.empty();
+    ISequence<IAnyUriItem> retval;
+    if (focus == null) {
+      // context item absent - handled by Metapath runtime
+      retval = ISequence.empty();
+    } else if (focus instanceof IDocumentNodeItem) {
+      retval = ISequence.of(fnDocumentUri((IDocumentNodeItem) focus));
+    } else if (focus instanceof INodeItem) {
+      // node item but not a document - return empty sequence per XPath spec
+      retval = ISequence.empty();
+    } else {
+      // not a node at all - throw type error per XPath spec
+      throw new InvalidTypeMetapathException(
+          focus,
+          String.format("Expected type '%s', but the node was type '%s'.",
+              INodeItem.class.getName(),
+              focus.getClass().getName()));
+    }
+    return retval;
   }
 
   @SuppressWarnings("unused")

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDocumentUri.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDocumentUri.java
@@ -51,7 +51,7 @@ public final class FnDocumentUri {
       .focusIndependent()
       .argument(IArgument.builder()
           .name("arg1")
-          .type(IDocumentNodeItem.type())
+          .type(INodeItem.type())
           .zeroOrOne()
           .build())
       .returnType(IAnyUriItem.type())

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDocumentUri.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDocumentUri.java
@@ -85,7 +85,7 @@ public final class FnDocumentUri {
       // not a node at all - throw type error per XPath spec
       throw new InvalidTypeMetapathException(
           focus,
-          String.format("Expected type '%s', but the item was type '%s'.",
+          String.format("Expected type '%s', but the context item was type '%s'.",
               INodeItem.class.getName(),
               focus.getClass().getName()));
     }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDocumentUri.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDocumentUri.java
@@ -85,7 +85,7 @@ public final class FnDocumentUri {
       // not a node at all - throw type error per XPath spec
       throw new InvalidTypeMetapathException(
           focus,
-          String.format("Expected type '%s', but the node was type '%s'.",
+          String.format("Expected type '%s', but the item was type '%s'.",
               INodeItem.class.getName(),
               focus.getClass().getName()));
     }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDocumentUri.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDocumentUri.java
@@ -5,6 +5,7 @@
 
 package gov.nist.secauto.metaschema.core.metapath.function.library;
 
+import gov.nist.secauto.metaschema.core.metapath.ContextAbsentDynamicMetapathException;
 import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
 import gov.nist.secauto.metaschema.core.metapath.MetapathConstants;
 import gov.nist.secauto.metaschema.core.metapath.function.FunctionUtils;
@@ -72,8 +73,9 @@ public final class FnDocumentUri {
 
     ISequence<IAnyUriItem> retval;
     if (focus == null) {
-      // context item absent - handled by Metapath runtime
-      retval = ISequence.empty();
+      // Per XPath 3.1: If the context item is absent, dynamic error [err:XPDY0002]
+      throw new ContextAbsentDynamicMetapathException(
+          "The context item is absent for fn:document-uri()");
     } else if (focus instanceof IDocumentNodeItem) {
       retval = ISequence.of(fnDocumentUri((IDocumentNodeItem) focus));
     } else if (focus instanceof INodeItem) {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnPath.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnPath.java
@@ -13,6 +13,7 @@ import gov.nist.secauto.metaschema.core.metapath.function.IFunction;
 import gov.nist.secauto.metaschema.core.metapath.item.IItem;
 import gov.nist.secauto.metaschema.core.metapath.item.ISequence;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
+import gov.nist.secauto.metaschema.core.metapath.item.node.IDocumentNodeItem;
 import gov.nist.secauto.metaschema.core.metapath.item.node.INodeItem;
 import gov.nist.secauto.metaschema.core.metapath.type.InvalidTypeMetapathException;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
@@ -76,7 +77,7 @@ public final class FnPath {
     if (focus == null) {
       retval = ISequence.empty();
     } else if (focus instanceof INodeItem) {
-      retval = ISequence.of(IStringItem.valueOf(((INodeItem) focus).toPath(IPathFormatter.METAPATH_PATH_FORMATER)));
+      retval = ISequence.of(fnPath((INodeItem) focus));
     } else {
       throw new InvalidTypeMetapathException(
           focus,
@@ -136,6 +137,16 @@ public final class FnPath {
    */
   @Nullable
   public static IStringItem fnPath(@Nullable INodeItem item) {
-    return item == null ? null : IStringItem.valueOf(item.toPath(IPathFormatter.METAPATH_PATH_FORMATER));
+    if (item == null) {
+      return null;
+    }
+    String path = item.toPath(IPathFormatter.METAPATH_PATH_FORMATER);
+    // Per XPath 3.1, document nodes return "/" for their path
+    // The MetapathFormatter returns empty string for document nodes
+    // (to enable proper joining), so we need to handle this case
+    if (item instanceof IDocumentNodeItem && path.isEmpty()) {
+      path = "/";
+    }
+    return IStringItem.valueOf(path);
   }
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnPath.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnPath.java
@@ -84,7 +84,7 @@ public final class FnPath {
     } else {
       throw new InvalidTypeMetapathException(
           focus,
-          String.format("Expected type '%s', but the node was type '%s'.",
+          String.format("Expected type '%s', but the item was type '%s'.",
               INodeItem.class.getName(),
               focus.getClass().getName()));
     }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnPath.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnPath.java
@@ -5,6 +5,7 @@
 
 package gov.nist.secauto.metaschema.core.metapath.function.library;
 
+import gov.nist.secauto.metaschema.core.metapath.ContextAbsentDynamicMetapathException;
 import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
 import gov.nist.secauto.metaschema.core.metapath.MetapathConstants;
 import gov.nist.secauto.metaschema.core.metapath.format.IPathFormatter;
@@ -75,7 +76,9 @@ public final class FnPath {
 
     ISequence<IStringItem> retval;
     if (focus == null) {
-      retval = ISequence.empty();
+      // Per XPath 3.1: If the context item is absent, dynamic error [err:XPDY0002]
+      throw new ContextAbsentDynamicMetapathException(
+          "The context item is absent for fn:path()");
     } else if (focus instanceof INodeItem) {
       retval = ISequence.of(fnPath((INodeItem) focus));
     } else {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnPath.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnPath.java
@@ -84,7 +84,7 @@ public final class FnPath {
     } else {
       throw new InvalidTypeMetapathException(
           focus,
-          String.format("Expected type '%s', but the item was type '%s'.",
+          String.format("Expected type '%s', but the context item was type '%s'.",
               INodeItem.class.getName(),
               focus.getClass().getName()));
     }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnPath.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnPath.java
@@ -8,7 +8,6 @@ package gov.nist.secauto.metaschema.core.metapath.function.library;
 import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
 import gov.nist.secauto.metaschema.core.metapath.MetapathConstants;
 import gov.nist.secauto.metaschema.core.metapath.format.IPathFormatter;
-import gov.nist.secauto.metaschema.core.metapath.function.FunctionUtils;
 import gov.nist.secauto.metaschema.core.metapath.function.IArgument;
 import gov.nist.secauto.metaschema.core.metapath.function.IFunction;
 import gov.nist.secauto.metaschema.core.metapath.item.IItem;
@@ -73,13 +72,17 @@ public final class FnPath {
       @NonNull DynamicContext dynamicContext,
       IItem focus) {
 
-    INodeItem item = FunctionUtils.requireTypeOrNull(INodeItem.class, focus);
-
     ISequence<IStringItem> retval;
-    if (item == null) {
+    if (focus == null) {
       retval = ISequence.empty();
+    } else if (focus instanceof INodeItem) {
+      retval = ISequence.of(IStringItem.valueOf(((INodeItem) focus).toPath(IPathFormatter.METAPATH_PATH_FORMATER)));
     } else {
-      retval = ISequence.of(IStringItem.valueOf(item.toPath(IPathFormatter.METAPATH_PATH_FORMATER)));
+      throw new InvalidTypeMetapathException(
+          focus,
+          String.format("Expected type '%s', but the node was type '%s'.",
+              INodeItem.class.getName(),
+              focus.getClass().getName()));
     }
     return retval;
   }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MpRecurseDepth.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MpRecurseDepth.java
@@ -15,6 +15,7 @@ import gov.nist.secauto.metaschema.core.metapath.item.IItem;
 import gov.nist.secauto.metaschema.core.metapath.item.ISequence;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
 import gov.nist.secauto.metaschema.core.metapath.item.node.INodeItem;
+import gov.nist.secauto.metaschema.core.metapath.type.InvalidTypeMetapathException;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
 import java.util.List;
@@ -80,7 +81,16 @@ public final class MpRecurseDepth {
       @NonNull DynamicContext dynamicContext,
       IItem focus) {
 
-    ISequence<INodeItem> initalContext = ISequence.of(FunctionUtils.requireType(INodeItem.class, focus));
+    if (!(focus instanceof INodeItem)) {
+      throw new InvalidTypeMetapathException(
+          focus,
+          focus == null
+              ? String.format("Expected non-null type '%s', but the node was null.", INodeItem.class.getName())
+              : String.format("Expected type '%s', but the node was type '%s'.",
+                  INodeItem.class.getName(),
+                  focus.getClass().getName()));
+    }
+    ISequence<INodeItem> initalContext = ISequence.of((INodeItem) focus);
 
     ISequence<? extends IStringItem> arg = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(0)));
     IStringItem recursionPath = ObjectUtils.requireNonNull(arg.getFirstItem(true));

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnBaseUriTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnBaseUriTest.java
@@ -8,6 +8,7 @@ package gov.nist.secauto.metaschema.core.metapath.function.library;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import gov.nist.secauto.metaschema.core.metapath.ContextAbsentDynamicMetapathException;
 import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
 import gov.nist.secauto.metaschema.core.metapath.ExpressionTestBase;
 import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
@@ -70,6 +71,20 @@ class FnBaseUriTest
     assertThrows(InvalidTypeMetapathException.class, () -> {
       IMetapathExpression.compile("base-uri()", dynamicContext.getStaticContext())
           .evaluateAs(IStringItem.valueOf("test"), IMetapathExpression.ResultType.ITEM, dynamicContext);
+    });
+  }
+
+  /**
+   * Per XPath 3.1 spec, if the context item is absent, a dynamic error
+   * (err:XPDY0002) is raised.
+   */
+  @Test
+  void testContextAbsentThrowsDynamicError() {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    assertThrows(ContextAbsentDynamicMetapathException.class, () -> {
+      IMetapathExpression.compile("base-uri()", dynamicContext.getStaticContext())
+          .evaluateAs(null, IMetapathExpression.ResultType.ITEM, dynamicContext);
     });
   }
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnBaseUriTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnBaseUriTest.java
@@ -1,0 +1,75 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.function.library;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
+import gov.nist.secauto.metaschema.core.metapath.ExpressionTestBase;
+import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyUriItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
+import gov.nist.secauto.metaschema.core.metapath.type.InvalidTypeMetapathException;
+import gov.nist.secauto.metaschema.core.testing.model.mocking.MockedDocumentGenerator;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the XPath 3.1 <a href=
+ * "https://www.w3.org/TR/xpath-functions-31/#func-base-uri">fn:base-uri</a>
+ * function.
+ * <p>
+ * Per XPath 3.1 spec:
+ * <ul>
+ * <li>Zero-argument form uses context item as implicit argument</li>
+ * <li>If context item is absent: raises err:XPDY0002</li>
+ * <li>If context item is not a node: raises err:XPTY0004</li>
+ * <li>Returns base URI of the node or empty sequence if no base URI</li>
+ * </ul>
+ */
+class FnBaseUriTest
+    extends ExpressionTestBase {
+
+  @Test
+  void testWithNodeFocus() {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    IAnyUriItem result = IMetapathExpression.compile("base-uri()", dynamicContext.getStaticContext())
+        .evaluateAs(
+            MockedDocumentGenerator.generateDocumentNodeItem(),
+            IMetapathExpression.ResultType.ITEM,
+            dynamicContext);
+    // The mocked document should have a base URI
+    assertNotNull(result);
+  }
+
+  @Test
+  void testWithOneArg() {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    IAnyUriItem result = IMetapathExpression.compile("base-uri(/root)", dynamicContext.getStaticContext())
+        .evaluateAs(
+            MockedDocumentGenerator.generateDocumentNodeItem(),
+            IMetapathExpression.ResultType.ITEM,
+            dynamicContext);
+    assertNotNull(result);
+  }
+
+  /**
+   * Per XPath 3.1 spec, if the zero-argument form is called and the context item
+   * is not a node, a type error (err:XPTY0004) is raised.
+   */
+  @Test
+  void testNotANodeThrowsTypeError() {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    assertThrows(InvalidTypeMetapathException.class, () -> {
+      IMetapathExpression.compile("base-uri()", dynamicContext.getStaticContext())
+          .evaluateAs(IStringItem.valueOf("test"), IMetapathExpression.ResultType.ITEM, dynamicContext);
+    });
+  }
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnBaseUriTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnBaseUriTest.java
@@ -5,6 +5,7 @@
 
 package gov.nist.secauto.metaschema.core.metapath.function.library;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -44,8 +45,9 @@ class FnBaseUriTest
             MockedDocumentGenerator.generateDocumentNodeItem(),
             IMetapathExpression.ResultType.ITEM,
             dynamicContext);
-    // The mocked document should have a base URI
+    // The mocked document should have a base URI matching the expected value
     assertNotNull(result);
+    assertEquals(MockedDocumentGenerator.BASE_URI.toString(), result.asUri().toString());
   }
 
   @Test
@@ -57,7 +59,9 @@ class FnBaseUriTest
             MockedDocumentGenerator.generateDocumentNodeItem(),
             IMetapathExpression.ResultType.ITEM,
             dynamicContext);
+    // The /root node should have the same base URI as the document
     assertNotNull(result);
+    assertEquals(MockedDocumentGenerator.BASE_URI.toString(), result.asUri().toString());
   }
 
   /**

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDataTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDataTest.java
@@ -1,0 +1,104 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.function.library;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
+import gov.nist.secauto.metaschema.core.metapath.ExpressionTestBase;
+import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
+import gov.nist.secauto.metaschema.core.metapath.item.ISequence;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IIntegerItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
+import gov.nist.secauto.metaschema.core.testing.model.mocking.MockedDocumentGenerator;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the XPath 3.1
+ * <a href="https://www.w3.org/TR/xpath-functions-31/#func-data">fn:data</a>
+ * function.
+ * <p>
+ * Per XPath 3.1 spec, fn:data() atomizes its argument:
+ * <ul>
+ * <li>Atomic values pass through unchanged</li>
+ * <li>Nodes are replaced with their typed values</li>
+ * <li>Arrays are flattened</li>
+ * <li>The function does NOT throw for non-node items</li>
+ * </ul>
+ */
+class FnDataTest
+    extends ExpressionTestBase {
+
+  @Test
+  void testWithFieldNodeFocus() {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    // When focus is a field node with a value, fn:data returns its typed value
+    // Use a field node which has a typed value, not a document node
+    IAnyAtomicItem result = IMetapathExpression.compile("data(/root/field)", dynamicContext.getStaticContext())
+        .evaluateAs(
+            MockedDocumentGenerator.generateDocumentNodeItem(),
+            IMetapathExpression.ResultType.ITEM,
+            dynamicContext);
+    // Field nodes have typed values
+    assertNotNull(result);
+  }
+
+  /**
+   * Per XPath 3.1 spec, fn:data() atomizes its argument. For atomic values, they
+   * pass through unchanged. This is different from fn:base-uri, fn:path, etc.
+   * which require a node.
+   */
+  @Test
+  void testWithAtomicValueFocus() {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    // When focus is an atomic value (string), fn:data returns it unchanged
+    IStringItem result = IMetapathExpression.compile("data()", dynamicContext.getStaticContext())
+        .evaluateAs(IStringItem.valueOf("test"), IMetapathExpression.ResultType.ITEM, dynamicContext);
+    assertNotNull(result);
+    assertEquals("test", result.asString());
+  }
+
+  @Test
+  void testWithIntegerFocus() {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    // When focus is an integer, fn:data returns it unchanged
+    IIntegerItem result = IMetapathExpression.compile("data()", dynamicContext.getStaticContext())
+        .evaluateAs(IIntegerItem.valueOf(42), IMetapathExpression.ResultType.ITEM, dynamicContext);
+    assertNotNull(result);
+    assertEquals(42, result.asInteger().intValue());
+  }
+
+  @Test
+  void testWithOneArgNode() {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    // Use field node which has a typed value (not assembly which has no typed
+    // value)
+    ISequence<IAnyAtomicItem> result
+        = IMetapathExpression.compile("data(/root/field)", dynamicContext.getStaticContext())
+            .evaluate(
+                MockedDocumentGenerator.generateDocumentNodeItem(),
+                dynamicContext);
+    assertNotNull(result);
+  }
+
+  @Test
+  void testWithOneArgSequence() {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    // Test atomizing a sequence of atomic values
+    ISequence<IAnyAtomicItem> result = IMetapathExpression.compile("data((1, 2, 3))", dynamicContext.getStaticContext())
+        .evaluate(null, dynamicContext);
+    assertNotNull(result);
+    assertEquals(3, result.size());
+  }
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDataTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDataTest.java
@@ -100,5 +100,11 @@ class FnDataTest
         .evaluate(null, dynamicContext);
     assertNotNull(result);
     assertEquals(3, result.size());
+
+    // Verify actual values and order
+    java.util.List<IAnyAtomicItem> items = result.getValue();
+    assertEquals(1, ((IIntegerItem) items.get(0)).asInteger().intValue());
+    assertEquals(2, ((IIntegerItem) items.get(1)).asInteger().intValue());
+    assertEquals(3, ((IIntegerItem) items.get(2)).asInteger().intValue());
   }
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDocumentUriTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDocumentUriTest.java
@@ -5,6 +5,7 @@
 
 package gov.nist.secauto.metaschema.core.metapath.function.library;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -47,8 +48,9 @@ class FnDocumentUriTest
             MockedDocumentGenerator.generateDocumentNodeItem(),
             IMetapathExpression.ResultType.ITEM,
             dynamicContext);
-    // The mocked document should have a document URI
+    // The mocked document should have a document URI matching the expected value
     assertNotNull(result);
+    assertEquals(MockedDocumentGenerator.BASE_URI.toString(), result.asUri().toString());
   }
 
   /**

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDocumentUriTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDocumentUriTest.java
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.function.library;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
+import gov.nist.secauto.metaschema.core.metapath.ExpressionTestBase;
+import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyUriItem;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
+import gov.nist.secauto.metaschema.core.metapath.type.InvalidTypeMetapathException;
+import gov.nist.secauto.metaschema.core.testing.model.mocking.MockedDocumentGenerator;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the XPath 3.1 <a href=
+ * "https://www.w3.org/TR/xpath-functions-31/#func-document-uri">fn:document-uri</a>
+ * function.
+ * <p>
+ * Per XPath 3.1 spec:
+ * <ul>
+ * <li>Zero-argument form uses context item as implicit argument</li>
+ * <li>If context item is absent: raises err:XPDY0002</li>
+ * <li>If context item is not a node: raises err:XPTY0004</li>
+ * <li>If node is not a document node: returns empty sequence (NOT an
+ * error)</li>
+ * <li>Returns document URI if available, empty sequence otherwise</li>
+ * </ul>
+ */
+class FnDocumentUriTest
+    extends ExpressionTestBase {
+
+  @Test
+  void testWithDocumentNodeFocus() {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    IAnyUriItem result = IMetapathExpression.compile("document-uri()", dynamicContext.getStaticContext())
+        .evaluateAs(
+            MockedDocumentGenerator.generateDocumentNodeItem(),
+            IMetapathExpression.ResultType.ITEM,
+            dynamicContext);
+    // The mocked document should have a document URI
+    assertNotNull(result);
+  }
+
+  /**
+   * Per XPath 3.1 spec, if the argument is a node but not a document node, the
+   * function returns empty sequence (not an error).
+   */
+  @Test
+  void testWithNonDocumentNodeReturnsEmpty() {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    // /root returns the root assembly node, not the document node
+    IAnyUriItem result = IMetapathExpression.compile("document-uri(/root)", dynamicContext.getStaticContext())
+        .evaluateAs(
+            MockedDocumentGenerator.generateDocumentNodeItem(),
+            IMetapathExpression.ResultType.ITEM,
+            dynamicContext);
+    // Non-document nodes return null (empty sequence)
+    assertNull(result);
+  }
+
+  /**
+   * Per XPath 3.1 spec, if the zero-argument form is called and the context item
+   * is not a node, a type error (err:XPTY0004) is raised.
+   */
+  @Test
+  void testNotANodeThrowsTypeError() {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    assertThrows(InvalidTypeMetapathException.class, () -> {
+      IMetapathExpression.compile("document-uri()", dynamicContext.getStaticContext())
+          .evaluateAs(IStringItem.valueOf("test"), IMetapathExpression.ResultType.ITEM, dynamicContext);
+    });
+  }
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDocumentUriTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDocumentUriTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import gov.nist.secauto.metaschema.core.metapath.ContextAbsentDynamicMetapathException;
 import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
 import gov.nist.secauto.metaschema.core.metapath.ExpressionTestBase;
 import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
@@ -79,6 +80,20 @@ class FnDocumentUriTest
     assertThrows(InvalidTypeMetapathException.class, () -> {
       IMetapathExpression.compile("document-uri()", dynamicContext.getStaticContext())
           .evaluateAs(IStringItem.valueOf("test"), IMetapathExpression.ResultType.ITEM, dynamicContext);
+    });
+  }
+
+  /**
+   * Per XPath 3.1 spec, if the context item is absent, a dynamic error
+   * (err:XPDY0002) is raised.
+   */
+  @Test
+  void testContextAbsentThrowsDynamicError() {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    assertThrows(ContextAbsentDynamicMetapathException.class, () -> {
+      IMetapathExpression.compile("document-uri()", dynamicContext.getStaticContext())
+          .evaluateAs(null, IMetapathExpression.ResultType.ITEM, dynamicContext);
     });
   }
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnPathTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnPathTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import gov.nist.secauto.metaschema.core.metapath.ContextAbsentDynamicMetapathException;
 import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
 import gov.nist.secauto.metaschema.core.metapath.ExpressionTestBase;
 import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
@@ -111,6 +112,20 @@ class FnPathTest
     assertThrows(InvalidTypeMetapathException.class, () -> {
       IMetapathExpression.compile("path()", dynamicContext.getStaticContext())
           .evaluateAs(IStringItem.valueOf("test"), IMetapathExpression.ResultType.ITEM, dynamicContext);
+    });
+  }
+
+  /**
+   * Per XPath 3.1 spec, if the context item is absent, a dynamic error
+   * (err:XPDY0002) is raised.
+   */
+  @Test
+  void testContextAbsentThrowsDynamicError() {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    assertThrows(ContextAbsentDynamicMetapathException.class, () -> {
+      IMetapathExpression.compile("path()", dynamicContext.getStaticContext())
+          .evaluateAs(null, IMetapathExpression.ResultType.ITEM, dynamicContext);
     });
   }
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnPathTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnPathTest.java
@@ -1,0 +1,116 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.function.library;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
+import gov.nist.secauto.metaschema.core.metapath.ExpressionTestBase;
+import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
+import gov.nist.secauto.metaschema.core.metapath.type.InvalidTypeMetapathException;
+import gov.nist.secauto.metaschema.core.testing.model.mocking.MockedDocumentGenerator;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Tests for the XPath 3.1
+ * <a href="https://www.w3.org/TR/xpath-functions-31/#func-path">fn:path</a>
+ * function.
+ * <p>
+ * Per XPath 3.1 spec:
+ * <ul>
+ * <li>Zero-argument form uses context item as implicit argument</li>
+ * <li>If context item is absent: raises err:XPDY0002</li>
+ * <li>If context item is not a node: raises err:XPTY0004</li>
+ * <li>Returns a path expression identifying the node in the tree</li>
+ * </ul>
+ */
+class FnPathTest
+    extends ExpressionTestBase {
+
+  private static Stream<Arguments> provideValues() {
+    // path(/root) and deeper return Q{...} namespace-qualified paths
+    return Stream.of(
+        Arguments.of("path(/root)"),
+        Arguments.of("path(/root/assembly)"),
+        Arguments.of("path(/root/assembly/@assembly-flag)"),
+        Arguments.of("path(/root/field)"),
+        Arguments.of("path(/root/field/@field-flag)"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideValues")
+  void test(@NonNull String metapath) {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    IStringItem result = IMetapathExpression.compile(metapath, dynamicContext.getStaticContext())
+        .evaluateAs(
+            MockedDocumentGenerator.generateDocumentNodeItem(),
+            IMetapathExpression.ResultType.ITEM,
+            dynamicContext);
+    assertNotNull(result);
+    // Path should start with "/" for absolute paths or "Q{" for namespace-qualified
+    // paths
+    assertTrue(result.asString().startsWith("/") || result.asString().startsWith("Q{"));
+  }
+
+  /**
+   * Per XPath 3.1 spec, path() with document node focus returns "/".
+   */
+  @Test
+  void testWithDocumentNodeFocus() {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    IStringItem result = IMetapathExpression.compile("path()", dynamicContext.getStaticContext())
+        .evaluateAs(
+            MockedDocumentGenerator.generateDocumentNodeItem(),
+            IMetapathExpression.ResultType.ITEM,
+            dynamicContext);
+    assertNotNull(result);
+    assertEquals("/", result.asString());
+  }
+
+  /**
+   * Per XPath 3.1 spec, path(.) with document node focus returns "/".
+   */
+  @Test
+  void testWithSelfAndDocumentNodeFocus() {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    IStringItem result = IMetapathExpression.compile("path(.)", dynamicContext.getStaticContext())
+        .evaluateAs(
+            MockedDocumentGenerator.generateDocumentNodeItem(),
+            IMetapathExpression.ResultType.ITEM,
+            dynamicContext);
+    assertNotNull(result);
+    assertEquals("/", result.asString());
+  }
+
+  /**
+   * Per XPath 3.1 spec, if the zero-argument form is called and the context item
+   * is not a node, a type error (err:XPTY0004) is raised.
+   */
+  @Test
+  void testNotANodeThrowsTypeError() {
+    DynamicContext dynamicContext = newDynamicContext();
+
+    assertThrows(InvalidTypeMetapathException.class, () -> {
+      IMetapathExpression.compile("path()", dynamicContext.getStaticContext())
+          .evaluateAs(IStringItem.valueOf("test"), IMetapathExpression.ResultType.ITEM, dynamicContext);
+    });
+  }
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FunctionTestBase.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FunctionTestBase.java
@@ -10,7 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
 import gov.nist.secauto.metaschema.core.metapath.ExpressionTestBase;
-import gov.nist.secauto.metaschema.core.metapath.function.FunctionUtils;
 import gov.nist.secauto.metaschema.core.metapath.function.IFunction;
 import gov.nist.secauto.metaschema.core.metapath.item.IItem;
 import gov.nist.secauto.metaschema.core.metapath.item.ISequence;
@@ -70,8 +69,8 @@ public class FunctionTestBase
     assertAll(
         () -> assertEquals(expectedResult, result),
         () -> assertEquals(
-            FunctionUtils.getTypes(expectedResult),
-            FunctionUtils.getTypes(result)));
+            expectedResult.getItemTypes(),
+            result.getItemTypes()));
 
   }
 


### PR DESCRIPTION
## Summary

This PR replaces deprecated `FunctionUtils.requireType()`, `requireTypeOrNull()`, `toNumeric()`, and `getTypes()` calls with inline implementations aligned with the XPath 3.1 specification.

### XPath 3.1 Specification Alignment

The following functions have been updated to match XPath 3.1 behavior:

| Function | Context Absent | Non-Node Context | Non-Document Node |
|----------|---------------|------------------|-------------------|
| fn:base-uri() | err:XPDY0002 | err:XPTY0004 | N/A |
| fn:document-uri() | err:XPDY0002 | err:XPTY0004 | Empty sequence |
| fn:path() | err:XPDY0002 | err:XPTY0004 | N/A |
| fn:data() | N/A | Atomizes value | N/A |

### Changes

- **FnBaseUri, FnDocumentUri, FnPath**: Updated to throw:
  - `ContextAbsentDynamicMetapathException` (err:XPDY0002) when context item is absent
  - `InvalidTypeMetapathException` (err:XPTY0004) when context item is not a node
- **FnData**: Corrected to atomize any item type per XPath 3.1 (atomic values pass through unchanged, nodes are replaced with typed values)
- **FnDocumentUri**: One-arg signature corrected to accept `node()?` (not just `document-node()?`) and return empty sequence for non-document nodes
- **FnPath**: Now returns "/" for document nodes per XPath 3.1
- **IMetapathExpression**: Replace deprecated `toNumeric()` with explicit atomization
- **MpRecurseDepth**: Replace deprecated `requireType()` with explicit validation
- **FunctionTestBase**: Replace deprecated `getTypes()` with `ISequence.getItemTypes()`

### XPath 3.1 Specification References

- [fn:base-uri](https://www.w3.org/TR/xpath-functions-31/#func-base-uri)
- [fn:data](https://www.w3.org/TR/xpath-functions-31/#func-data)
- [fn:document-uri](https://www.w3.org/TR/xpath-functions-31/#func-document-uri)
- [fn:path](https://www.w3.org/TR/xpath-functions-31/#func-path)

### Documentation

Added section to CLAUDE.md documenting that Metapath is an XPath 3.1 implementation and the spec should be used as behavioral reference.

## Test plan

- [x] Run `mvn -pl core test` - All tests pass
- [x] New unit tests verify XPath 3.1 compliant behavior for fn:base-uri, fn:data, fn:document-uri, fn:path
- [x] Tests verify context absent throws ContextAbsentDynamicMetapathException (err:XPDY0002)
- [x] Tests verify non-node focus throws InvalidTypeMetapathException (err:XPTY0004)
- [x] Tests verify fn:data atomizes atomic values without error
- [x] Tests verify fn:path returns "/" for document nodes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter runtime type and context validation for XPath 3.1 functions with clearer type/context error reporting.
  * Numeric conversion now atomizes and casts values before numeric conversion to avoid invalid/ambiguous results.

* **Tests**
  * Added extensive tests covering fn:base-uri, fn:data, fn:document-uri, fn:path and related type/context error scenarios.

* **Documentation**
  * New Metapath/XPath 3.1 guidance clarifying spec-based behavior, deviation handling, and generated-code provenance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->