### PR TITLE
Migrate tests to use IModuleBuilder instead of ModuleLoader

### DIFF
--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/AnonymousFunctionCallTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/AnonymousFunctionCallTest.java
@@ -13,7 +13,7 @@ import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
 import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression.ResultType;
 import gov.nist.secauto.metaschema.core.metapath.StaticContext;
 import gov.nist.secauto.metaschema.core.metapath.item.node.INodeItem;
-import gov.nist.secauto.metaschema.core.testing.model.mocking.MockedDocumentGenerator;
+import gov.nist.secauto.metaschema.core.testsupport.mocking.MockedDocumentGenerator;
 
 import org.junit.jupiter.api.Test;
 

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/BuildCstVisitorTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/BuildCstVisitorTest.java
@@ -51,7 +51,7 @@ import gov.nist.secauto.metaschema.core.metapath.item.node.IFieldNodeItem;
 import gov.nist.secauto.metaschema.core.metapath.item.node.IFlagNodeItem;
 import gov.nist.secauto.metaschema.core.metapath.item.node.IRootAssemblyNodeItem;
 import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
-import gov.nist.secauto.metaschema.core.testing.model.mocking.MockNodeItemFactory;
+import gov.nist.secauto.metaschema.core.testsupport.mocking.MockNodeItemFactory;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
 import org.antlr.v4.runtime.CharStreams;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/logic/PredicateExpressionTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/logic/PredicateExpressionTest.java
@@ -17,7 +17,7 @@ import gov.nist.secauto.metaschema.core.metapath.IExpression;
 import gov.nist.secauto.metaschema.core.metapath.item.ISequence;
 import gov.nist.secauto.metaschema.core.metapath.item.node.IAssemblyNodeItem;
 import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
-import gov.nist.secauto.metaschema.core.testing.model.mocking.MockNodeItemFactory;
+import gov.nist.secauto.metaschema.core.testsupport.mocking.MockNodeItemFactory;
 import gov.nist.secauto.metaschema.core.util.CollectionUtil;
 
 import org.junit.jupiter.api.Test;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/path/RootSlashOnlyPathTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/path/RootSlashOnlyPathTest.java
@@ -16,7 +16,7 @@ import gov.nist.secauto.metaschema.core.metapath.item.ISequence;
 import gov.nist.secauto.metaschema.core.metapath.item.node.IDocumentNodeItem;
 import gov.nist.secauto.metaschema.core.metapath.item.node.INodeItem;
 import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
-import gov.nist.secauto.metaschema.core.testing.model.mocking.MockNodeItemFactory;
+import gov.nist.secauto.metaschema.core.testsupport.mocking.MockNodeItemFactory;
 import gov.nist.secauto.metaschema.core.util.CollectionUtil;
 
 import org.junit.jupiter.api.Test;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/path/StepTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/path/StepTest.java
@@ -17,7 +17,7 @@ import gov.nist.secauto.metaschema.core.metapath.item.node.IFlagNodeItem;
 import gov.nist.secauto.metaschema.core.metapath.item.node.IModelNodeItem;
 import gov.nist.secauto.metaschema.core.metapath.item.node.INodeItem;
 import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
-import gov.nist.secauto.metaschema.core.testing.model.mocking.MockNodeItemFactory;
+import gov.nist.secauto.metaschema.core.testsupport.mocking.MockNodeItemFactory;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
 import org.assertj.core.api.Assertions;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/type/InstanceOfTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/cst/type/InstanceOfTest.java
@@ -19,7 +19,7 @@ import gov.nist.secauto.metaschema.core.metapath.item.atomic.IUuidItem;
 import gov.nist.secauto.metaschema.core.metapath.item.function.IMapItem;
 import gov.nist.secauto.metaschema.core.metapath.item.node.IDocumentNodeItem;
 import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
-import gov.nist.secauto.metaschema.core.testing.model.mocking.MockNodeItemFactory;
+import gov.nist.secauto.metaschema.core.testsupport.mocking.MockNodeItemFactory;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnBaseUriTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnBaseUriTest.java
@@ -16,7 +16,7 @@ import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyUriItem;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
 import gov.nist.secauto.metaschema.core.metapath.type.InvalidTypeMetapathException;
-import gov.nist.secauto.metaschema.core.testing.model.mocking.MockedDocumentGenerator;
+import gov.nist.secauto.metaschema.core.testsupport.mocking.MockedDocumentGenerator;
 
 import org.junit.jupiter.api.Test;
 

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDataTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDataTest.java
@@ -15,7 +15,7 @@ import gov.nist.secauto.metaschema.core.metapath.item.ISequence;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IIntegerItem;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
-import gov.nist.secauto.metaschema.core.testing.model.mocking.MockedDocumentGenerator;
+import gov.nist.secauto.metaschema.core.testsupport.mocking.MockedDocumentGenerator;
 
 import org.junit.jupiter.api.Test;
 

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDocumentUriTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDocumentUriTest.java
@@ -17,7 +17,7 @@ import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyUriItem;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
 import gov.nist.secauto.metaschema.core.metapath.type.InvalidTypeMetapathException;
-import gov.nist.secauto.metaschema.core.testing.model.mocking.MockedDocumentGenerator;
+import gov.nist.secauto.metaschema.core.testsupport.mocking.MockedDocumentGenerator;
 
 import org.junit.jupiter.api.Test;
 

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnHasChildrenTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnHasChildrenTest.java
@@ -15,7 +15,7 @@ import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
 import gov.nist.secauto.metaschema.core.metapath.item.node.INodeItem;
 import gov.nist.secauto.metaschema.core.metapath.type.InvalidTypeMetapathException;
