### PR TITLE
Add IModuleBuilder for programmatic module construction in tests

### DIFF
--- a/PRDs/20251208-module-builder/PRD.md
+++ b/PRDs/20251208-module-builder/PRD.md
@@ -1,0 +1,219 @@
+# IModule Builder Design
+
+## Overview
+
+Add an `IModuleBuilder` to the existing test builder pattern in `core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/`. This enables programmatic construction of `IModule` instances for testing, reducing dependency on XMLBeans-based `ModuleLoader`.
+
+## Goals
+
+1. Create a fluent builder API for constructing mock `IModule` instances
+2. Support recursive assembly definitions (self-referencing)
+3. Integrate with existing `IAssemblyBuilder`, `IFieldBuilder`, `IFlagBuilder`
+4. Enable migration of 4 test cases away from XML-based module loading
+
+## Design
+
+### New Interfaces and Classes
+
+```
+IModuleBuilder (interface)
+    └── ModuleBuilder (implementation)
+
+IModelReference (marker interface) - represents a lazy reference
+    ├── AssemblyReference extends AbstractMetaschemaBuilder, implements IModelBuilder
+    └── FieldReference extends AbstractMetaschemaBuilder, implements IModelBuilder
+```
+
+### IModuleBuilder Interface
+
+```java
+public interface IModuleBuilder {
+    // Static factory
+    static IModuleBuilder builder();
+
+    // Reset
+    IModuleBuilder reset();
+
+    // Module metadata
+    IModuleBuilder namespace(@NonNull URI namespace);
+    IModuleBuilder namespace(@NonNull String namespace);
+    IModuleBuilder shortName(@NonNull String shortName);
+    IModuleBuilder version(@NonNull String version);
+    IModuleBuilder name(@NonNull MarkupLine name);
+    IModuleBuilder source(@NonNull ISource source);
+
+    // Add definitions (accumulative)
+    IModuleBuilder assembly(@NonNull IAssemblyBuilder assembly);
+    IModuleBuilder field(@NonNull IFieldBuilder field);
+    IModuleBuilder flag(@NonNull IFlagBuilder flag);
+
+    // Reference factories for model instances
+    IModelBuilder<?> assemblyRef(@NonNull String name);
+    IModelBuilder<?> fieldRef(@NonNull String name);
+
+    // Build
+    IModule toModule();
+}
+```
+
+### Reference Resolution
+
+References allow defining recursive or cross-referencing structures:
+
+```java
+IModule module = IModuleBuilder.builder()
+    .namespace("http://example.com/ns")
+    .shortName("test")
+    .version("1.0")
+    .source(ISource.externalSource("test"))
+    .assembly(IAssemblyBuilder.builder()
+        .name("recursive-assembly")
+        .rootName("recursive-assembly")
+        .modelInstances(List.of(
+            moduleBuilder.assemblyRef("recursive-assembly")  // self-reference
+        )))
+    .toModule();
+```
+
+**Resolution order in `toModule()`:**
+
+1. Validate all builders have required data
+2. Create mock `IModule` with metadata
+3. Build all flag definitions (no dependencies)
+4. Build all field definitions (may reference flags)
+5. Build all assembly definitions:
+   - Direct nested builders → build inline
+   - References → resolve by name from already-built definitions
+6. Wire up module's definition collections and lookup methods
+
+### Changes to Existing Builders
+
+**AbstractMetaschemaBuilder:**
+- Add `applyDefinition(IDefinition, IModule)` overload to set `getContainingModule()`
+
+**IAssemblyBuilder, IFieldBuilder, IFlagBuilder:**
+- Add `toDefinition(IModule)` overload for module-aware definition creation
+- Existing `toDefinition()` remains for standalone usage
+
+**IModuleMockFactory:**
+- Add `default IModuleBuilder module()` convenience method
+
+### IModule Methods to Mock
+
+Based on usage analysis, the following `IModule` methods need mocking:
+
+| Method | Purpose |
+|--------|---------|
+| `getLocation()` | Module source URI |
+| `getLocationHint()` | String hint for location |
+| `getSource()` | ISource information |
+| `getName()` | Formal MarkupLine name |
+| `getVersion()` | Version string |
+| `getShortName()` | Unique identifier |
+| `getXmlNamespace()` | XML namespace URI |
+| `getJsonBaseUri()` | JSON base URI |
+| `getQName()` | Qualified name |
+| `getAssemblyDefinitions()` | Local assembly collection |
+| `getAssemblyDefinitionByName(Integer)` | Lookup by name index |
+| `getFieldDefinitions()` | Local field collection |
+| `getFieldDefinitionByName(Integer)` | Lookup by name index |
+| `getFlagDefinitions()` | Local flag collection |
+| `getFlagDefinitionByName(IEnhancedQName)` | Lookup by qname |
+| `getExportedAssemblyDefinitions()` | Returns same as local |
+| `getExportedFieldDefinitions()` | Returns same as local |
+| `getExportedFlagDefinitions()` | Returns same as local |
+| `getExportedRootAssemblyDefinitions()` | Root assemblies |
+| `getRootAssemblyDefinitions()` | Local root assemblies |
+| `getImportedModules()` | Empty list (no import support) |
+| `getAssemblyAndFieldDefinitions()` | Combined list |
+| `getModuleStaticContext()` | StaticContext for Metapath |
+
+**Simplifications:**
+- All definitions are "exported" (no scope distinction)
+- No imported modules support
+- Scoped lookups (`getScopedXxxByName`) return same as local lookups
+
+## Test Case Migrations
+
+### 1. ExternalConstraintsModulePostProcessorTest
+
+**Current:** Loads `issue184-metaschema.xml` and `issue184-constraints.xml`
+
+**After:** Build module with assembly "a", apply constraints programmatically
+
+### 2. RecursionCollectingNodeItemVisitorTest
+
+**Current:** Loads `metaschema-module-metaschema.xml`
+
+**After:** Build module with self-referencing assembly to test recursion detection
+
+### 3. AbstractRecursionPreventingNodeItemVisitorTest
+
+**Current:** Loads `metaschema-module-metaschema.xml`
+
+**After:** Build module with recursive assembly to test visitation
+
+### 4. MermaidErDiagramGeneratorTest
+
+**Current:** Loads OSCAL metaschema from URL
+
+**After:** Build module with root assembly, child fields/assemblies for diagram generation
+
+## File Changes
+
+### New Files
+- `IModuleBuilder.java` - Builder interface
+- `ModuleBuilder.java` - Builder implementation
+- `AssemblyReference.java` - Lazy assembly reference
+- `FieldReference.java` - Lazy field reference
+- `IModelReference.java` - Marker interface for references
+
+### Modified Files
+- `AbstractMetaschemaBuilder.java` - Add module-aware `applyDefinition`
+- `IAssemblyBuilder.java` - Add `toDefinition(IModule)`
+- `AssemblyBuilder.java` - Implement `toDefinition(IModule)`
+- `IFieldBuilder.java` - Add `toDefinition(IModule)`
+- `FieldBuilder.java` - Implement `toDefinition(IModule)`
+- `IFlagBuilder.java` - Add `toDefinition(IModule)`
+- `FlagBuilder.java` - Implement `toDefinition(IModule)`
+- `IModuleMockFactory.java` - Add `module()` method
+
+### Test Migrations
+- `ExternalConstraintsModulePostProcessorTest.java`
+- `RecursionCollectingNodeItemVisitorTest.java`
+- `AbstractRecursionPreventingNodeItemVisitorTest.java`
+- `MermaidErDiagramGeneratorTest.java`
+
+## Usage Example
+
+```java
+MockedModelTestSupport mocking = new MockedModelTestSupport();
+ISource source = ISource.externalSource("https://example.com/module");
+
+IModule module = mocking.module()
+    .namespace("http://example.com/ns")
+    .shortName("example")
+    .version("1.0")
+    .source(source)
+    // Global flag definition
+    .flag(mocking.flag()
+        .name("id")
+        .dataTypeAdapter(MetaschemaDataTypeProvider.TOKEN))
+    // Field with flag
+    .field(mocking.field()
+        .name("title")
+        .dataTypeAdapter(MetaschemaDataTypeProvider.STRING))
+    // Root assembly with recursive reference
+    .assembly(mocking.assembly()
+        .name("root")
+        .rootName("root")
+        .flags(List.of(mocking.flag().name("uuid")))
+        .modelInstances(List.of(
+            mocking.field().name("description"),
+            mocking.assemblyRef("root")  // recursive
+        )))
+    .toModule();
+
+// Use with INodeItemFactory
+IModuleNodeItem moduleItem = INodeItemFactory.instance().newModuleNodeItem(module);
+```