-import gov.nist.secauto.metaschema.core.testing.model.mocking.MockedDocumentGenerator;
+import gov.nist.secauto.metaschema.core.testsupport.mocking.MockedDocumentGenerator;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnInnermostTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnInnermostTest.java
@@ -17,7 +17,7 @@ import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
 import gov.nist.secauto.metaschema.core.metapath.item.node.INodeItem;
 import gov.nist.secauto.metaschema.core.metapath.type.InvalidTypeMetapathException;
 import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
-import gov.nist.secauto.metaschema.core.testing.model.mocking.MockedDocumentGenerator;
+import gov.nist.secauto.metaschema.core.testsupport.mocking.MockedDocumentGenerator;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnLocalNameTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnLocalNameTest.java
@@ -16,7 +16,7 @@ import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
 import gov.nist.secauto.metaschema.core.metapath.type.InvalidTypeMetapathException;
 import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
-import gov.nist.secauto.metaschema.core.testing.model.mocking.MockedDocumentGenerator;
+import gov.nist.secauto.metaschema.core.testsupport.mocking.MockedDocumentGenerator;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnNameTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnNameTest.java
@@ -16,7 +16,7 @@ import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
 import gov.nist.secauto.metaschema.core.metapath.type.InvalidTypeMetapathException;
 import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
-import gov.nist.secauto.metaschema.core.testing.model.mocking.MockedDocumentGenerator;
+import gov.nist.secauto.metaschema.core.testsupport.mocking.MockedDocumentGenerator;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnNamespaceUriTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnNamespaceUriTest.java
@@ -16,7 +16,7 @@ import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
 import gov.nist.secauto.metaschema.core.metapath.type.InvalidTypeMetapathException;
 import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
-import gov.nist.secauto.metaschema.core.testing.model.mocking.MockedDocumentGenerator;
+import gov.nist.secauto.metaschema.core.testsupport.mocking.MockedDocumentGenerator;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnOutermostTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnOutermostTest.java
@@ -17,7 +17,7 @@ import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
 import gov.nist.secauto.metaschema.core.metapath.item.node.INodeItem;
 import gov.nist.secauto.metaschema.core.metapath.type.InvalidTypeMetapathException;
 import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
-import gov.nist.secauto.metaschema.core.testing.model.mocking.MockedDocumentGenerator;
+import gov.nist.secauto.metaschema.core.testsupport.mocking.MockedDocumentGenerator;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnPathTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnPathTest.java
@@ -16,7 +16,7 @@ import gov.nist.secauto.metaschema.core.metapath.ExpressionTestBase;
 import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
 import gov.nist.secauto.metaschema.core.metapath.type.InvalidTypeMetapathException;
-import gov.nist.secauto.metaschema.core.testing.model.mocking.MockedDocumentGenerator;
+import gov.nist.secauto.metaschema.core.testsupport.mocking.MockedDocumentGenerator;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnRootTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnRootTest.java
@@ -15,7 +15,7 @@ import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
 import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
 import gov.nist.secauto.metaschema.core.metapath.item.node.INodeItem;
 import gov.nist.secauto.metaschema.core.metapath.type.InvalidTypeMetapathException;
-import gov.nist.secauto.metaschema.core.testing.model.mocking.MockedDocumentGenerator;
+import gov.nist.secauto.metaschema.core.testsupport.mocking.MockedDocumentGenerator;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/item/node/AbstractRecursionPreventingNodeItemVisitorTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/item/node/AbstractRecursionPreventingNodeItemVisitorTest.java
@@ -7,8 +7,8 @@ package gov.nist.secauto.metaschema.core.metapath.item.node;
 
 import gov.nist.secauto.metaschema.core.model.IModule;
 import gov.nist.secauto.metaschema.core.model.ISource;
-import gov.nist.secauto.metaschema.core.testing.model.IModuleBuilder;
-import gov.nist.secauto.metaschema.core.testing.model.MockedModelTestSupport;
+import gov.nist.secauto.metaschema.core.testsupport.builder.IModuleBuilder;
+import gov.nist.secauto.metaschema.core.testsupport.MockedModelTestSupport;
 
 import org.junit.jupiter.api.Test;
 

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/item/node/AbstractRecursionPreventingNodeItemVisitorTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/item/node/AbstractRecursionPreventingNodeItemVisitorTest.java
@@ -10,9 +10,12 @@ import gov.nist.secauto.metaschema.core.model.ISource;
 import gov.nist.secauto.metaschema.core.testsupport.builder.IModuleBuilder;
 import gov.nist.secauto.metaschema.core.testsupport.MockedModelTestSupport;
 
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.List;
 
 class AbstractRecursionPreventingNodeItemVisitorTest {
@@ -46,7 +49,10 @@ class AbstractRecursionPreventingNodeItemVisitorTest {
         };
 
     // This should complete without infinite loop due to recursion prevention
-    visitor.visitMetaschema(INodeItemFactory.instance().newModuleNodeItem(module), null);
+    // Using timeout assertion to make the test intent explicit
+    assertTimeoutPreemptively(Duration.ofSeconds(1), () -> {
+      visitor.visitMetaschema(INodeItemFactory.instance().newModuleNodeItem(module), null);
+    });
   }
 
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/item/node/AbstractRecursionPreventingNodeItemVisitorTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/item/node/AbstractRecursionPreventingNodeItemVisitorTest.java
@@ -1,20 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
 
 package gov.nist.secauto.metaschema.core.metapath.item.node;
 
 import gov.nist.secauto.metaschema.core.model.IModule;
-import gov.nist.secauto.metaschema.core.model.MetaschemaException;
-import gov.nist.secauto.metaschema.core.model.xml.ModuleLoader;
-import gov.nist.secauto.metaschema.core.util.ObjectUtils;
+import gov.nist.secauto.metaschema.core.model.ISource;
+import gov.nist.secauto.metaschema.core.testing.model.IModuleBuilder;
+import gov.nist.secauto.metaschema.core.testing.model.MockedModelTestSupport;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.nio.file.Paths;
+import java.net.URI;
+import java.util.List;
 
 class AbstractRecursionPreventingNodeItemVisitorTest {
 
+  private static final String TEST_NAMESPACE = "http://example.com/ns/recursion-test";
+
   @Test
-  void testRecursion() throws MetaschemaException, IOException {
+  void testRecursion() {
+    // Build a module with a self-referencing assembly
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create(TEST_NAMESPACE));
+
+    IModule module = IModuleBuilder.builder()
+        .namespace(TEST_NAMESPACE)
+        .shortName("recursion-test")
+        .version("1.0.0")
+        .source(source)
+        .assembly(mocking.assembly()
+            .name("recursive-node")
+            .rootName("recursive-node")
+            .modelInstances(List.of(
+                mocking.assemblyRef("recursive-node"))))
+        .toModule();
+
     AbstractRecursionPreventingNodeItemVisitor<Void, Void> visitor
         = new AbstractRecursionPreventingNodeItemVisitor<>() {
           @Override
@@ -23,8 +45,7 @@ class AbstractRecursionPreventingNodeItemVisitorTest {
           }
         };
 
-    IModule module = new ModuleLoader().load(ObjectUtils.notNull(
-        Paths.get("metaschema/schema/metaschema/metaschema-module-metaschema.xml")));
+    // This should complete without infinite loop due to recursion prevention
     visitor.visitMetaschema(INodeItemFactory.instance().newModuleNodeItem(module), null);
   }
 

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/item/node/DefaultNodeItemFactoryTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/item/node/DefaultNodeItemFactoryTest.java
@@ -10,7 +10,7 @@ import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
 import gov.nist.secauto.metaschema.core.model.IAssemblyDefinition;
 import gov.nist.secauto.metaschema.core.model.ISource;
 import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
-import gov.nist.secauto.metaschema.core.testing.model.MockedModelTestSupport;
+import gov.nist.secauto.metaschema.core.testsupport.MockedModelTestSupport;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
 import org.junit.jupiter.api.Test;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/item/node/RecursionCollectingNodeItemVisitorTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/item/node/RecursionCollectingNodeItemVisitorTest.java
@@ -10,8 +10,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import gov.nist.secauto.metaschema.core.model.IModule;
 import gov.nist.secauto.metaschema.core.model.ISource;
-import gov.nist.secauto.metaschema.core.testing.model.IModuleBuilder;
-import gov.nist.secauto.metaschema.core.testing.model.MockedModelTestSupport;
+import gov.nist.secauto.metaschema.core.testsupport.builder.IModuleBuilder;
+import gov.nist.secauto.metaschema.core.testsupport.MockedModelTestSupport;
 
 import org.junit.jupiter.api.Test;
 

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/item/node/RecursionCollectingNodeItemVisitorTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/item/node/RecursionCollectingNodeItemVisitorTest.java
@@ -1,48 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
 
 package gov.nist.secauto.metaschema.core.metapath.item.node;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 import gov.nist.secauto.metaschema.core.model.IModule;
-import gov.nist.secauto.metaschema.core.model.MetaschemaException;
-import gov.nist.secauto.metaschema.core.model.xml.ModuleLoader;
-import gov.nist.secauto.metaschema.core.util.ObjectUtils;
+import gov.nist.secauto.metaschema.core.model.ISource;
+import gov.nist.secauto.metaschema.core.testing.model.IModuleBuilder;
+import gov.nist.secauto.metaschema.core.testing.model.MockedModelTestSupport;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.nio.file.Paths;
+import java.net.URI;
+import java.util.List;
 import java.util.Set;
-
-import edu.umd.cs.findbugs.annotations.NonNull;
 
 class RecursionCollectingNodeItemVisitorTest {
 
+  private static final String TEST_NAMESPACE = "http://example.com/ns/recursion-test";
+
   @Test
-  void testAssemblyRecursion() throws MetaschemaException, IOException {
-    IModule module = new ModuleLoader().load(ObjectUtils.notNull(
-        Paths.get("metaschema/schema/metaschema/metaschema-module-metaschema.xml")));
+  void testAssemblyRecursion() {
+    // Build a module with a self-referencing assembly
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create(TEST_NAMESPACE));
+
+    IModule module = IModuleBuilder.builder()
+        .namespace(TEST_NAMESPACE)
+        .shortName("recursion-test")
+        .version("1.0.0")
+        .source(source)
+        .assembly(mocking.assembly()
+            .name("recursive-node")
+            .rootName("recursive-node")
+            .modelInstances(List.of(
+                mocking.assemblyRef("recursive-node"))))
+        .toModule();
 
     RecursionCollectingNodeItemVisitor walker = new RecursionCollectingNodeItemVisitor();
     walker.visit(module);
     Set<RecursionCollectingNodeItemVisitor.AssemblyRecord> recursiveAssemblies
         = walker.getRecursiveAssemblyDefinitions();
 
-    System.out.println("Recursive Assemblies");
-    System.out.println("--------------------");
-    recursiveAssemblies.forEach(record -> {
-      System.out.println(record.getDefinition().getFormalName());
-      record.getLocations().forEach(location -> {
-        assert location != null;
-        System.out.println("- " + metapath(location));
-      });
-    });
-  }
+    // Verify that the recursive assembly was detected
+    assertFalse(recursiveAssemblies.isEmpty(), "Should detect recursive assembly");
+    assertEquals(1, recursiveAssemblies.size(), "Should have exactly one recursive assembly");
 
-  private static String metapath(@NonNull IDefinitionNodeItem<?, ?> item) {
-    return metapath(item.getMetapath());
-  }
-
-  private static String metapath(@NonNull String path) {
-    return path.replaceAll("\\[1\\]", "");
+    RecursionCollectingNodeItemVisitor.AssemblyRecord record = recursiveAssemblies.iterator().next();
+    assertEquals("recursive-node", record.getDefinition().getName(),
+        "Recursive assembly should be 'recursive-node'");
   }
 
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/model/constraint/DefaultConstraintValidatorTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/model/constraint/DefaultConstraintValidatorTest.java
@@ -28,7 +28,7 @@ import gov.nist.secauto.metaschema.core.metapath.item.node.IFlagNodeItem;
 import gov.nist.secauto.metaschema.core.model.IFlagDefinition;
 import gov.nist.secauto.metaschema.core.model.ISource;
 import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
-import gov.nist.secauto.metaschema.core.testing.model.mocking.MockNodeItemFactory;
+import gov.nist.secauto.metaschema.core.testsupport.mocking.MockNodeItemFactory;
 import gov.nist.secauto.metaschema.core.util.CollectionUtil;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/model/constraint/ExternalConstraintsModulePostProcessorTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/model/constraint/ExternalConstraintsModulePostProcessorTest.java
@@ -9,36 +9,57 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import gov.nist.secauto.metaschema.core.model.IAssemblyDefinition;
 import gov.nist.secauto.metaschema.core.model.IModule;
+import gov.nist.secauto.metaschema.core.model.ISource;
 import gov.nist.secauto.metaschema.core.model.MetaschemaException;
-import gov.nist.secauto.metaschema.core.model.xml.ModuleLoader;
 import gov.nist.secauto.metaschema.core.model.xml.XmlMetaConstraintLoader;
 import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
-import gov.nist.secauto.metaschema.core.util.CollectionUtil;
+import gov.nist.secauto.metaschema.core.testing.model.IModuleBuilder;
+import gov.nist.secauto.metaschema.core.testing.model.MockedModelTestSupport;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Paths;
 import java.util.List;
 
 class ExternalConstraintsModulePostProcessorTest {
 
+  private static final String TEST_NAMESPACE = "http://csrc.nist.gov/ns/test/metaschema/constraint-targeting-test";
+
   @Test
   void test() throws MetaschemaException, IOException {
-
+    // Load external constraints from XML
     List<IConstraintSet> constraints
         = new XmlMetaConstraintLoader().load(ObjectUtils.notNull(
             Paths.get("src/test/resources/content/issue184-constraints.xml")));
 
-    IModule module
-        = new ModuleLoader(CollectionUtil.singletonList(new ExternalConstraintsModulePostProcessor(constraints)))
-            .load(ObjectUtils.notNull(
-                Paths.get("src/test/resources/content/issue184-metaschema.xml")));
+    // Build module programmatically instead of loading from XML
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create(TEST_NAMESPACE));
 
+    IModule module = IModuleBuilder.builder()
+        .namespace(TEST_NAMESPACE)
+        .shortName("constraint-targeting-test")
+        .version("1.0.0")
+        .source(source)
+        .assembly(mocking.assembly()
+            .name("a")
+            .rootName("a")
+            .flags(List.of(mocking.flag().name("value")))
+            .modelInstances(List.of(
+                mocking.assemblyRef("a"))))
+        .toModule();
+
+    // Apply external constraints to the module
+    ExternalConstraintsModulePostProcessor postProcessor
+        = new ExternalConstraintsModulePostProcessor(constraints);
+    postProcessor.processModule(module);
+
+    // Verify constraint was applied
     IAssemblyDefinition definition = ObjectUtils.requireNonNull(module.getAssemblyDefinitionByName(
-        IEnhancedQName.of("http://csrc.nist.gov/ns/test/metaschema/constraint-targeting-test", "a")
-            .getIndexPosition()));
+        IEnhancedQName.of(TEST_NAMESPACE, "a").getIndexPosition()));
 
     assertEquals(1, definition.getConstraints().size());
   }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/model/constraint/ExternalConstraintsModulePostProcessorTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/model/constraint/ExternalConstraintsModulePostProcessorTest.java