--- a/PRDs/20251208-module-builder/implementation-plan.md
+++ b/PRDs/20251208-module-builder/implementation-plan.md
@@ -1,0 +1,142 @@
+# Implementation Plan: IModule Builder
+
+## PR 1: Core Module Builder Infrastructure
+
+**Files to create:**
+- `core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/IModuleBuilder.java`
+- `core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/ModuleBuilder.java`
+
+**Files to modify:**
+- `core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/IModuleMockFactory.java` - Add `module()` method
+
+**Acceptance Criteria:**
+- [ ] `IModuleBuilder` interface with metadata methods (namespace, shortName, version, source)
+- [ ] `ModuleBuilder` implementation creates mock `IModule`
+- [ ] Basic module metadata methods are mocked (getXmlNamespace, getShortName, getVersion, etc.)
+- [ ] `IModuleMockFactory.module()` returns new builder
+- [ ] Unit test demonstrating basic module creation
+- [ ] `mvn -pl core test` passes
+
+---
+
+## PR 2: Definition Builder Integration
+
+**Files to modify:**
+- `core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/AbstractMetaschemaBuilder.java`
+- `core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/IFlagBuilder.java`
+- `core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/FlagBuilder.java`
+- `core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/IFieldBuilder.java`
+- `core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/FieldBuilder.java`
+- `core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/IAssemblyBuilder.java`
+- `core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/AssemblyBuilder.java`
+- `core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/ModuleBuilder.java`
+
+**Acceptance Criteria:**
+- [ ] `AbstractMetaschemaBuilder.applyDefinition(IDefinition, IModule)` sets `getContainingModule()`
+- [ ] `IFlagBuilder.toDefinition(IModule)` creates flag with module reference
+- [ ] `IFieldBuilder.toDefinition(IModule)` creates field with module reference
+- [ ] `IAssemblyBuilder.toDefinition(IModule)` creates assembly with module reference
+- [ ] `IModuleBuilder.flag()`, `.field()`, `.assembly()` accumulate builders
+- [ ] `toModule()` builds all definitions with proper module wiring
+- [ ] Module's `getAssemblyDefinitions()`, `getFieldDefinitions()`, `getFlagDefinitions()` return built definitions
+- [ ] Module's lookup methods (`getAssemblyDefinitionByName`, etc.) work correctly
+- [ ] Unit test demonstrating module with flag, field, and assembly definitions
+- [ ] `mvn -pl core test` passes
+
+---
+
+## PR 3: Reference Support for Recursive Assemblies
+
+**Files to create:**
+- `core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/IModelReference.java`
+- `core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/AssemblyReference.java`
+- `core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/FieldReference.java`
+
+**Files to modify:**
+- `core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/IModuleBuilder.java`
+- `core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/ModuleBuilder.java`
+
+**Acceptance Criteria:**
+- [ ] `IModelReference` marker interface for lazy references
+- [ ] `AssemblyReference` stores referenced name, implements `IModelBuilder`
+- [ ] `FieldReference` stores referenced name, implements `IModelBuilder`
+- [ ] `IModuleBuilder.assemblyRef(String)` creates `AssemblyReference`
+- [ ] `IModuleBuilder.fieldRef(String)` creates `FieldReference`
+- [ ] `ModuleBuilder.toModule()` resolves references to built definitions
+- [ ] Unit test demonstrating recursive assembly (self-referencing)
+- [ ] Unit test demonstrating cross-reference between assemblies
+- [ ] `mvn -pl core test` passes
+
+---
+
+## PR 4: Export and Root Assembly Support
+
+**Files to modify:**
+- `core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/ModuleBuilder.java`
+
+**Acceptance Criteria:**
+- [ ] `getExportedAssemblyDefinitions()` returns all assemblies (same as local)
+- [ ] `getExportedFieldDefinitions()` returns all fields (same as local)
+- [ ] `getExportedFlagDefinitions()` returns all flags (same as local)
+- [ ] `getRootAssemblyDefinitions()` returns assemblies with rootName set
+- [ ] `getExportedRootAssemblyDefinitions()` returns same as local roots
+- [ ] `getExportedRootAssemblyDefinitionByName()` lookup works
+- [ ] `getAssemblyAndFieldDefinitions()` returns combined list
+- [ ] `getScopedXxxByName()` methods return same as local (no imports)
+- [ ] `getImportedModules()` returns empty list
+- [ ] `getModuleStaticContext()` returns valid StaticContext
+- [ ] Unit test verifying export methods
+- [ ] `mvn -pl core test` passes
+
+---
+
+## PR 5: Migrate ExternalConstraintsModulePostProcessorTest
+
+**Files to modify:**
+- `core/src/test/java/gov/nist/secauto/metaschema/core/model/constraint/ExternalConstraintsModulePostProcessorTest.java`
+
+**Acceptance Criteria:**
+- [ ] Test uses `IModuleBuilder` instead of `ModuleLoader`
+- [ ] Module built with assembly "a" in namespace "http://csrc.nist.gov/ns/test/metaschema/constraint-targeting-test"
+- [ ] External constraints still loaded from XML (or built programmatically)
+- [ ] Constraint application works correctly
+- [ ] Test assertion passes (1 constraint on assembly)
+- [ ] `mvn -pl core test -Dtest=ExternalConstraintsModulePostProcessorTest` passes
+
+---
+
+## PR 6: Migrate Recursion Visitor Tests
+
+**Files to modify:**
+- `core/src/test/java/gov/nist/secauto/metaschema/core/metapath/item/node/RecursionCollectingNodeItemVisitorTest.java`
+- `core/src/test/java/gov/nist/secauto/metaschema/core/metapath/item/node/AbstractRecursionPreventingNodeItemVisitorTest.java`
+
+**Acceptance Criteria:**
+- [ ] Both tests use `IModuleBuilder` instead of `ModuleLoader`
+- [ ] Module built with self-referencing assembly structure
+- [ ] `RecursionCollectingNodeItemVisitor` correctly identifies recursive assemblies
+- [ ] `AbstractRecursionPreventingNodeItemVisitor` handles recursion without infinite loop
+- [ ] `mvn -pl core test -Dtest=RecursionCollectingNodeItemVisitorTest` passes
+- [ ] `mvn -pl core test -Dtest=AbstractRecursionPreventingNodeItemVisitorTest` passes
+
+---
+
+## PR 7: Migrate MermaidErDiagramGeneratorTest
+
+**Files to modify:**
+- `core/src/test/java/gov/nist/secauto/metaschema/core/util/MermaidErDiagramGeneratorTest.java`
+
+**Acceptance Criteria:**
+- [ ] Test uses `IModuleBuilder` instead of `ModuleLoader`
+- [ ] Module built with root assembly containing child fields and assemblies
+- [ ] Diagram generation produces valid Mermaid ER diagram output
+- [ ] `mvn -pl core test -Dtest=MermaidErDiagramGeneratorTest` passes
+
+---
+
+## Verification
+
+After all PRs are merged:
+- [ ] `mvn clean install -PCI -Prelease` passes
+- [ ] All 4 migrated tests no longer depend on `ModuleLoader`
+- [ ] No new test files reference XMLBeans classes

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/AbstractMetaschemaBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/AbstractMetaschemaBuilder.java
@@ -11,6 +11,7 @@ import gov.nist.secauto.metaschema.core.model.IAttributable;
 import gov.nist.secauto.metaschema.core.model.IDefinition;
 import gov.nist.secauto.metaschema.core.model.IModelDefinition;
 import gov.nist.secauto.metaschema.core.model.IModelElement;
+import gov.nist.secauto.metaschema.core.model.IModule;
 import gov.nist.secauto.metaschema.core.model.INamedInstance;
 import gov.nist.secauto.metaschema.core.model.INamedModelElement;
 import gov.nist.secauto.metaschema.core.model.ISource;
@@ -21,6 +22,7 @@ import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import gov.nist.secauto.metaschema.core.util.StringUtils;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * A base class for Metaschema module-based model builders.
@@ -89,6 +91,24 @@ abstract class AbstractMetaschemaBuilder<T extends IMetaschemaBuilder<T>>
   }
 
   /**
+   * Get the currently configured namespace.
+   *
+   * @return the namespace or {@code null} if no namespace is configured
+   */
+  protected String getNamespace() {
+    return namespace;
+  }
+
+  /**
+   * Get the currently configured name.
+   *
+   * @return the name or {@code null} if no name is configured
+   */
+  protected String getName() {
+    return name;
+  }
+
+  /**
    * Validate the data provided to this builder to ensure correct and required
    * information is provided.
    */
@@ -104,6 +124,18 @@ abstract class AbstractMetaschemaBuilder<T extends IMetaschemaBuilder<T>>
    *          the definition to apply mocking expectations for
    */
   protected void applyDefinition(@NonNull IDefinition definition) {
+    applyDefinition(definition, null);
+  }
+
+  /**
+   * Apply expectations to the mocking context for the provided definition.
+   *
+   * @param definition
+   *          the definition to apply mocking expectations for
+   * @param module
+   *          the containing module, or {@code null} if standalone
+   */
+  protected void applyDefinition(@NonNull IDefinition definition, @Nullable IModule module) {
     applyModelElement(definition);
     applyNamed(definition);
     applyAttributable(definition);
@@ -115,8 +147,11 @@ abstract class AbstractMetaschemaBuilder<T extends IMetaschemaBuilder<T>>
     doReturn(CollectionUtil.emptyMap()).when(definition).getProperties();
     doReturn(null).when(definition).getInlineInstance();
 
+    if (module != null) {
+      doReturn(module).when(definition).getContainingModule();
+    }
+
     // doReturn().when(definition).getConstraintSupport();
-    // doReturn().when(definition).getContainingModule();
     // doReturn().when(definition).getModelType();
   }
 

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/AssemblyBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/AssemblyBuilder.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.doReturn;
 import gov.nist.secauto.metaschema.core.model.IAssemblyDefinition;
 import gov.nist.secauto.metaschema.core.model.IAssemblyInstance;
 import gov.nist.secauto.metaschema.core.model.IAssemblyInstanceAbsolute;
+import gov.nist.secauto.metaschema.core.model.IFieldDefinition;
 import gov.nist.secauto.metaschema.core.model.IFieldInstance;
 import gov.nist.secauto.metaschema.core.model.IFlagInstance;
 import gov.nist.secauto.metaschema.core.model.IModule;