@@ -13,8 +13,8 @@ import gov.nist.secauto.metaschema.core.model.ISource;
 import gov.nist.secauto.metaschema.core.model.MetaschemaException;
 import gov.nist.secauto.metaschema.core.model.xml.XmlMetaConstraintLoader;
 import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
-import gov.nist.secauto.metaschema.core.testing.model.IModuleBuilder;
-import gov.nist.secauto.metaschema.core.testing.model.MockedModelTestSupport;
+import gov.nist.secauto.metaschema.core.testsupport.builder.IModuleBuilder;
+import gov.nist.secauto.metaschema.core.testsupport.MockedModelTestSupport;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
 import org.junit.jupiter.api.Test;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/model/constraint/impl/AbstractConfigurableMessageConstraintTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/model/constraint/impl/AbstractConfigurableMessageConstraintTest.java
@@ -19,7 +19,7 @@ import gov.nist.secauto.metaschema.core.model.constraint.ConstraintValidationExc
 import gov.nist.secauto.metaschema.core.model.constraint.DefaultConstraintValidator;
 import gov.nist.secauto.metaschema.core.model.constraint.FindingCollectingConstraintValidationHandler;
 import gov.nist.secauto.metaschema.core.model.constraint.IExpectConstraint;
-import gov.nist.secauto.metaschema.core.testing.model.mocking.MockedDocumentGenerator;
+import gov.nist.secauto.metaschema.core.testsupport.mocking.MockedDocumentGenerator;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
 import org.junit.jupiter.api.Test;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/MockedModelTestSupport.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/MockedModelTestSupport.java
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-package gov.nist.secauto.metaschema.core.testing.model;
+package gov.nist.secauto.metaschema.core.testsupport;
 