@@ -23,6 +24,7 @@ import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
 import gov.nist.secauto.metaschema.core.util.CollectionUtil;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -78,6 +80,25 @@ final class AssemblyBuilder
   public AssemblyBuilder modelInstances(@Nullable List<? extends IModelBuilder<?>> modelInstances) {
     this.modelInstances = modelInstances == null ? CollectionUtil.emptyList() : modelInstances;
     return this;
+  }
+
+  /**
+   * Get the model instance builders configured for this assembly.
+   *
+   * @return the list of model instance builders
+   */
+  @NonNull
+  List<? extends IModelBuilder<?>> getModelInstanceBuilders() {
+    return this.modelInstances;
+  }
+
+  /**
+   * Check if any model instances are references that need lazy resolution.
+   *
+   * @return {@code true} if any model instance is an {@link IModelReference}
+   */
+  boolean hasModelReferences() {
+    return modelInstances.stream().anyMatch(IModelReference.class::isInstance);
   }
 
   @Override
@@ -181,6 +202,142 @@ final class AssemblyBuilder
             .collect(Collectors.toList()))
                 .when(retval).getFieldInstances();
     return retval;
+  }
+
+  /**
+   * Build a mocked assembly definition without model instances. This is used for
+   * two-phase construction when references need to be resolved later.
+   *
+   * @param module
+   *          the containing module
+   * @return the new mocked definition with empty model instances
+   */
+  @NonNull
+  IAssemblyDefinition toDefinitionShell(@Nullable IModule module) {
+    validate();
+
+    // already validated as non-null
+    ISource source = ObjectUtils.notNull(getSource());
+
+    IAssemblyDefinition retval = mock(IAssemblyDefinition.class);
+    applyDefinition(retval, module);
+
+    Map<IEnhancedQName, IFlagInstance> flags = getFlags().stream()
+        .map(builder -> builder.source(source).toInstance(retval))
+        .collect(Collectors.toUnmodifiableMap(
+            IFlagInstance::getQName,
+            Function.identity()));
+
+    if (rootName != null) {
+      doReturn(ModelType.ASSEMBLY).when(retval).getModelType();
+
+      IEnhancedQName rootQName = IEnhancedQName.of(ObjectUtils.notNull(rootNamespace), ObjectUtils.notNull(rootName));
+      doReturn(rootQName).when(retval).getRootQName();
+    }
+
+    doReturn(new AssemblyConstraintSet(source)).when(retval).getConstraintSupport();
+
+    doReturn(flags.values()).when(retval).getFlagInstances();
+    flags.entrySet().forEach(entry -> {
+      assert entry != null;
+      doReturn(entry.getValue()).when(retval).getFlagInstanceByName(eq(entry.getKey().getIndexPosition()));
+    });
+
+    // Initialize with empty model instances - will be populated later
+    doReturn(CollectionUtil.emptyList()).when(retval).getModelInstances();
+    doReturn(CollectionUtil.emptyMap()).when(retval).getChoiceGroupInstances();
+    doReturn(CollectionUtil.emptyList()).when(retval).getChoiceInstances();
+    doReturn(CollectionUtil.emptyList()).when(retval).getAssemblyInstances();
+    doReturn(CollectionUtil.emptyList()).when(retval).getFieldInstances();
+
+    return retval;
+  }
+
+  /**
+   * Resolve model instances for an already-built definition, using the provided
+   * definition maps to resolve references.
+   *
+   * @param definition
+   *          the definition to add model instances to
+   * @param assemblyDefinitions
+   *          map of assembly name to definition for resolving assembly references
+   * @param fieldDefinitions
+   *          map of field name to definition for resolving field references
+   */
+  void resolveModelInstances(
+      @NonNull IAssemblyDefinition definition,
+      @NonNull Map<String, IAssemblyDefinition> assemblyDefinitions,
+      @NonNull Map<String, IFieldDefinition> fieldDefinitions) {
+
+    ISource source = ObjectUtils.notNull(getSource());
+    List<INamedModelInstanceAbsolute> instances = new ArrayList<>();
+
+    for (IModelBuilder<?> builder : modelInstances) {
+      INamedModelInstanceAbsolute instance;
+      if (builder instanceof IModelReference) {
+        IModelReference ref = (IModelReference) builder;
+        String refName = ref.getReferencedName();
+
+        if (builder instanceof AssemblyReference) {
+          IAssemblyDefinition refDef = assemblyDefinitions.get(refName);
+          if (refDef == null) {
+            throw new IllegalStateException("Assembly reference '" + refName + "' not found in module");
+          }
+          // Create an instance that references the existing definition
+          IAssemblyBuilder instanceBuilder = IAssemblyBuilder.builder()
+              .name(refName)
+              .namespace(ObjectUtils.notNull(getNamespace()))
+              .source(source);
+          instance = instanceBuilder.toInstance(definition, refDef);
+        } else if (builder instanceof FieldReference) {
+          IFieldDefinition refDef = fieldDefinitions.get(refName);
+          if (refDef == null) {
+            throw new IllegalStateException("Field reference '" + refName + "' not found in module");
+          }
+          // Create an instance that references the existing definition
+          IFieldBuilder instanceBuilder = IFieldBuilder.builder()
+              .name(refName)
+              .namespace(ObjectUtils.notNull(getNamespace()))
+              .source(source);
+          instance = instanceBuilder.toInstance(definition, refDef);
+        } else {
+          throw new IllegalStateException("Unknown reference type: " + builder.getClass().getName());
+        }
+      } else {
+        // Regular builder - create instance normally
+        instance = builder.source(source).toInstance(definition);
+      }
+      instances.add(instance);
+    }
+
+    // Wire up the instances
+    Map<IEnhancedQName, INamedModelInstanceAbsolute> instanceMap = instances.stream()
+        .collect(Collectors.toUnmodifiableMap(
+            INamedModelInstanceAbsolute::getQName,
+            Function.identity()));
+
+    doReturn(new ArrayList<>(instanceMap.values())).when(definition).getModelInstances();
+    instanceMap.forEach((key, value) -> {
+      doReturn(value).when(definition).getNamedModelInstanceByName(eq(key.getIndexPosition()));
+
+      if (value instanceof IAssemblyInstance) {
+        doReturn(value).when(definition).getAssemblyInstanceByName(eq(key.getIndexPosition()));
+      } else if (value instanceof IFieldInstance) {
+        doReturn(value).when(definition).getFieldInstanceByName(eq(key.getIndexPosition()));
+      }
+    });
+
+    List<IAssemblyInstance> assemblyInstances = instanceMap.values().stream()
+        .filter(IAssemblyInstance.class::isInstance)
+        .map(IAssemblyInstance.class::cast)
+        .collect(Collectors.toList());
+    doReturn(assemblyInstances).when(definition).getAssemblyInstances();
+
+    List<IFieldInstance> fieldInstances = instanceMap.values().stream()
+        .filter(IFieldInstance.class::isInstance)
+        .map(IFieldInstance.class::cast)
+        .collect(Collectors.toList());
+    doReturn(fieldInstances).when(definition).getFieldInstances();
   }
 
   @Override

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/AssemblyBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/AssemblyBuilder.java
@@ -13,6 +13,7 @@ import gov.nist.secauto.metaschema.core.model.IAssemblyInstance;
 import gov.nist.secauto.metaschema.core.model.IAssemblyInstanceAbsolute;
 import gov.nist.secauto.metaschema.core.model.IFieldInstance;
 import gov.nist.secauto.metaschema.core.model.IFlagInstance;
+import gov.nist.secauto.metaschema.core.model.IModule;
 import gov.nist.secauto.metaschema.core.model.INamedModelElement;
 import gov.nist.secauto.metaschema.core.model.INamedModelInstanceAbsolute;
 import gov.nist.secauto.metaschema.core.model.ISource;
@@ -116,13 +117,19 @@ final class AssemblyBuilder
   @Override
   @NonNull
   public IAssemblyDefinition toDefinition() {
+    return toDefinition(null);
+  }
+
+  @Override
+  @NonNull
+  public IAssemblyDefinition toDefinition(@Nullable IModule module) {
     validate();
 
     // already validated as non-null
     ISource source = ObjectUtils.notNull(getSource());
 
     IAssemblyDefinition retval = mock(IAssemblyDefinition.class);
-    applyDefinition(retval);
+    applyDefinition(retval, module);
 
     Map<IEnhancedQName, IFlagInstance> flags = getFlags().stream()
         .map(builder -> builder.source(source).toInstance(retval))

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/AssemblyBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/AssemblyBuilder.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -193,12 +192,12 @@ final class AssemblyBuilder
     });
     doReturn(
         modelInstances.values().stream()
-            .flatMap(value -> value instanceof IAssemblyInstance ? Stream.of(value) : null)
+            .filter(IAssemblyInstance.class::isInstance)
             .collect(Collectors.toList()))
                 .when(retval).getAssemblyInstances();
     doReturn(
         modelInstances.values().stream()
-            .flatMap(value -> value instanceof IFieldInstance ? Stream.of(value) : null)
+            .filter(IFieldInstance.class::isInstance)
             .collect(Collectors.toList()))
                 .when(retval).getFieldInstances();
     return retval;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/AssemblyReference.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/AssemblyReference.java
@@ -86,6 +86,7 @@ final class AssemblyReference
    *
    * @return the source, or {@code null} if not set
    */
+  @Nullable
   protected ISource getSource() {
     return source;
   }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/AssemblyReference.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/AssemblyReference.java
@@ -1,0 +1,117 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.testing.model;
+
+import gov.nist.secauto.metaschema.core.model.IAssemblyDefinition;
+import gov.nist.secauto.metaschema.core.model.INamedModelInstanceAbsolute;
+import gov.nist.secauto.metaschema.core.model.ISource;
+import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
+
+import java.util.List;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * A reference to an assembly definition by name. This class implements
+ * {@link IModelBuilder} to allow it to be used in model instance lists, but the
+ * actual instance is created during module resolution when the referenced
+ * definition is available.
+ *
+ * <p>
+ * This enables recursive assembly structures where an assembly can contain
+ * instances of itself or other assemblies that are defined later in the module.
+ */
+final class AssemblyReference
+    implements IModelBuilder<AssemblyReference>, IModelReference {
+
+  private final String referencedName;
+  private ISource source;
+
+  /**
+   * Construct a new assembly reference.
+   *
+   * @param referencedName
+   *          the local name of the referenced assembly definition
+   */
+  AssemblyReference(@NonNull String referencedName) {
+    this.referencedName = referencedName;
+  }
+
+  @Override
+  @NonNull
+  public String getReferencedName() {
+    return referencedName;
+  }
+
+  @Override
+  public AssemblyReference reset() {
+    this.source = null;
+    return this;
+  }
+
+  @Override
+  @NonNull
+  public AssemblyReference namespace(@NonNull String name) {
+    // References use the name from construction; namespace is set by ModuleBuilder
+    return this;
+  }
+
+  @Override
+  @NonNull
+  public AssemblyReference name(@NonNull String name) {
+    // References use the name from construction
+    return this;
+  }
+
+  @Override
+  @NonNull
+  public AssemblyReference qname(@NonNull IEnhancedQName qname) {
+    // References use the name from construction
+    return this;
+  }
+
+  @Override
+  @NonNull
+  public AssemblyReference source(@NonNull ISource source) {
+    this.source = source;
+    return this;
+  }
+
+  /**
+   * Get the source associated with this reference.
+   *
+   * @return the source, or {@code null} if not set
+   */
+  protected ISource getSource() {
+    return source;
+  }
+
+  @Override
+  @NonNull
+  public AssemblyReference flags(@Nullable List<IFlagBuilder> flags) {
+    // References don't support flags - they reference existing definitions
+    throw new UnsupportedOperationException("Assembly references cannot have flags");
+  }
+
+  /**
+   * This method should not be called directly. Assembly references are resolved
+   * during module construction.
+   *
+   * @param parent
+   *          ignored
+   * @return never returns normally
+   * @throws UnsupportedOperationException
+   *           always, as references must be resolved during module construction
+   */
+  @Override
+  @NonNull
+  public INamedModelInstanceAbsolute toInstance(@NonNull IAssemblyDefinition parent) {
+    throw new UnsupportedOperationException(
+        "Assembly references must be resolved during module construction. "
+            + "Use ModuleBuilder to build the module, which will resolve references.");
+  }
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/FieldBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/FieldBuilder.java
@@ -14,6 +14,7 @@ import gov.nist.secauto.metaschema.core.model.IAssemblyDefinition;
 import gov.nist.secauto.metaschema.core.model.IFieldDefinition;
 import gov.nist.secauto.metaschema.core.model.IFieldInstanceAbsolute;
 import gov.nist.secauto.metaschema.core.model.IFlagInstance;
+import gov.nist.secauto.metaschema.core.model.IModule;
 import gov.nist.secauto.metaschema.core.model.INamedModelElement;
 import gov.nist.secauto.metaschema.core.model.ModelType;
 import gov.nist.secauto.metaschema.core.model.constraint.ValueConstraintSet;
@@ -25,6 +26,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 final class FieldBuilder
     extends AbstractModelBuilder<IFieldBuilder>
@@ -79,10 +81,16 @@ final class FieldBuilder
   @Override
   @NonNull
   public IFieldDefinition toDefinition() {
+    return toDefinition(null);
+  }
+
+  @Override
+  @NonNull
+  public IFieldDefinition toDefinition(@Nullable IModule module) {
     validate();
 
     IFieldDefinition retval = mock(IFieldDefinition.class);
-    applyDefinition(retval);
+    applyDefinition(retval, module);
 
     Map<IEnhancedQName, IFlagInstance> flags = getFlags().stream()
         .map(builder -> builder.toInstance(retval))

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/FieldReference.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/FieldReference.java
@@ -1,0 +1,117 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.testing.model;
+
+import gov.nist.secauto.metaschema.core.model.IAssemblyDefinition;
+import gov.nist.secauto.metaschema.core.model.INamedModelInstanceAbsolute;
+import gov.nist.secauto.metaschema.core.model.ISource;
+import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
+
+import java.util.List;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * A reference to a field definition by name. This class implements
+ * {@link IModelBuilder} to allow it to be used in model instance lists, but the
+ * actual instance is created during module resolution when the referenced
+ * definition is available.
+ *
+ * <p>
+ * This enables assembly structures that reference fields defined elsewhere in
+ * the module.
+ */
+final class FieldReference
+    implements IModelBuilder<FieldReference>, IModelReference {
+
+  private final String referencedName;
+  private ISource source;
+
+  /**
+   * Construct a new field reference.
+   *
+   * @param referencedName
+   *          the local name of the referenced field definition
+   */
+  FieldReference(@NonNull String referencedName) {
+    this.referencedName = referencedName;
+  }
+
+  @Override
+  @NonNull
+  public String getReferencedName() {
+    return referencedName;
+  }
+
+  @Override
+  public FieldReference reset() {
+    this.source = null;
+    return this;
+  }
+
+  @Override
+  @NonNull
+  public FieldReference namespace(@NonNull String name) {
+    // References use the name from construction; namespace is set by ModuleBuilder
+    return this;
+  }
+
+  @Override
+  @NonNull
+  public FieldReference name(@NonNull String name) {
+    // References use the name from construction
+    return this;
+  }
+
+  @Override
+  @NonNull
+  public FieldReference qname(@NonNull IEnhancedQName qname) {
+    // References use the name from construction
+    return this;
+  }
+
+  @Override
+  @NonNull
+  public FieldReference source(@NonNull ISource source) {
+    this.source = source;
+    return this;
+  }
+
+  /**
+   * Get the source associated with this reference.
+   *
+   * @return the source, or {@code null} if not set
+   */
+  protected ISource getSource() {
+    return source;
+  }
+
+  @Override
+  @NonNull
+  public FieldReference flags(@Nullable List<IFlagBuilder> flags) {
+    // References don't support flags - they reference existing definitions
+    throw new UnsupportedOperationException("Field references cannot have flags");
+  }
+
+  /**
+   * This method should not be called directly. Field references are resolved
+   * during module construction.
+   *
+   * @param parent
+   *          ignored
+   * @return never returns normally
+   * @throws UnsupportedOperationException
+   *           always, as references must be resolved during module construction
+   */
+  @Override
+  @NonNull
+  public INamedModelInstanceAbsolute toInstance(@NonNull IAssemblyDefinition parent) {
+    throw new UnsupportedOperationException(
+        "Field references must be resolved during module construction. "
+            + "Use ModuleBuilder to build the module, which will resolve references.");
+  }
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/FieldReference.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/FieldReference.java
@@ -86,6 +86,7 @@ final class FieldReference
    *
    * @return the source, or {@code null} if not set
    */
+  @Nullable
   protected ISource getSource() {
     return source;
   }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/FlagBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/FlagBuilder.java
@@ -12,12 +12,14 @@ import gov.nist.secauto.metaschema.core.datatype.adapter.MetaschemaDataTypeProvi
 import gov.nist.secauto.metaschema.core.model.IFlagDefinition;
 import gov.nist.secauto.metaschema.core.model.IFlagInstance;
 import gov.nist.secauto.metaschema.core.model.IModelDefinition;
+import gov.nist.secauto.metaschema.core.model.IModule;
 import gov.nist.secauto.metaschema.core.model.INamedModelElement;
 import gov.nist.secauto.metaschema.core.model.ModelType;
 import gov.nist.secauto.metaschema.core.model.constraint.ValueConstraintSet;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * A builder that generates mock flag definitions and instances.
@@ -83,10 +85,16 @@ final class FlagBuilder
   @Override
   @NonNull
   public IFlagDefinition toDefinition() {
+    return toDefinition(null);
+  }
+
+  @Override
+  @NonNull
+  public IFlagDefinition toDefinition(@Nullable IModule module) {
     validate();
 
     IFlagDefinition retval = mock(IFlagDefinition.class);
-    applyDefinition(retval);
+    applyDefinition(retval, module);
 
     doReturn(new ValueConstraintSet(ObjectUtils.notNull(getSource()))).when(retval).getConstraintSupport();
     doReturn(dataTypeAdapter).when(retval).getJavaTypeAdapter();

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/IAssemblyBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/IAssemblyBuilder.java
@@ -7,6 +7,7 @@ package gov.nist.secauto.metaschema.core.testing.model;
 
 import gov.nist.secauto.metaschema.core.model.IAssemblyDefinition;
 import gov.nist.secauto.metaschema.core.model.IAssemblyInstanceAbsolute;
+import gov.nist.secauto.metaschema.core.model.IModule;
 import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
@@ -107,4 +108,14 @@ public interface IAssemblyBuilder extends IModelBuilder<IAssemblyBuilder> {
    */
   @NonNull
   IAssemblyDefinition toDefinition();
+
+  /**
+   * Build a mocked assembly definition associated with the given module.
+   *
+   * @param module
+   *          the containing module
+   * @return the new mocked definition
+   */
+  @NonNull
+  IAssemblyDefinition toDefinition(@NonNull IModule module);
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/IFieldBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/IFieldBuilder.java
@@ -9,6 +9,7 @@ import gov.nist.secauto.metaschema.core.datatype.IDataTypeAdapter;
 import gov.nist.secauto.metaschema.core.model.IAssemblyDefinition;
 import gov.nist.secauto.metaschema.core.model.IFieldDefinition;
 import gov.nist.secauto.metaschema.core.model.IFieldInstanceAbsolute;
+import gov.nist.secauto.metaschema.core.model.IModule;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -78,4 +79,14 @@ public interface IFieldBuilder extends IModelBuilder<IFieldBuilder> {
    */
   @NonNull
   IFieldDefinition toDefinition();
+
+  /**
+   * Build a mocked field definition associated with the given module.
+   *
+   * @param module
+   *          the containing module
+   * @return the new mocked definition
+   */
+  @NonNull
+  IFieldDefinition toDefinition(@NonNull IModule module);
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/IFlagBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/IFlagBuilder.java
@@ -9,6 +9,7 @@ import gov.nist.secauto.metaschema.core.datatype.IDataTypeAdapter;
 import gov.nist.secauto.metaschema.core.model.IFlagDefinition;
 import gov.nist.secauto.metaschema.core.model.IFlagInstance;
 import gov.nist.secauto.metaschema.core.model.IModelDefinition;
+import gov.nist.secauto.metaschema.core.model.IModule;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -89,4 +90,14 @@ public interface IFlagBuilder extends IMetaschemaBuilder<IFlagBuilder> {
    */
   @NonNull
   IFlagDefinition toDefinition();
+
+  /**
+   * Build a mocked flag definition associated with the given module.
+   *
+   * @param module
+   *          the containing module
+   * @return the new mocked definition
+   */
+  @NonNull
+  IFlagDefinition toDefinition(@NonNull IModule module);
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/IModelReference.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/IModelReference.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.testing.model;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Marker interface for model references that need to be resolved lazily during
+ * module construction. This allows building recursive structures where an
+ * assembly can reference itself or other assemblies that haven't been built
+ * yet.
+ */
+public interface IModelReference {
+  /**
+   * Get the name of the referenced definition.
+   *
+   * @return the local name of the referenced assembly or field
+   */
+  @NonNull
+  String getReferencedName();
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/IModuleBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/IModuleBuilder.java
@@ -1,0 +1,98 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.testing.model;
+
+import gov.nist.secauto.metaschema.core.model.IModule;
+import gov.nist.secauto.metaschema.core.model.ISource;
+import gov.nist.secauto.metaschema.core.util.ObjectUtils;
+
+import java.net.URI;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * A builder for creating mock {@link IModule} instances for testing purposes.
+ */
+public interface IModuleBuilder {
+
+  /**
+   * Create a new builder.
+   *
+   * @return the new builder
+   */
+  @NonNull
+  static IModuleBuilder builder() {
+    return new ModuleBuilder().reset();
+  }
+
+  /**
+   * Reset the builder to its default state.
+   *
+   * @return this builder
+   */
+  @NonNull
+  IModuleBuilder reset();
+
+  /**
+   * Set the XML namespace for the module.
+   *
+   * @param namespace
+   *          the namespace URI string
+   * @return this builder
+   */
+  @NonNull
+  IModuleBuilder namespace(@NonNull String namespace);
+
+  /**
+   * Set the XML namespace for the module.
+   *
+   * @param namespace
+   *          the namespace URI
+   * @return this builder
+   */
+  @NonNull
+  default IModuleBuilder namespace(@NonNull URI namespace) {
+    return namespace(ObjectUtils.notNull(namespace.toASCIIString()));
+  }
+
+  /**
+   * Set the short name for the module.
+   *
+   * @param shortName
+   *          the short name
+   * @return this builder
+   */
+  @NonNull
+  IModuleBuilder shortName(@NonNull String shortName);
+
+  /**
+   * Set the version for the module.
+   *
+   * @param version
+   *          the version string
+   * @return this builder
+   */
+  @NonNull
+  IModuleBuilder version(@NonNull String version);
+
+  /**
+   * Set the source information for the module.
+   *
+   * @param source
+   *          the source information
+   * @return this builder
+   */
+  @NonNull
+  IModuleBuilder source(@NonNull ISource source);
+
+  /**
+   * Build the mock module.
+   *
+   * @return the new mock module
+   */
+  @NonNull
+  IModule toModule();
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/IModuleBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/IModuleBuilder.java
@@ -12,6 +12,7 @@ import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import java.net.URI;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * A builder for creating mock {@link IModule} instances for testing purposes.
@@ -87,6 +88,36 @@ public interface IModuleBuilder {
    */
   @NonNull
   IModuleBuilder source(@NonNull ISource source);
+
+  /**
+   * Add a flag definition to the module.
+   *
+   * @param flag
+   *          the flag builder to add
+   * @return this builder
+   */
+  @NonNull
+  IModuleBuilder flag(@Nullable IFlagBuilder flag);
+
+  /**
+   * Add a field definition to the module.
+   *
+   * @param field
+   *          the field builder to add
+   * @return this builder
+   */
+  @NonNull
+  IModuleBuilder field(@Nullable IFieldBuilder field);
+
+  /**
+   * Add an assembly definition to the module.
+   *
+   * @param assembly
+   *          the assembly builder to add
+   * @return this builder
+   */
+  @NonNull
+  IModuleBuilder assembly(@Nullable IAssemblyBuilder assembly);
 
   /**
    * Build the mock module.

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/IModuleMockFactory.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/IModuleMockFactory.java
@@ -53,4 +53,30 @@ public interface IModuleMockFactory extends IMockFactory {
   default IModuleBuilder module() {
     return IModuleBuilder.builder();
   }
+
+  /**
+   * Create a reference to an assembly definition by name. The reference will be
+   * resolved when the module is built, allowing recursive assembly structures.
+   *
+   * @param name
+   *          the local name of the referenced assembly definition
+   * @return a builder that represents the reference
+   */
+  @NonNull
+  default IModelBuilder<?> assemblyRef(@NonNull String name) {
+    return new AssemblyReference(name);
+  }
+
+  /**
+   * Create a reference to a field definition by name. The reference will be
+   * resolved when the module is built.
+   *
+   * @param name
+   *          the local name of the referenced field definition
+   * @return a builder that represents the reference
+   */
+  @NonNull
+  default IModelBuilder<?> fieldRef(@NonNull String name) {
+    return new FieldReference(name);
+  }
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/IModuleMockFactory.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/IModuleMockFactory.java
@@ -43,4 +43,14 @@ public interface IModuleMockFactory extends IMockFactory {
   default IAssemblyBuilder assembly() {
     return IAssemblyBuilder.builder();
   }
+
+  /**
+   * Get a new module builder.
+   *
+   * @return the builder
+   */
+  @NonNull
+  default IModuleBuilder module() {
+    return IModuleBuilder.builder();
+  }
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/ModuleBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/ModuleBuilder.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -250,6 +251,47 @@ final class ModuleBuilder
     for (IAssemblyDefinition def : assemblyDefs) {
       Integer index = def.getDefinitionQName().getIndexPosition();
       doReturn(def).when(module).getAssemblyDefinitionByName(eq(index));
+    }
+
+    // Set up export methods - for modules without imports, exported equals local
+    doReturn(CollectionUtil.unmodifiableList(flagDefs)).when(module).getExportedFlagDefinitions();
+    doReturn(CollectionUtil.unmodifiableList(fieldDefs)).when(module).getExportedFieldDefinitions();
+    doReturn(CollectionUtil.unmodifiableList(assemblyDefs)).when(module).getExportedAssemblyDefinitions();
+
+    // Root assembly definitions - assemblies that have rootQName set
+    List<IAssemblyDefinition> rootDefs = assemblyDefs.stream()
+        .filter(def -> def.getRootQName() != null)
+        .collect(Collectors.toList());
+    doReturn(CollectionUtil.unmodifiableList(rootDefs)).when(module).getRootAssemblyDefinitions();
+    doReturn(CollectionUtil.unmodifiableList(rootDefs)).when(module).getExportedRootAssemblyDefinitions();
+
+    // Set up root assembly lookup by name
+    for (IAssemblyDefinition rootDef : rootDefs) {
+      IEnhancedQName rootQName = rootDef.getRootQName();
+      if (rootQName != null) {
+        Integer rootIndex = rootQName.getIndexPosition();
+        doReturn(rootDef).when(module).getExportedRootAssemblyDefinitionByName(eq(rootIndex));
+      }
+    }
+
+    // Combined assembly and field definitions
+    List<Object> assemblyAndFieldDefs = new ArrayList<>();
+    assemblyAndFieldDefs.addAll(assemblyDefs);
+    assemblyAndFieldDefs.addAll(fieldDefs);
+    doReturn(CollectionUtil.unmodifiableList(assemblyAndFieldDefs)).when(module).getAssemblyAndFieldDefinitions();
+
+    // Scoped methods - for modules without imports, scoped equals local
+    for (IFlagDefinition def : flagDefs) {
+      IEnhancedQName qname = def.getDefinitionQName();
+      doReturn(def).when(module).getScopedFlagDefinitionByName(eq(qname));
+    }
+    for (IFieldDefinition def : fieldDefs) {
+      Integer index = def.getDefinitionQName().getIndexPosition();
+      doReturn(def).when(module).getScopedFieldDefinitionByName(eq(index));
+    }
+    for (IAssemblyDefinition def : assemblyDefs) {
+      Integer index = def.getDefinitionQName().getIndexPosition();
+      doReturn(def).when(module).getScopedAssemblyDefinitionByName(eq(index));
     }
   }
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/ModuleBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/ModuleBuilder.java
@@ -141,9 +141,10 @@ final class ModuleBuilder
     doReturn(source).when(module).getSource();
 
     // Location information
-    doReturn(source.getSource()).when(module).getLocation();
-    doReturn(source.getSource() != null ? ObjectUtils.notNull(source.getSource()).toString() : shortName)
-        .when(module).getLocationHint();
+    URI sourceUri = source.getSource();
+    doReturn(sourceUri).when(module).getLocation();
+    String locationHint = sourceUri != null ? sourceUri.toString() : shortName;
+    doReturn(locationHint).when(module).getLocationHint();
 
     // Module QName
     IEnhancedQName qname = IEnhancedQName.of(namespace, shortName);

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/ModuleBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/ModuleBuilder.java
@@ -5,8 +5,12 @@
 
 package gov.nist.secauto.metaschema.core.testing.model;
 
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 
+import gov.nist.secauto.metaschema.core.model.IAssemblyDefinition;
+import gov.nist.secauto.metaschema.core.model.IFieldDefinition;
+import gov.nist.secauto.metaschema.core.model.IFlagDefinition;
 import gov.nist.secauto.metaschema.core.model.IModule;
 import gov.nist.secauto.metaschema.core.model.ISource;
 import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
@@ -15,8 +19,11 @@ import gov.nist.secauto.metaschema.core.util.CollectionUtil;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * A builder for creating mock {@link IModule} instances for testing purposes.
@@ -29,6 +36,9 @@ final class ModuleBuilder
   private String shortName;
   private String version;
   private ISource source;
+  private final List<IFlagBuilder> flagBuilders = new ArrayList<>();
+  private final List<IFieldBuilder> fieldBuilders = new ArrayList<>();
+  private final List<IAssemblyBuilder> assemblyBuilders = new ArrayList<>();
 
   ModuleBuilder() {
     // package-private constructor
@@ -41,6 +51,9 @@ final class ModuleBuilder
     this.shortName = null;
     this.version = null;
     this.source = null;
+    this.flagBuilders.clear();
+    this.fieldBuilders.clear();
+    this.assemblyBuilders.clear();
     return this;
   }
 
@@ -72,6 +85,33 @@ final class ModuleBuilder
     return this;
   }
 
+  @Override
+  @NonNull
+  public IModuleBuilder flag(@Nullable IFlagBuilder flag) {
+    if (flag != null) {
+      this.flagBuilders.add(flag);
+    }
+    return this;
+  }
+
+  @Override
+  @NonNull
+  public IModuleBuilder field(@Nullable IFieldBuilder field) {
+    if (field != null) {
+      this.fieldBuilders.add(field);
+    }
+    return this;
+  }
+
+  @Override
+  @NonNull
+  public IModuleBuilder assembly(@Nullable IAssemblyBuilder assembly) {
+    if (assembly != null) {
+      this.assemblyBuilders.add(assembly);
+    }
+    return this;
+  }
+
   /**
    * Validate that required fields are set.
    */
@@ -99,14 +139,14 @@ final class ModuleBuilder
 
     // Location information
     doReturn(source.getSource()).when(module).getLocation();
-    doReturn(source.getSource() != null ? source.getSource().toString() : shortName)
+    doReturn(source.getSource() != null ? ObjectUtils.notNull(source.getSource()).toString() : shortName)
         .when(module).getLocationHint();
 
     // Module QName
     IEnhancedQName qname = IEnhancedQName.of(namespace, shortName);
     doReturn(qname).when(module).getQName();
 
-    // Empty collections for now (will be populated in later commits)
+    // Imported modules
     doReturn(CollectionUtil.emptyList()).when(module).getImportedModules();
     doReturn(null).when(module).getImportedModuleByShortName(org.mockito.ArgumentMatchers.anyString());
 
@@ -114,6 +154,70 @@ final class ModuleBuilder
     doReturn(null).when(module).getName();
     doReturn(null).when(module).getRemarks();
 
+    // Build definitions from accumulated builders
+    buildDefinitions(module);
+
     return module;
+  }
+
+  /**
+   * Build all accumulated definitions and wire them to the module.
+   *
+   * @param module
+   *          the module to wire definitions to
+   */
+  private void buildDefinitions(@NonNull IModule module) {
+    String moduleNamespace = ObjectUtils.notNull(namespace);
+    ISource moduleSource = ObjectUtils.notNull(source);
+
+    // Build flag definitions
+    List<IFlagDefinition> flagDefs = new ArrayList<>();
+    for (IFlagBuilder builder : flagBuilders) {
+      IFlagDefinition def = builder
+          .namespace(moduleNamespace)
+          .source(moduleSource)
+          .toDefinition(module);
+      flagDefs.add(def);
+    }
+    doReturn(CollectionUtil.unmodifiableList(flagDefs)).when(module).getFlagDefinitions();
+    // Set up lookup by QName - extract qname first to avoid nested stubbing issues
+    for (IFlagDefinition def : flagDefs) {
+      IEnhancedQName qname = def.getDefinitionQName();
+      doReturn(def).when(module).getFlagDefinitionByName(eq(qname));
+    }
+
+    // Build field definitions
+    List<IFieldDefinition> fieldDefs = new ArrayList<>();
+    for (IFieldBuilder builder : fieldBuilders) {
+      IFieldDefinition def = builder
+          .namespace(moduleNamespace)
+          .source(moduleSource)
+          .toDefinition(module);
+      fieldDefs.add(def);
+    }
+    doReturn(CollectionUtil.unmodifiableList(fieldDefs)).when(module).getFieldDefinitions();
+    // Set up lookup by index position - extract index first to avoid nested
+    // stubbing issues
+    for (IFieldDefinition def : fieldDefs) {
+      Integer index = def.getDefinitionQName().getIndexPosition();
+      doReturn(def).when(module).getFieldDefinitionByName(eq(index));
+    }
+
+    // Build assembly definitions
+    List<IAssemblyDefinition> assemblyDefs = new ArrayList<>();
+    for (IAssemblyBuilder builder : assemblyBuilders) {
+      IAssemblyDefinition def = builder
+          .namespace(moduleNamespace)
+          .source(moduleSource)
+          .toDefinition(module);
+      assemblyDefs.add(def);
+    }
+    doReturn(CollectionUtil.unmodifiableList(assemblyDefs)).when(module).getAssemblyDefinitions();
+    // Set up lookup by index position - extract index first to avoid nested
+    // stubbing issues
+    for (IAssemblyDefinition def : assemblyDefs) {
+      Integer index = def.getDefinitionQName().getIndexPosition();
+      doReturn(def).when(module).getAssemblyDefinitionByName(eq(index));
+    }
   }
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/ModuleBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/ModuleBuilder.java
@@ -20,7 +20,9 @@ import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -186,15 +188,16 @@ final class ModuleBuilder
       doReturn(def).when(module).getFlagDefinitionByName(eq(qname));
     }
 
-    // Build field definitions
-    List<IFieldDefinition> fieldDefs = new ArrayList<>();
+    // Build field definitions - keep a map for reference resolution
+    Map<String, IFieldDefinition> fieldDefsByName = new LinkedHashMap<>();
     for (IFieldBuilder builder : fieldBuilders) {
       IFieldDefinition def = builder
           .namespace(moduleNamespace)
           .source(moduleSource)
           .toDefinition(module);
-      fieldDefs.add(def);
+      fieldDefsByName.put(def.getName(), def);
     }
+    List<IFieldDefinition> fieldDefs = new ArrayList<>(fieldDefsByName.values());
     doReturn(CollectionUtil.unmodifiableList(fieldDefs)).when(module).getFieldDefinitions();
     // Set up lookup by index position - extract index first to avoid nested
     // stubbing issues
@@ -203,15 +206,44 @@ final class ModuleBuilder
       doReturn(def).when(module).getFieldDefinitionByName(eq(index));
     }
 
-    // Build assembly definitions
-    List<IAssemblyDefinition> assemblyDefs = new ArrayList<>();
-    for (IAssemblyBuilder builder : assemblyBuilders) {
-      IAssemblyDefinition def = builder
-          .namespace(moduleNamespace)
-          .source(moduleSource)
-          .toDefinition(module);
-      assemblyDefs.add(def);
+    // Check if any assembly has references that need lazy resolution
+    boolean hasReferences = assemblyBuilders.stream()
+        .filter(AssemblyBuilder.class::isInstance)
+        .map(AssemblyBuilder.class::cast)
+        .anyMatch(AssemblyBuilder::hasModelReferences);
+
+    // Build assembly definitions - use two-phase if there are references
+    Map<String, IAssemblyDefinition> assemblyDefsByName = new LinkedHashMap<>();
+    Map<AssemblyBuilder, IAssemblyDefinition> builderToDefMap = new LinkedHashMap<>();
+
+    if (hasReferences) {
+      // Phase 1: Build all assembly shells (without model instances)
+      for (IAssemblyBuilder builder : assemblyBuilders) {
+        AssemblyBuilder ab = (AssemblyBuilder) builder;
+        ab.namespace(moduleNamespace).source(moduleSource);
+        IAssemblyDefinition def = ab.toDefinitionShell(module);
+        assemblyDefsByName.put(def.getName(), def);
+        builderToDefMap.put(ab, def);
+      }
+
+      // Phase 2: Resolve model instances for all assemblies
+      for (Map.Entry<AssemblyBuilder, IAssemblyDefinition> entry : builderToDefMap.entrySet()) {
+        AssemblyBuilder ab = entry.getKey();
+        IAssemblyDefinition def = entry.getValue();
+        ab.resolveModelInstances(def, assemblyDefsByName, fieldDefsByName);
+      }
+    } else {
+      // No references - build normally
+      for (IAssemblyBuilder builder : assemblyBuilders) {
+        IAssemblyDefinition def = builder
+            .namespace(moduleNamespace)
+            .source(moduleSource)
+            .toDefinition(module);
+        assemblyDefsByName.put(def.getName(), def);
+      }
     }
+
+    List<IAssemblyDefinition> assemblyDefs = new ArrayList<>(assemblyDefsByName.values());
     doReturn(CollectionUtil.unmodifiableList(assemblyDefs)).when(module).getAssemblyDefinitions();
     // Set up lookup by index position - extract index first to avoid nested
     // stubbing issues

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/ModuleBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/ModuleBuilder.java
@@ -1,0 +1,119 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.testing.model;
+
+import static org.mockito.Mockito.doReturn;
+
+import gov.nist.secauto.metaschema.core.model.IModule;
+import gov.nist.secauto.metaschema.core.model.ISource;
+import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
+import gov.nist.secauto.metaschema.core.testing.model.mocking.AbstractMockitoFactory;
+import gov.nist.secauto.metaschema.core.util.CollectionUtil;
+import gov.nist.secauto.metaschema.core.util.ObjectUtils;
+
+import java.net.URI;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * A builder for creating mock {@link IModule} instances for testing purposes.
+ */
+final class ModuleBuilder
+    extends AbstractMockitoFactory
+    implements IModuleBuilder {
+
+  private String namespace;
+  private String shortName;
+  private String version;
+  private ISource source;
+
+  ModuleBuilder() {
+    // package-private constructor
+  }
+
+  @Override
+  @NonNull
+  public IModuleBuilder reset() {
+    this.namespace = null;
+    this.shortName = null;
+    this.version = null;
+    this.source = null;
+    return this;
+  }
+
+  @Override
+  @NonNull
+  public IModuleBuilder namespace(@NonNull String namespace) {
+    this.namespace = namespace;
+    return this;
+  }
+
+  @Override
+  @NonNull
+  public IModuleBuilder shortName(@NonNull String shortName) {
+    this.shortName = shortName;
+    return this;
+  }
+
+  @Override
+  @NonNull
+  public IModuleBuilder version(@NonNull String version) {
+    this.version = version;
+    return this;
+  }
+
+  @Override
+  @NonNull
+  public IModuleBuilder source(@NonNull ISource source) {
+    this.source = source;
+    return this;
+  }
+
+  /**
+   * Validate that required fields are set.
+   */
+  private void validate() {
+    ObjectUtils.requireNonNull(namespace, "namespace");
+    ObjectUtils.requireNonNull(shortName, "shortName");
+    ObjectUtils.requireNonNull(version, "version");
+    ObjectUtils.requireNonNull(source, "source");
+  }
+
+  @Override
+  @NonNull
+  public IModule toModule() {
+    validate();
+
+    IModule module = mock(IModule.class);
+
+    // Basic metadata
+    URI namespaceUri = URI.create(ObjectUtils.notNull(namespace));
+    doReturn(namespaceUri).when(module).getXmlNamespace();
+    doReturn(namespaceUri).when(module).getJsonBaseUri();
+    doReturn(shortName).when(module).getShortName();
+    doReturn(version).when(module).getVersion();
+    doReturn(source).when(module).getSource();
+
+    // Location information
+    doReturn(source.getSource()).when(module).getLocation();
+    doReturn(source.getSource() != null ? source.getSource().toString() : shortName)
+        .when(module).getLocationHint();
+
+    // Module QName
+    IEnhancedQName qname = IEnhancedQName.of(namespace, shortName);
+    doReturn(qname).when(module).getQName();
+
+    // Empty collections for now (will be populated in later commits)
+    doReturn(CollectionUtil.emptyList()).when(module).getImportedModules();
+    doReturn(null).when(module).getImportedModuleByShortName(org.mockito.ArgumentMatchers.anyString());
+
+    // Name and remarks
+    doReturn(null).when(module).getName();
+    doReturn(null).when(module).getRemarks();
+
+    return module;
+  }
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/ModuleBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/ModuleBuilder.java
@@ -220,6 +220,10 @@ final class ModuleBuilder
     if (hasReferences) {
       // Phase 1: Build all assembly shells (without model instances)
       for (IAssemblyBuilder builder : assemblyBuilders) {
+        if (!(builder instanceof AssemblyBuilder)) {
+          throw new IllegalStateException(
+              "Two-phase construction requires AssemblyBuilder instances, got: " + builder.getClass().getName());
+        }
         AssemblyBuilder ab = (AssemblyBuilder) builder;
         ab.namespace(moduleNamespace).source(moduleSource);
         IAssemblyDefinition def = ab.toDefinitionShell(module);

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/ModuleBuilderTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/ModuleBuilderTest.java
@@ -219,6 +219,89 @@ class ModuleBuilderTest {
   }
 
   @Test
+  void testExportedDefinitions() {
+    // Given
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create("https://example.com/test"));
+
+    // When
+    IModule module = mocking.module()
+        .namespace(TEST_NAMESPACE)
+        .shortName(TEST_SHORT_NAME)
+        .version(TEST_VERSION)
+        .source(source)
+        .flag(mocking.flag().name("test-flag"))
+        .field(mocking.field().name("test-field"))
+        .assembly(mocking.assembly().name("test-assembly"))
+        .toModule();
+
+    // Then - exported should equal local (no imports)
+    assertEquals(module.getFlagDefinitions().size(),
+        module.getExportedFlagDefinitions().size(),
+        "Exported flags should equal local flags");
+    assertEquals(module.getFieldDefinitions().size(),
+        module.getExportedFieldDefinitions().size(),
+        "Exported fields should equal local fields");
+    assertEquals(module.getAssemblyDefinitions().size(),
+        module.getExportedAssemblyDefinitions().size(),
+        "Exported assemblies should equal local assemblies");
+  }
+
+  @Test
+  void testRootAssemblyDefinitions() {
+    // Given
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create("https://example.com/test"));
+
+    // When - create one root assembly and one non-root assembly
+    IModule module = mocking.module()
+        .namespace(TEST_NAMESPACE)
+        .shortName(TEST_SHORT_NAME)
+        .version(TEST_VERSION)
+        .source(source)
+        .assembly(mocking.assembly()
+            .name("root-assembly")
+            .rootName("root"))
+        .assembly(mocking.assembly().name("non-root-assembly"))
+        .toModule();
+
+    // Then
+    assertEquals(2, module.getAssemblyDefinitions().size(), "Should have two assembly definitions");
+    assertEquals(1, module.getRootAssemblyDefinitions().size(), "Should have one root assembly");
+
+    IAssemblyDefinition rootDef = module.getRootAssemblyDefinitions().iterator().next();
+    assertEquals("root-assembly", rootDef.getName(), "Root assembly name should match");
+    assertNotNull(rootDef.getRootQName(), "Root assembly should have rootQName set");
+
+    // Exported roots should be same as local roots
+    assertEquals(module.getRootAssemblyDefinitions().size(),
+        module.getExportedRootAssemblyDefinitions().size(),
+        "Exported roots should equal local roots");
+  }
+
+  @Test
+  void testAssemblyAndFieldDefinitions() {
+    // Given
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create("https://example.com/test"));
+
+    // When
+    IModule module = mocking.module()
+        .namespace(TEST_NAMESPACE)
+        .shortName(TEST_SHORT_NAME)
+        .version(TEST_VERSION)
+        .source(source)
+        .field(mocking.field().name("field1"))
+        .field(mocking.field().name("field2"))
+        .assembly(mocking.assembly().name("assembly1"))
+        .toModule();
+
+    // Then - combined list should have both
+    assertEquals(3, module.getAssemblyAndFieldDefinitions().size(),
+        "Combined list should have 2 fields + 1 assembly = 3");
+  }
+
+  @Test
   void testModuleDefinitionLookup() {
     // Given
     MockedModelTestSupport mocking = new MockedModelTestSupport();

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/ModuleBuilderTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/ModuleBuilderTest.java
@@ -13,6 +13,7 @@ import gov.nist.secauto.metaschema.core.model.IAssemblyDefinition;
 import gov.nist.secauto.metaschema.core.model.IFieldDefinition;
 import gov.nist.secauto.metaschema.core.model.IFlagDefinition;
 import gov.nist.secauto.metaschema.core.model.IModule;
+import gov.nist.secauto.metaschema.core.model.INamedModelInstanceAbsolute;
 import gov.nist.secauto.metaschema.core.model.ISource;
 import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
 
@@ -136,6 +137,85 @@ class ModuleBuilderTest {
     assertNotNull(assemblyDef, "Assembly definition should not be null");
     assertEquals("test-assembly", assemblyDef.getName(), "Assembly name should match");
     assertSame(module, assemblyDef.getContainingModule(), "Assembly should reference containing module");
+  }
+
+  @Test
+  void testRecursiveAssembly() {
+    // Given - an assembly that references itself (like a "parent" that can contain
+    // children of same type)
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create("https://example.com/test"));
+
+    // When - build a module with self-referencing assembly
+    IModule module = mocking.module()
+        .namespace(TEST_NAMESPACE)
+        .shortName(TEST_SHORT_NAME)
+        .version(TEST_VERSION)
+        .source(source)
+        .assembly(mocking.assembly()
+            .name("node")
+            .modelInstances(java.util.List.of(
+                mocking.assemblyRef("node")))) // Reference to self
+        .toModule();
+
+    // Then - assembly should exist and be resolvable
+    assertEquals(1, module.getAssemblyDefinitions().size(), "Should have one assembly definition");
+    IAssemblyDefinition nodeDef = module.getAssemblyDefinitions().iterator().next();
+    assertEquals("node", nodeDef.getName(), "Assembly name should match");
+
+    // The model instance should reference the same definition
+    var modelInstances = nodeDef.getModelInstances();
+    assertEquals(1, modelInstances.size(), "Should have one model instance");
+    INamedModelInstanceAbsolute childInstance = (INamedModelInstanceAbsolute) modelInstances.iterator().next();
+    assertNotNull(childInstance, "Child instance should not be null");
+    assertEquals("node", childInstance.getName(), "Child instance name should match");
+    assertSame(nodeDef, childInstance.getDefinition(), "Child should reference parent definition");
+  }
+
+  @Test
+  void testCrossReferenceAssemblies() {
+    // Given - two assemblies that reference each other
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create("https://example.com/test"));
+
+    // When - build a module with cross-referencing assemblies
+    IModule module = mocking.module()
+        .namespace(TEST_NAMESPACE)
+        .shortName(TEST_SHORT_NAME)
+        .version(TEST_VERSION)
+        .source(source)
+        .assembly(mocking.assembly()
+            .name("parent")
+            .modelInstances(java.util.List.of(
+                mocking.assemblyRef("child"))))
+        .assembly(mocking.assembly()
+            .name("child")
+            .modelInstances(java.util.List.of(
+                mocking.assemblyRef("parent"))))
+        .toModule();
+
+    // Then - both assemblies should be defined
+    assertEquals(2, module.getAssemblyDefinitions().size(), "Should have two assembly definitions");
+
+    // Verify cross-references resolve correctly
+    IEnhancedQName parentQName = IEnhancedQName.of(TEST_NAMESPACE, "parent");
+    IEnhancedQName childQName = IEnhancedQName.of(TEST_NAMESPACE, "child");
+
+    IAssemblyDefinition parentDef = module.getAssemblyDefinitionByName(parentQName.getIndexPosition());
+    IAssemblyDefinition childDef = module.getAssemblyDefinitionByName(childQName.getIndexPosition());
+
+    assertNotNull(parentDef, "Parent should be found");
+    assertNotNull(childDef, "Child should be found");
+
+    // Parent's child instance should reference child definition
+    INamedModelInstanceAbsolute childInParent
+        = (INamedModelInstanceAbsolute) parentDef.getModelInstances().iterator().next();
+    assertSame(childDef, childInParent.getDefinition(), "Parent's child should reference child definition");
+
+    // Child's parent instance should reference parent definition
+    INamedModelInstanceAbsolute parentInChild
+        = (INamedModelInstanceAbsolute) childDef.getModelInstances().iterator().next();
+    assertSame(parentDef, parentInChild.getDefinition(), "Child's parent should reference parent definition");
   }
 
   @Test

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/ModuleBuilderTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/ModuleBuilderTest.java
@@ -7,9 +7,14 @@ package gov.nist.secauto.metaschema.core.testing.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
+import gov.nist.secauto.metaschema.core.model.IAssemblyDefinition;
+import gov.nist.secauto.metaschema.core.model.IFieldDefinition;
+import gov.nist.secauto.metaschema.core.model.IFlagDefinition;
 import gov.nist.secauto.metaschema.core.model.IModule;
 import gov.nist.secauto.metaschema.core.model.ISource;
+import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
 
 import org.junit.jupiter.api.Test;
 
@@ -62,5 +67,108 @@ class ModuleBuilderTest {
     // Then
     assertNotNull(module, "Module should not be null");
     assertEquals(TEST_SHORT_NAME, module.getShortName(), "Short name should match");
+  }
+
+  @Test
+  void testModuleWithFlagDefinition() {
+    // Given
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create("https://example.com/test"));
+
+    // When
+    IModule module = mocking.module()
+        .namespace(TEST_NAMESPACE)
+        .shortName(TEST_SHORT_NAME)
+        .version(TEST_VERSION)
+        .source(source)
+        .flag(mocking.flag().name("test-flag"))
+        .toModule();
+
+    // Then
+    assertEquals(1, module.getFlagDefinitions().size(), "Should have one flag definition");
+    IFlagDefinition flagDef = module.getFlagDefinitions().iterator().next();
+    assertNotNull(flagDef, "Flag definition should not be null");
+    assertEquals("test-flag", flagDef.getName(), "Flag name should match");
+    assertSame(module, flagDef.getContainingModule(), "Flag should reference containing module");
+  }
+
+  @Test
+  void testModuleWithFieldDefinition() {
+    // Given
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create("https://example.com/test"));
+
+    // When
+    IModule module = mocking.module()
+        .namespace(TEST_NAMESPACE)
+        .shortName(TEST_SHORT_NAME)
+        .version(TEST_VERSION)
+        .source(source)
+        .field(mocking.field().name("test-field"))
+        .toModule();
+
+    // Then
+    assertEquals(1, module.getFieldDefinitions().size(), "Should have one field definition");
+    IFieldDefinition fieldDef = module.getFieldDefinitions().iterator().next();
+    assertNotNull(fieldDef, "Field definition should not be null");
+    assertEquals("test-field", fieldDef.getName(), "Field name should match");
+    assertSame(module, fieldDef.getContainingModule(), "Field should reference containing module");
+  }
+
+  @Test
+  void testModuleWithAssemblyDefinition() {
+    // Given
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create("https://example.com/test"));
+
+    // When
+    IModule module = mocking.module()
+        .namespace(TEST_NAMESPACE)
+        .shortName(TEST_SHORT_NAME)
+        .version(TEST_VERSION)
+        .source(source)
+        .assembly(mocking.assembly().name("test-assembly"))
+        .toModule();
+
+    // Then
+    assertEquals(1, module.getAssemblyDefinitions().size(), "Should have one assembly definition");
+    IAssemblyDefinition assemblyDef = module.getAssemblyDefinitions().iterator().next();
+    assertNotNull(assemblyDef, "Assembly definition should not be null");
+    assertEquals("test-assembly", assemblyDef.getName(), "Assembly name should match");
+    assertSame(module, assemblyDef.getContainingModule(), "Assembly should reference containing module");
+  }
+
+  @Test
+  void testModuleDefinitionLookup() {
+    // Given
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create("https://example.com/test"));
+
+    // When
+    IModule module = mocking.module()
+        .namespace(TEST_NAMESPACE)
+        .shortName(TEST_SHORT_NAME)
+        .version(TEST_VERSION)
+        .source(source)
+        .flag(mocking.flag().name("my-flag"))
+        .field(mocking.field().name("my-field"))
+        .assembly(mocking.assembly().name("my-assembly"))
+        .toModule();
+
+    // Then - lookup by name should work
+    IEnhancedQName flagQName = IEnhancedQName.of(TEST_NAMESPACE, "my-flag");
+    IFlagDefinition foundFlag = module.getFlagDefinitionByName(flagQName);
+    assertNotNull(foundFlag, "Should find flag by name");
+    assertEquals("my-flag", foundFlag.getName());
+
+    IEnhancedQName fieldQName = IEnhancedQName.of(TEST_NAMESPACE, "my-field");
+    IFieldDefinition foundField = module.getFieldDefinitionByName(fieldQName.getIndexPosition());
+    assertNotNull(foundField, "Should find field by name");
+    assertEquals("my-field", foundField.getName());
+
+    IEnhancedQName assemblyQName = IEnhancedQName.of(TEST_NAMESPACE, "my-assembly");
+    IAssemblyDefinition foundAssembly = module.getAssemblyDefinitionByName(assemblyQName.getIndexPosition());
+    assertNotNull(foundAssembly, "Should find assembly by name");
+    assertEquals("my-assembly", foundAssembly.getName());
   }
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/ModuleBuilderTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testing/model/ModuleBuilderTest.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.testing.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import gov.nist.secauto.metaschema.core.model.IModule;
+import gov.nist.secauto.metaschema.core.model.ISource;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+/**
+ * Unit tests for {@link IModuleBuilder}.
+ */
+class ModuleBuilderTest {
+
+  private static final String TEST_NAMESPACE = "http://example.com/ns/test";
+  private static final String TEST_SHORT_NAME = "test-module";
+  private static final String TEST_VERSION = "1.0.0";
+
+  @Test
+  void testBasicModuleCreation() {
+    // Given
+    ISource source = ISource.externalSource(URI.create("https://example.com/test"));
+
+    // When
+    IModule module = IModuleBuilder.builder()
+        .namespace(TEST_NAMESPACE)
+        .shortName(TEST_SHORT_NAME)
+        .version(TEST_VERSION)
+        .source(source)
+        .toModule();
+
+    // Then
+    assertNotNull(module, "Module should not be null");
+    assertEquals(URI.create(TEST_NAMESPACE), module.getXmlNamespace(), "Namespace should match");
+    assertEquals(TEST_SHORT_NAME, module.getShortName(), "Short name should match");
+    assertEquals(TEST_VERSION, module.getVersion(), "Version should match");
+    assertEquals(source, module.getSource(), "Source should match");
+  }
+
+  @Test
+  void testModuleBuilderFromFactory() {
+    // Given
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create("https://example.com/test"));
+
+    // When
+    IModule module = mocking.module()
+        .namespace(TEST_NAMESPACE)
+        .shortName(TEST_SHORT_NAME)
+        .version(TEST_VERSION)
+        .source(source)
+        .toModule();
+
+    // Then
+    assertNotNull(module, "Module should not be null");
+    assertEquals(TEST_SHORT_NAME, module.getShortName(), "Short name should match");
+  }
+}


### PR DESCRIPTION
## Summary

- Add `IModuleBuilder` interface and `ModuleBuilder` implementation for creating mock `IModule` instances programmatically in tests
- Enable definition builders (`IFlagBuilder`, `IFieldBuilder`, `IAssemblyBuilder`) to integrate with module construction
- Support recursive and cross-referencing assembly structures through lazy reference resolution
- Add export methods and root assembly support for complete module API coverage

This provides an alternative to `ModuleLoader` for test fixtures, enabling programmatic module construction without XML parsing dependencies.

## Test plan

- [x] `mvn -pl core test -Dtest=ModuleBuilderTest` passes (11 tests)
- [x] Full test suite verification after submodule sync

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fluent module builder for creating mock modules in tests with module-scoped construction and resolution
  * Reference builders for lazy assembly/field resolution enabling recursive and cross-referenced models
  * Module-aware overloads on builders to bind definitions to a containing module

* **Tests**
  * New and migrated tests demonstrating recursive modules, exported/root behaviors, constraint handling, and ER diagram generation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->