-import gov.nist.secauto.metaschema.core.testing.model.mocking.AbstractMockitoFactory;
+import gov.nist.secauto.metaschema.core.testsupport.builder.IModuleMockFactory;
+import gov.nist.secauto.metaschema.core.testsupport.mocking.AbstractMockitoFactory;
 
 /**
  * Provides the ability to generate mocked Metaschema module definitions and

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/AbstractMetaschemaBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/AbstractMetaschemaBuilder.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-package gov.nist.secauto.metaschema.core.testing.model;
+package gov.nist.secauto.metaschema.core.testsupport.builder;
 
 import static org.mockito.Mockito.doReturn;
 
@@ -16,7 +16,7 @@ import gov.nist.secauto.metaschema.core.model.INamedInstance;
 import gov.nist.secauto.metaschema.core.model.INamedModelElement;
 import gov.nist.secauto.metaschema.core.model.ISource;
 import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
-import gov.nist.secauto.metaschema.core.testing.model.mocking.AbstractMockitoFactory;
+import gov.nist.secauto.metaschema.core.testsupport.mocking.AbstractMockitoFactory;
 import gov.nist.secauto.metaschema.core.util.CollectionUtil;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import gov.nist.secauto.metaschema.core.util.StringUtils;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/AbstractModelBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/AbstractModelBuilder.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-package gov.nist.secauto.metaschema.core.testing.model;
+package gov.nist.secauto.metaschema.core.testsupport.builder;
 
 import gov.nist.secauto.metaschema.core.util.CollectionUtil;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/AssemblyBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/AssemblyBuilder.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-package gov.nist.secauto.metaschema.core.testing.model;
+package gov.nist.secauto.metaschema.core.testsupport.builder;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/AssemblyReference.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/AssemblyReference.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-package gov.nist.secauto.metaschema.core.testing.model;
+package gov.nist.secauto.metaschema.core.testsupport.builder;
 
 import gov.nist.secauto.metaschema.core.model.IAssemblyDefinition;
 import gov.nist.secauto.metaschema.core.model.INamedModelInstanceAbsolute;
@@ -16,28 +16,28 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
- * A reference to a field definition by name. This class implements
+ * A reference to an assembly definition by name. This class implements
  * {@link IModelBuilder} to allow it to be used in model instance lists, but the
  * actual instance is created during module resolution when the referenced
  * definition is available.
  *
  * <p>
- * This enables assembly structures that reference fields defined elsewhere in
- * the module.
+ * This enables recursive assembly structures where an assembly can contain
+ * instances of itself or other assemblies that are defined later in the module.
  */
-final class FieldReference
-    implements IModelBuilder<FieldReference>, IModelReference {
+final class AssemblyReference
+    implements IModelBuilder<AssemblyReference>, IModelReference {
 
   private final String referencedName;
   private ISource source;
 
   /**
-   * Construct a new field reference.
+   * Construct a new assembly reference.
    *
    * @param referencedName
-   *          the local name of the referenced field definition
+   *          the local name of the referenced assembly definition
    */
-  FieldReference(@NonNull String referencedName) {
+  AssemblyReference(@NonNull String referencedName) {
     this.referencedName = referencedName;
   }
 
@@ -48,35 +48,35 @@ final class FieldReference
   }
 
   @Override
-  public FieldReference reset() {
+  public AssemblyReference reset() {
     this.source = null;
     return this;
   }
 
   @Override
   @NonNull
-  public FieldReference namespace(@NonNull String name) {
+  public AssemblyReference namespace(@NonNull String name) {
     // References use the name from construction; namespace is set by ModuleBuilder
     return this;
   }
 
   @Override
   @NonNull
-  public FieldReference name(@NonNull String name) {
+  public AssemblyReference name(@NonNull String name) {
     // References use the name from construction
     return this;
   }
 
   @Override
   @NonNull
-  public FieldReference qname(@NonNull IEnhancedQName qname) {
+  public AssemblyReference qname(@NonNull IEnhancedQName qname) {
     // References use the name from construction
     return this;
   }
 
   @Override
   @NonNull
-  public FieldReference source(@NonNull ISource source) {
+  public AssemblyReference source(@NonNull ISource source) {
     this.source = source;
     return this;
   }
@@ -93,13 +93,13 @@ final class FieldReference
 
   @Override
   @NonNull
-  public FieldReference flags(@Nullable List<IFlagBuilder> flags) {
+  public AssemblyReference flags(@Nullable List<IFlagBuilder> flags) {
     // References don't support flags - they reference existing definitions
-    throw new UnsupportedOperationException("Field references cannot have flags");
+    throw new UnsupportedOperationException("Assembly references cannot have flags");
   }
 
   /**
-   * This method should not be called directly. Field references are resolved
+   * This method should not be called directly. Assembly references are resolved
    * during module construction.
    *
    * @param parent
@@ -112,7 +112,7 @@ final class FieldReference
   @NonNull
   public INamedModelInstanceAbsolute toInstance(@NonNull IAssemblyDefinition parent) {
     throw new UnsupportedOperationException(
-        "Field references must be resolved during module construction. "
+        "Assembly references must be resolved during module construction. "
             + "Use ModuleBuilder to build the module, which will resolve references.");
   }
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/FieldBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/FieldBuilder.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-package gov.nist.secauto.metaschema.core.testing.model;
+package gov.nist.secauto.metaschema.core.testsupport.builder;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/FieldReference.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/FieldReference.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-package gov.nist.secauto.metaschema.core.testing.model;
+package gov.nist.secauto.metaschema.core.testsupport.builder;
 
 import gov.nist.secauto.metaschema.core.model.IAssemblyDefinition;
 import gov.nist.secauto.metaschema.core.model.INamedModelInstanceAbsolute;
@@ -16,28 +16,28 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
- * A reference to an assembly definition by name. This class implements
+ * A reference to a field definition by name. This class implements
  * {@link IModelBuilder} to allow it to be used in model instance lists, but the
  * actual instance is created during module resolution when the referenced
  * definition is available.
  *
  * <p>
- * This enables recursive assembly structures where an assembly can contain
- * instances of itself or other assemblies that are defined later in the module.
+ * This enables assembly structures that reference fields defined elsewhere in
+ * the module.
  */
-final class AssemblyReference
-    implements IModelBuilder<AssemblyReference>, IModelReference {
+final class FieldReference
+    implements IModelBuilder<FieldReference>, IModelReference {
 
   private final String referencedName;
   private ISource source;
 
   /**
-   * Construct a new assembly reference.
+   * Construct a new field reference.
    *
    * @param referencedName
-   *          the local name of the referenced assembly definition
+   *          the local name of the referenced field definition
    */
-  AssemblyReference(@NonNull String referencedName) {
+  FieldReference(@NonNull String referencedName) {
     this.referencedName = referencedName;
   }
 
@@ -48,35 +48,35 @@ final class AssemblyReference
   }
 
   @Override
-  public AssemblyReference reset() {
+  public FieldReference reset() {
     this.source = null;
     return this;
   }
 
   @Override
   @NonNull
-  public AssemblyReference namespace(@NonNull String name) {
+  public FieldReference namespace(@NonNull String name) {
     // References use the name from construction; namespace is set by ModuleBuilder
     return this;
   }
 
   @Override
   @NonNull
-  public AssemblyReference name(@NonNull String name) {
+  public FieldReference name(@NonNull String name) {
     // References use the name from construction
     return this;
   }
 
   @Override
   @NonNull
-  public AssemblyReference qname(@NonNull IEnhancedQName qname) {
+  public FieldReference qname(@NonNull IEnhancedQName qname) {
     // References use the name from construction
     return this;
   }
 
   @Override
   @NonNull
-  public AssemblyReference source(@NonNull ISource source) {
+  public FieldReference source(@NonNull ISource source) {
     this.source = source;
     return this;
   }
@@ -93,13 +93,13 @@ final class AssemblyReference
 
   @Override
   @NonNull
-  public AssemblyReference flags(@Nullable List<IFlagBuilder> flags) {
+  public FieldReference flags(@Nullable List<IFlagBuilder> flags) {
     // References don't support flags - they reference existing definitions
-    throw new UnsupportedOperationException("Assembly references cannot have flags");
+    throw new UnsupportedOperationException("Field references cannot have flags");
   }
 
   /**
-   * This method should not be called directly. Assembly references are resolved
+   * This method should not be called directly. Field references are resolved
    * during module construction.
    *
    * @param parent
@@ -112,7 +112,7 @@ final class AssemblyReference
   @NonNull
   public INamedModelInstanceAbsolute toInstance(@NonNull IAssemblyDefinition parent) {
     throw new UnsupportedOperationException(
-        "Assembly references must be resolved during module construction. "
+        "Field references must be resolved during module construction. "
             + "Use ModuleBuilder to build the module, which will resolve references.");
   }
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/FlagBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/FlagBuilder.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-package gov.nist.secauto.metaschema.core.testing.model;
+package gov.nist.secauto.metaschema.core.testsupport.builder;
 
 import static org.mockito.Mockito.doReturn;
 

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/IAssemblyBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/IAssemblyBuilder.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-package gov.nist.secauto.metaschema.core.testing.model;
+package gov.nist.secauto.metaschema.core.testsupport.builder;
 
 import gov.nist.secauto.metaschema.core.model.IAssemblyDefinition;
 import gov.nist.secauto.metaschema.core.model.IAssemblyInstanceAbsolute;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/IFieldBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/IFieldBuilder.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-package gov.nist.secauto.metaschema.core.testing.model;
+package gov.nist.secauto.metaschema.core.testsupport.builder;
 
 import gov.nist.secauto.metaschema.core.datatype.IDataTypeAdapter;
 import gov.nist.secauto.metaschema.core.model.IAssemblyDefinition;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/IFlagBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/IFlagBuilder.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-package gov.nist.secauto.metaschema.core.testing.model;
+package gov.nist.secauto.metaschema.core.testsupport.builder;
 
 import gov.nist.secauto.metaschema.core.datatype.IDataTypeAdapter;
 import gov.nist.secauto.metaschema.core.model.IFlagDefinition;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/IMetaschemaBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/IMetaschemaBuilder.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-package gov.nist.secauto.metaschema.core.testing.model;
+package gov.nist.secauto.metaschema.core.testsupport.builder;
 
 import gov.nist.secauto.metaschema.core.model.ISource;
 import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/IModelBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/IModelBuilder.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-package gov.nist.secauto.metaschema.core.testing.model;
+package gov.nist.secauto.metaschema.core.testsupport.builder;
 
 import gov.nist.secauto.metaschema.core.model.IAssemblyDefinition;
 import gov.nist.secauto.metaschema.core.model.INamedModelInstanceAbsolute;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/IModelReference.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/IModelReference.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-package gov.nist.secauto.metaschema.core.testing.model;
+package gov.nist.secauto.metaschema.core.testsupport.builder;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/IModuleBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/IModuleBuilder.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-package gov.nist.secauto.metaschema.core.testing.model;
+package gov.nist.secauto.metaschema.core.testsupport.builder;
 
 import gov.nist.secauto.metaschema.core.model.IModule;
 import gov.nist.secauto.metaschema.core.model.ISource;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/IModuleMockFactory.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/IModuleMockFactory.java
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-package gov.nist.secauto.metaschema.core.testing.model;
+package gov.nist.secauto.metaschema.core.testsupport.builder;
 
-import gov.nist.secauto.metaschema.core.testing.model.mocking.IMockFactory;
+import gov.nist.secauto.metaschema.core.testsupport.mocking.IMockFactory;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/ModuleBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/ModuleBuilder.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-package gov.nist.secauto.metaschema.core.testing.model;
+package gov.nist.secauto.metaschema.core.testsupport.builder;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -14,7 +14,7 @@ import gov.nist.secauto.metaschema.core.model.IFlagDefinition;
 import gov.nist.secauto.metaschema.core.model.IModule;
 import gov.nist.secauto.metaschema.core.model.ISource;
 import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
-import gov.nist.secauto.metaschema.core.testing.model.mocking.AbstractMockitoFactory;
+import gov.nist.secauto.metaschema.core.testsupport.mocking.AbstractMockitoFactory;
 import gov.nist.secauto.metaschema.core.util.CollectionUtil;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/mocking/AbstractJMockFactory.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/mocking/AbstractJMockFactory.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-package gov.nist.secauto.metaschema.core.testing.model.mocking;
+package gov.nist.secauto.metaschema.core.testsupport.mocking;
 
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/mocking/AbstractMockitoFactory.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/mocking/AbstractMockitoFactory.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-package gov.nist.secauto.metaschema.core.testing.model.mocking;
+package gov.nist.secauto.metaschema.core.testsupport.mocking;
 
 import static org.mockito.Mockito.withSettings;
 

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/mocking/IMockFactory.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/mocking/IMockFactory.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-package gov.nist.secauto.metaschema.core.testing.model.mocking;
+package gov.nist.secauto.metaschema.core.testsupport.mocking;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/mocking/MockNodeItemFactory.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/mocking/MockNodeItemFactory.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-package gov.nist.secauto.metaschema.core.testing.model.mocking;
+package gov.nist.secauto.metaschema.core.testsupport.mocking;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -38,7 +38,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 /**
  * Generates mock node item objects.
  */
-// FIXME: Integrate with classes in gov.nist.secauto.metaschema.core.testing
+// FIXME: Integrate with classes in gov.nist.secauto.metaschema.core.testsupport
 @SuppressWarnings("checkstyle:MissingJavadocMethodCheck")
 @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
 public class MockNodeItemFactory

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/mocking/MockedDocumentGenerator.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/mocking/MockedDocumentGenerator.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-package gov.nist.secauto.metaschema.core.testing.model.mocking;
+package gov.nist.secauto.metaschema.core.testsupport.mocking;
 
 import gov.nist.secauto.metaschema.core.mdm.IDMAssemblyNodeItem;
 import gov.nist.secauto.metaschema.core.mdm.IDMDocumentNodeItem;
@@ -18,7 +18,7 @@ import gov.nist.secauto.metaschema.core.model.IFlagDefinition;
 import gov.nist.secauto.metaschema.core.model.IFlagInstance;
 import gov.nist.secauto.metaschema.core.model.ISource;
 import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
-import gov.nist.secauto.metaschema.core.testing.model.MockedModelTestSupport;
+import gov.nist.secauto.metaschema.core.testsupport.MockedModelTestSupport;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
 import java.net.URI;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/tests/ModuleBuilderTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/tests/ModuleBuilderTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-package gov.nist.secauto.metaschema.core.testing.model;
+package gov.nist.secauto.metaschema.core.testsupport.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -16,6 +16,8 @@ import gov.nist.secauto.metaschema.core.model.IModule;
 import gov.nist.secauto.metaschema.core.model.INamedModelInstanceAbsolute;
 import gov.nist.secauto.metaschema.core.model.ISource;
 import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
+import gov.nist.secauto.metaschema.core.testsupport.MockedModelTestSupport;
+import gov.nist.secauto.metaschema.core.testsupport.builder.IModuleBuilder;
 
 import org.junit.jupiter.api.Test;
 

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/util/MermaidErDiagramGeneratorTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/util/MermaidErDiagramGeneratorTest.java
@@ -61,5 +61,8 @@ class MermaidErDiagramGeneratorTest {
     // Verify the diagram contains expected elements
     assertTrue(diagram.contains("erDiagram"), "Diagram should start with erDiagram");
     assertTrue(diagram.contains("root"), "Diagram should contain root assembly");
+    assertTrue(diagram.contains("child-item"), "Diagram should contain child-item assembly");
+    assertTrue(diagram.contains("title"), "Diagram should contain title field");
+    assertTrue(diagram.contains("description"), "Diagram should contain description field");
   }
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/util/MermaidErDiagramGeneratorTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/util/MermaidErDiagramGeneratorTest.java
@@ -10,8 +10,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import gov.nist.secauto.metaschema.core.model.IModule;
 import gov.nist.secauto.metaschema.core.model.ISource;
 import gov.nist.secauto.metaschema.core.model.util.MermaidErDiagramGenerator;
-import gov.nist.secauto.metaschema.core.testing.model.IModuleBuilder;
-import gov.nist.secauto.metaschema.core.testing.model.MockedModelTestSupport;
+import gov.nist.secauto.metaschema.core.testsupport.builder.IModuleBuilder;
+import gov.nist.secauto.metaschema.core.testsupport.MockedModelTestSupport;
 
 import org.junit.jupiter.api.Test;
 

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/util/MermaidErDiagramGeneratorTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/util/MermaidErDiagramGeneratorTest.java
@@ -5,29 +5,61 @@
 
 package gov.nist.secauto.metaschema.core.util;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import gov.nist.secauto.metaschema.core.model.IModule;
-import gov.nist.secauto.metaschema.core.model.MetaschemaException;
+import gov.nist.secauto.metaschema.core.model.ISource;
 import gov.nist.secauto.metaschema.core.model.util.MermaidErDiagramGenerator;
-import gov.nist.secauto.metaschema.core.model.xml.ModuleLoader;
+import gov.nist.secauto.metaschema.core.testing.model.IModuleBuilder;
+import gov.nist.secauto.metaschema.core.testing.model.MockedModelTestSupport;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.URI;
-import java.net.URISyntaxException;
+import java.util.List;
 
 class MermaidErDiagramGeneratorTest {
 
-  @Test
-  void testErDiagram() throws IOException, MetaschemaException, URISyntaxException {
-    // IModule module = new ModuleLoader()
-    // .load(Paths.get("metaschema/schema/metaschema/metaschema-module-metaschema.xml"));
-    IModule module = new ModuleLoader()
-        .load(new URI("https://github.com/usnistgov/OSCAL/raw/main/src/metaschema/oscal_complete_metaschema.xml"));
+  private static final String TEST_NAMESPACE = "http://example.com/ns/diagram-test";
 
-    try (PrintWriter writer = new PrintWriter(System.out)) {
+  @Test
+  void testErDiagram() {
+    // Build a module with a root assembly containing fields and nested assemblies
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create(TEST_NAMESPACE));
+
+    IModule module = IModuleBuilder.builder()
+        .namespace(TEST_NAMESPACE)
+        .shortName("diagram-test")
+        .version("1.0.0")
+        .source(source)
+        .field(mocking.field().name("title"))
+        .field(mocking.field().name("description"))
+        .assembly(mocking.assembly()
+            .name("child-item")
+            .flags(List.of(mocking.flag().name("id"))))
+        .assembly(mocking.assembly()
+            .name("root")
+            .rootName("root")
+            .flags(List.of(mocking.flag().name("id")))
+            .modelInstances(List.of(
+                mocking.fieldRef("title"),
+                mocking.fieldRef("description"),
+                mocking.assemblyRef("child-item"))))
+        .toModule();
+
+    // Generate the diagram to a string
+    StringWriter stringWriter = new StringWriter();
+    try (PrintWriter writer = new PrintWriter(stringWriter)) {
       MermaidErDiagramGenerator.generate(module, writer);
     }
+
+    String diagram = stringWriter.toString();
+
+    // Verify the diagram contains expected elements
+    assertTrue(diagram.contains("erDiagram"), "Diagram should start with erDiagram");
+    assertTrue(diagram.contains("root"), "Diagram should contain root assembly");
   }
 }


### PR DESCRIPTION
## Summary

- Migrate `ExternalConstraintsModulePostProcessorTest` to use `IModuleBuilder` for programmatic module construction
- Migrate `RecursionCollectingNodeItemVisitorTest` and `AbstractRecursionPreventingNodeItemVisitorTest` to use `IModuleBuilder`
- Migrate `MermaidErDiagramGeneratorTest` to use `IModuleBuilder`

This PR continues the work from #530 by migrating test classes to use the new module builder infrastructure, reducing dependencies on `ModuleLoader` and XMLBeans for loading test modules.

## Test plan

- [x] `mvn -pl core test -Dtest=ExternalConstraintsModulePostProcessorTest` passes
- [x] `mvn -pl core test -Dtest=RecursionCollectingNodeItemVisitorTest` passes  
- [x] `mvn -pl core test -Dtest=AbstractRecursionPreventingNodeItemVisitorTest` passes
- [x] `mvn -pl core test -Dtest=MermaidErDiagramGeneratorTest` passes
- [x] `mvn -pl core test` passes (full core module test suite)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Many tests now construct models/modules in-memory instead of loading files, simplifying setup and improving test isolation and speed.
  * Simplified assertions and removed unnecessary exception declarations from test signatures.
  * Consolidated and updated test-support utilities and import paths under a unified test-support namespace.

* **Refactor**
  * Shortened and self-contained test flows for easier maintenance and clearer intent.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->