### PR TITLE
Add IConstraintSetBuilder for programmatic constraint set construction

### DIFF
--- a/core/src/test/java/gov/nist/secauto/metaschema/core/model/constraint/ExternalConstraintsModulePostProcessorTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/model/constraint/ExternalConstraintsModulePostProcessorTest.java
@@ -7,21 +7,20 @@ package gov.nist.secauto.metaschema.core.model.constraint;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import gov.nist.secauto.metaschema.core.datatype.markup.MarkupLine;
+import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
 import gov.nist.secauto.metaschema.core.model.IAssemblyDefinition;
 import gov.nist.secauto.metaschema.core.model.IModule;
 import gov.nist.secauto.metaschema.core.model.ISource;
-import gov.nist.secauto.metaschema.core.model.MetaschemaException;
-import gov.nist.secauto.metaschema.core.model.xml.XmlMetaConstraintLoader;
 import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
-import gov.nist.secauto.metaschema.core.testsupport.builder.IModuleBuilder;
 import gov.nist.secauto.metaschema.core.testsupport.MockedModelTestSupport;
+import gov.nist.secauto.metaschema.core.testsupport.builder.IModuleBuilder;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.net.URI;
-import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.List;
 
 class ExternalConstraintsModulePostProcessorTest {
@@ -29,21 +28,38 @@ class ExternalConstraintsModulePostProcessorTest {
   private static final String TEST_NAMESPACE = "http://csrc.nist.gov/ns/test/metaschema/constraint-targeting-test";
 
   @Test
-  void test() throws MetaschemaException, IOException {
-    // Load external constraints from XML
-    List<IConstraintSet> constraints
-        = new XmlMetaConstraintLoader().load(ObjectUtils.notNull(
-            Paths.get("src/test/resources/content/issue184-constraints.xml")));
-
-    // Build module programmatically instead of loading from XML
+  void test() {
+    // Build constraints programmatically instead of loading from XML
+    // Original XML:
+    // <context>
+    // <metapath target="//*"/>
+    // <constraints>
+    // <allowed-values target="@value">
+    // <enum value="value1">Value #1</enum>
+    // </allowed-values>
+    // </constraints>
+    // </context>
     MockedModelTestSupport mocking = new MockedModelTestSupport();
-    ISource source = ISource.externalSource(URI.create(TEST_NAMESPACE));
+    ISource constraintSource = ISource.externalSource(URI.create(TEST_NAMESPACE + "/constraints"));
+
+    IConstraintSet constraintSet = mocking.constraintSet()
+        .source(constraintSource)
+        .context(ctx -> ctx
+            .metapath("//*")
+            .constraint(IAllowedValuesConstraint.builder()
+                .source(constraintSource)
+                .target(IMetapathExpression.compile("@value"))
+                .allowedValue(IAllowedValue.of("value1", MarkupLine.fromMarkdown("Value #1"), null))))
+        .build();
+
+    // Build module programmatically
+    ISource moduleSource = ISource.externalSource(URI.create(TEST_NAMESPACE));
 
     IModule module = IModuleBuilder.builder()
         .namespace(TEST_NAMESPACE)
         .shortName("constraint-targeting-test")
         .version("1.0.0")
-        .source(source)
+        .source(moduleSource)
         .assembly(mocking.assembly()
             .name("a")
             .rootName("a")
@@ -54,7 +70,7 @@ class ExternalConstraintsModulePostProcessorTest {
 
     // Apply external constraints to the module
     ExternalConstraintsModulePostProcessor postProcessor
-        = new ExternalConstraintsModulePostProcessor(constraints);
+        = new ExternalConstraintsModulePostProcessor(Collections.singletonList(constraintSet));
     postProcessor.processModule(module);
 
     // Verify constraint was applied

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/ConstraintSetBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/ConstraintSetBuilder.java
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.testsupport.builder;
+
+import gov.nist.secauto.metaschema.core.model.ISource;
+import gov.nist.secauto.metaschema.core.model.constraint.IConstraintSet;
+import gov.nist.secauto.metaschema.core.model.constraint.MetaConstraintSet;
+import gov.nist.secauto.metaschema.core.util.ObjectUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Implementation of {@link IConstraintSetBuilder} for creating constraint sets
+ * programmatically.
+ */
+public class ConstraintSetBuilder implements IConstraintSetBuilder {
+  private ISource source;
+  @NonNull
+  private final List<IConstraintSet> imports = new ArrayList<>();
+  @NonNull
+  private final List<ContextBuilder> contexts = new ArrayList<>();
+
+  /**
+   * Construct a new builder.
+   */
+  public ConstraintSetBuilder() {
+    // default constructor
+  }
+
+  @Override
+  @NonNull
+  public IConstraintSetBuilder source(@NonNull ISource source) {
+    this.source = source;
+    return this;
+  }
+
+  @Override
+  @NonNull
+  public IConstraintSetBuilder imports(@NonNull IConstraintSet... imports) {
+    this.imports.addAll(Arrays.asList(imports));
+    return this;
+  }
+
+  @Override
+  @NonNull
+  public IConstraintSetBuilder context(@NonNull Consumer<IContextBuilder> contextConfigurer) {
+    ContextBuilder contextBuilder = new ContextBuilder(ObjectUtils.requireNonNull(source));
+    contextConfigurer.accept(contextBuilder);
+    this.contexts.add(contextBuilder);
+    return this;
+  }
+
+  @Override
+  @NonNull
+  public IConstraintSet build() {
+    ISource constraintSource = ObjectUtils.requireNonNull(source, "source must be set");
+
+    // Build contexts
+    List<MetaConstraintSet.Context> builtContexts = new ArrayList<>();
+    for (ContextBuilder contextBuilder : contexts) {
+      builtContexts.add(contextBuilder.build(null));
+    }
+
+    return new MetaConstraintSet(constraintSource, imports, builtContexts);
+  }
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/ConstraintSetBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/ConstraintSetBuilder.java
@@ -52,7 +52,8 @@ public class ConstraintSetBuilder implements IConstraintSetBuilder {
   @Override
   @NonNull
   public IConstraintSetBuilder context(@NonNull Consumer<IContextBuilder> contextConfigurer) {
-    ContextBuilder contextBuilder = new ContextBuilder(ObjectUtils.requireNonNull(source));
+    ContextBuilder contextBuilder = new ContextBuilder(
+        ObjectUtils.requireNonNull(source, "source must be set before adding contexts"));
     contextConfigurer.accept(contextBuilder);
     this.contexts.add(contextBuilder);
     return this;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/ContextBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/ContextBuilder.java
@@ -1,0 +1,123 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.testsupport.builder;
+
+import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
+import gov.nist.secauto.metaschema.core.model.ISource;
+import gov.nist.secauto.metaschema.core.model.constraint.AbstractConstraintBuilder;
+import gov.nist.secauto.metaschema.core.model.constraint.AssemblyConstraintSet;
+import gov.nist.secauto.metaschema.core.model.constraint.IAllowedValuesConstraint;
+import gov.nist.secauto.metaschema.core.model.constraint.IConstraint;
+import gov.nist.secauto.metaschema.core.model.constraint.IExpectConstraint;
+import gov.nist.secauto.metaschema.core.model.constraint.IIndexHasKeyConstraint;
+import gov.nist.secauto.metaschema.core.model.constraint.IMatchesConstraint;
+import gov.nist.secauto.metaschema.core.model.constraint.IModelConstrained;
+import gov.nist.secauto.metaschema.core.model.constraint.MetaConstraintSet;
+import gov.nist.secauto.metaschema.core.util.ObjectUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Implementation of {@link IContextBuilder} for creating constraint contexts.
+ */
+public class ContextBuilder implements IContextBuilder {
+  @NonNull
+  private final ISource source;
+  @NonNull
+  private final List<IMetapathExpression> metapaths = new ArrayList<>();
+  @NonNull
+  private final List<IConstraint> constraints = new ArrayList<>();
+  @NonNull
+  private final List<ContextBuilder> childContexts = new ArrayList<>();
+
+  /**
+   * Construct a new context builder.
+   *
+   * @param source
+   *          the source for constraints in this context
+   */
+  public ContextBuilder(@NonNull ISource source) {
+    this.source = source;
+  }
+
+  @Override
+  @NonNull
+  public IContextBuilder metapath(@NonNull String target) {
+    this.metapaths.add(IMetapathExpression.lazyCompile(target, source.getStaticContext()));
+    return this;
+  }
+
+  @Override
+  @NonNull
+  public <B extends AbstractConstraintBuilder<B, C>, C extends IConstraint> IContextBuilder constraint(
+      @NonNull AbstractConstraintBuilder<B, C> constraintBuilder) {
+    this.constraints.add(constraintBuilder.build());
+    return this;
+  }
+
+  @Override
+  @NonNull
+  public IContextBuilder childContext(@NonNull Consumer<IContextBuilder> childConfigurer) {
+    ContextBuilder childBuilder = new ContextBuilder(source);
+    childConfigurer.accept(childBuilder);
+    this.childContexts.add(childBuilder);
+    return this;
+  }
+
+  /**
+   * Build the context.
+   *
+   * @param parent
+   *          the parent context, or null if this is a top-level context
+   * @return the built context
+   */
+  @NonNull
+  MetaConstraintSet.Context build(@Nullable MetaConstraintSet.Context parent) {
+    // Create the constraint set for this context
+    IModelConstrained modelConstrained = new AssemblyConstraintSet(source);
+
+    // Add constraints to the model
+    for (IConstraint constraint : constraints) {
+      addConstraint(modelConstrained, constraint);
+    }
+
+    // Create the context
+    MetaConstraintSet.Context context = new MetaConstraintSet.Context(
+        parent,
+        source,
+        ObjectUtils.notNull(metapaths),
+        modelConstrained);
+
+    // Build and add child contexts
+    List<MetaConstraintSet.Context> builtChildren = new ArrayList<>();
+    for (ContextBuilder childBuilder : childContexts) {
+      builtChildren.add(childBuilder.build(context));
+    }
+    context.addAll(builtChildren);
+
+    return context;
+  }
+
+  private static void addConstraint(@NonNull IModelConstrained modelConstrained, @NonNull IConstraint constraint) {
+    if (constraint instanceof IAllowedValuesConstraint) {
+      modelConstrained.addConstraint((IAllowedValuesConstraint) constraint);
+    } else if (constraint instanceof IMatchesConstraint) {
+      modelConstrained.addConstraint((IMatchesConstraint) constraint);
+    } else if (constraint instanceof IExpectConstraint) {
+      modelConstrained.addConstraint((IExpectConstraint) constraint);
+    } else if (constraint instanceof IIndexHasKeyConstraint) {
+      modelConstrained.addConstraint((IIndexHasKeyConstraint) constraint);
+    } else {
+      throw new UnsupportedOperationException(
+          "Unsupported constraint type: " + constraint.getClass().getName());
+    }
+  }
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/ContextBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/ContextBuilder.java
@@ -19,7 +19,6 @@ import gov.nist.secauto.metaschema.core.model.constraint.IMatchesConstraint;
 import gov.nist.secauto.metaschema.core.model.constraint.IModelConstrained;
 import gov.nist.secauto.metaschema.core.model.constraint.IUniqueConstraint;
 import gov.nist.secauto.metaschema.core.model.constraint.MetaConstraintSet;
-import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -104,11 +103,11 @@ public class ContextBuilder implements IContextBuilder {
       addConstraint(modelConstrained, constraint);
     }
 
-    // Create the context
+    // Create the context with a defensive copy of metapaths
     MetaConstraintSet.Context context = new MetaConstraintSet.Context(
         parent,
         source,
-        ObjectUtils.notNull(metapaths),
+        List.copyOf(metapaths),
         modelConstrained);
 
     // Build and add child contexts
@@ -126,6 +125,10 @@ public class ContextBuilder implements IContextBuilder {
    * <p>
    * This method dispatches the constraint to the appropriate typed add method
    * based on the constraint's runtime type.
+   * <p>
+   * <b>Note:</b> When new constraint types are added to the Metaschema constraint
+   * model, this method and the class-level Javadoc must be updated to include
+   * support for the new type.
    *
    * @param modelConstrained
    *          the model constrained object to add the constraint to

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/ContextBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/ContextBuilder.java
@@ -10,11 +10,14 @@ import gov.nist.secauto.metaschema.core.model.ISource;
 import gov.nist.secauto.metaschema.core.model.constraint.AbstractConstraintBuilder;
 import gov.nist.secauto.metaschema.core.model.constraint.AssemblyConstraintSet;
 import gov.nist.secauto.metaschema.core.model.constraint.IAllowedValuesConstraint;
+import gov.nist.secauto.metaschema.core.model.constraint.ICardinalityConstraint;
 import gov.nist.secauto.metaschema.core.model.constraint.IConstraint;
 import gov.nist.secauto.metaschema.core.model.constraint.IExpectConstraint;
+import gov.nist.secauto.metaschema.core.model.constraint.IIndexConstraint;
 import gov.nist.secauto.metaschema.core.model.constraint.IIndexHasKeyConstraint;
 import gov.nist.secauto.metaschema.core.model.constraint.IMatchesConstraint;
 import gov.nist.secauto.metaschema.core.model.constraint.IModelConstrained;
+import gov.nist.secauto.metaschema.core.model.constraint.IUniqueConstraint;
 import gov.nist.secauto.metaschema.core.model.constraint.MetaConstraintSet;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
@@ -28,17 +31,17 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 /**
  * Implementation of {@link IContextBuilder} for creating constraint contexts.
  * <p>
- * This builder supports the following constraint types:
+ * This builder supports all constraint types defined in the Metaschema
+ * constraint model:
  * <ul>
  * <li>{@link IAllowedValuesConstraint}</li>
  * <li>{@link IMatchesConstraint}</li>
  * <li>{@link IExpectConstraint}</li>
  * <li>{@link IIndexHasKeyConstraint}</li>
+ * <li>{@link ICardinalityConstraint}</li>
+ * <li>{@link IIndexConstraint}</li>
+ * <li>{@link IUniqueConstraint}</li>
  * </ul>
- * Other constraint types (such as {@code ICardinalityConstraint},
- * {@code IIndexConstraint}, or {@code IUniqueConstraint}) will throw an
- * {@link UnsupportedOperationException} when added. To support additional
- * constraint types, extend the {@link #addConstraint} method.
  */
 public class ContextBuilder implements IContextBuilder {
   @NonNull
@@ -131,6 +134,7 @@ public class ContextBuilder implements IContextBuilder {
    * @throws UnsupportedOperationException
    *           if the constraint type is not supported
    */
+  @SuppressWarnings("PMD.CyclomaticComplexity")
   private static void addConstraint(@NonNull IModelConstrained modelConstrained, @NonNull IConstraint constraint) {
     if (constraint instanceof IAllowedValuesConstraint) {
       modelConstrained.addConstraint((IAllowedValuesConstraint) constraint);
@@ -140,6 +144,12 @@ public class ContextBuilder implements IContextBuilder {
       modelConstrained.addConstraint((IExpectConstraint) constraint);
     } else if (constraint instanceof IIndexHasKeyConstraint) {
       modelConstrained.addConstraint((IIndexHasKeyConstraint) constraint);
+    } else if (constraint instanceof ICardinalityConstraint) {
+      modelConstrained.addConstraint((ICardinalityConstraint) constraint);
+    } else if (constraint instanceof IIndexConstraint) {
+      modelConstrained.addConstraint((IIndexConstraint) constraint);
+    } else if (constraint instanceof IUniqueConstraint) {
+      modelConstrained.addConstraint((IUniqueConstraint) constraint);
     } else {
       throw new UnsupportedOperationException(
           "Unsupported constraint type: " + constraint.getClass().getName());

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/ContextBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/ContextBuilder.java
@@ -27,6 +27,18 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * Implementation of {@link IContextBuilder} for creating constraint contexts.
+ * <p>
+ * This builder supports the following constraint types:
+ * <ul>
+ * <li>{@link IAllowedValuesConstraint}</li>
+ * <li>{@link IMatchesConstraint}</li>
+ * <li>{@link IExpectConstraint}</li>
+ * <li>{@link IIndexHasKeyConstraint}</li>
+ * </ul>
+ * Other constraint types (such as {@code ICardinalityConstraint},
+ * {@code IIndexConstraint}, or {@code IUniqueConstraint}) will throw an
+ * {@link UnsupportedOperationException} when added. To support additional
+ * constraint types, extend the {@link #addConstraint} method.
  */
 public class ContextBuilder implements IContextBuilder {
   @NonNull

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/ContextBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/ContextBuilder.java
@@ -106,6 +106,19 @@ public class ContextBuilder implements IContextBuilder {
     return context;
   }
 
+  /**
+   * Add a constraint to the model constrained object.
+   * <p>
+   * This method dispatches the constraint to the appropriate typed add method
+   * based on the constraint's runtime type.
+   *
+   * @param modelConstrained
+   *          the model constrained object to add the constraint to
+   * @param constraint
+   *          the constraint to add
+   * @throws UnsupportedOperationException
+   *           if the constraint type is not supported
+   */
   private static void addConstraint(@NonNull IModelConstrained modelConstrained, @NonNull IConstraint constraint) {
     if (constraint instanceof IAllowedValuesConstraint) {
       modelConstrained.addConstraint((IAllowedValuesConstraint) constraint);

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/ContextBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/ContextBuilder.java
@@ -71,8 +71,8 @@ public class ContextBuilder implements IContextBuilder {
 
   @Override
   @NonNull
-  public <B extends AbstractConstraintBuilder<B, C>, C extends IConstraint> IContextBuilder constraint(
-      @NonNull AbstractConstraintBuilder<B, C> constraintBuilder) {
+  public IContextBuilder constraint(
+      @NonNull AbstractConstraintBuilder<?, ? extends IConstraint> constraintBuilder) {
     this.constraints.add(constraintBuilder.build());
     return this;
   }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/IConstraintSetBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/IConstraintSetBuilder.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.testsupport.builder;
+
+import gov.nist.secauto.metaschema.core.model.ISource;
+import gov.nist.secauto.metaschema.core.model.constraint.IConstraintSet;
+
+import java.util.function.Consumer;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * A builder for creating {@link IConstraintSet} instances programmatically.
+ * <p>
+ * This builder is intended for test support, allowing constraint sets to be
+ * constructed without loading XML files.
+ */
+public interface IConstraintSetBuilder {
+
+  /**
+   * Set the source for the constraint set.
+   *
+   * @param source
+   *          the source information
+   * @return this builder
+   */
+  @NonNull
+  IConstraintSetBuilder source(@NonNull ISource source);
+
+  /**
+   * Add an imported constraint set.
+   *
+   * @param imports
+   *          the constraint sets to import
+   * @return this builder
+   */
+  @NonNull
+  IConstraintSetBuilder imports(@NonNull IConstraintSet... imports);
+
+  /**
+   * Add a context to the constraint set.
+   *
+   * @param contextConfigurer
+   *          a consumer that configures the context
+   * @return this builder
+   */
+  @NonNull
+  IConstraintSetBuilder context(@NonNull Consumer<IContextBuilder> contextConfigurer);
+
+  /**
+   * Build the constraint set.
+   *
+   * @return the constructed constraint set
+   */
+  @NonNull
+  IConstraintSet build();
+
+  /**
+   * Create a new constraint set builder.
+   *
+   * @return the builder
+   */
+  @NonNull
+  static IConstraintSetBuilder builder() {
+    return new ConstraintSetBuilder();
+  }
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/IContextBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/IContextBuilder.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.testsupport.builder;
+
+import gov.nist.secauto.metaschema.core.model.constraint.AbstractConstraintBuilder;
+import gov.nist.secauto.metaschema.core.model.constraint.IConstraint;
+
+import java.util.function.Consumer;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * A builder for creating constraint contexts within a constraint set.
+ * <p>
+ * A context defines a metapath expression that targets specific elements, and
+ * the constraints that apply to those targets.
+ */
+public interface IContextBuilder {
+
+  /**
+   * Set the metapath expression that defines what this context targets.
+   *
+   * @param target
+   *          the metapath expression
+   * @return this builder
+   */
+  @NonNull
+  IContextBuilder metapath(@NonNull String target);
+
+  /**
+   * Add a constraint to this context using a constraint builder.
+   * <p>
+   * The builder's {@code build()} method will be called to create the constraint.
+   *
+   * @param <B>
+   *          the constraint builder type
+   * @param <C>
+   *          the constraint type
+   * @param constraintBuilder
+   *          the constraint builder
+   * @return this builder
+   */
+  @NonNull
+  <B extends AbstractConstraintBuilder<B, C>, C extends IConstraint> IContextBuilder constraint(
+      @NonNull AbstractConstraintBuilder<B, C> constraintBuilder);
+
+  /**
+   * Add a child context nested within this context.
+   *
+   * @param childConfigurer
+   *          a consumer that configures the child context
+   * @return this builder
+   */
+  @NonNull
+  IContextBuilder childContext(@NonNull Consumer<IContextBuilder> childConfigurer);
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/IContextBuilder.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/IContextBuilder.java
@@ -35,17 +35,13 @@ public interface IContextBuilder {
    * <p>
    * The builder's {@code build()} method will be called to create the constraint.
    *
-   * @param <B>
-   *          the constraint builder type
-   * @param <C>
-   *          the constraint type
    * @param constraintBuilder
    *          the constraint builder
    * @return this builder
    */
   @NonNull
-  <B extends AbstractConstraintBuilder<B, C>, C extends IConstraint> IContextBuilder constraint(
-      @NonNull AbstractConstraintBuilder<B, C> constraintBuilder);
+  IContextBuilder constraint(
+      @NonNull AbstractConstraintBuilder<?, ? extends IConstraint> constraintBuilder);
 
   /**
    * Add a child context nested within this context.

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/IModuleMockFactory.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/builder/IModuleMockFactory.java
@@ -79,4 +79,14 @@ public interface IModuleMockFactory extends IMockFactory {
   default IModelBuilder<?> fieldRef(@NonNull String name) {
     return new FieldReference(name);
   }
+
+  /**
+   * Get a new constraint set builder.
+   *
+   * @return the builder
+   */
+  @NonNull
+  default IConstraintSetBuilder constraintSet() {
+    return IConstraintSetBuilder.builder();
+  }
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/tests/ConstraintSetBuilderTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/tests/ConstraintSetBuilderTest.java
@@ -15,8 +15,14 @@ import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
 import gov.nist.secauto.metaschema.core.model.ISource;
 import gov.nist.secauto.metaschema.core.model.constraint.IAllowedValue;
 import gov.nist.secauto.metaschema.core.model.constraint.IAllowedValuesConstraint;
+import gov.nist.secauto.metaschema.core.model.constraint.ICardinalityConstraint;
 import gov.nist.secauto.metaschema.core.model.constraint.IConstraintSet;
+import gov.nist.secauto.metaschema.core.model.constraint.IExpectConstraint;
+import gov.nist.secauto.metaschema.core.model.constraint.IIndexConstraint;
+import gov.nist.secauto.metaschema.core.model.constraint.IIndexHasKeyConstraint;
+import gov.nist.secauto.metaschema.core.model.constraint.IKeyField;
 import gov.nist.secauto.metaschema.core.model.constraint.IMatchesConstraint;
+import gov.nist.secauto.metaschema.core.model.constraint.IUniqueConstraint;
 import gov.nist.secauto.metaschema.core.testsupport.MockedModelTestSupport;
 import gov.nist.secauto.metaschema.core.testsupport.builder.IConstraintSetBuilder;
 
@@ -182,6 +188,117 @@ class ConstraintSetBuilderTest {
                 .source(source)
                 .target(IMetapathExpression.compile("@attr2"))
                 .datatype(MetaschemaDataTypeProvider.STRING)))
+        .build();
+
+    // Then
+    assertNotNull(constraintSet, "Constraint set should not be null");
+    assertEquals(source, constraintSet.getSource(), "Source should match");
+  }
+
+  @Test
+  void testConstraintSetWithExpectConstraint() {
+    // Given
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create(TEST_NAMESPACE));
+
+    // When
+    IConstraintSet constraintSet = mocking.constraintSet()
+        .source(source)
+        .context(ctx -> ctx
+            .metapath("//item")
+            .constraint(IExpectConstraint.builder()
+                .source(source)
+                .target(IMetapathExpression.compile("."))
+                .test(IMetapathExpression.compile("@id != ''"))))
+        .build();
+
+    // Then
+    assertNotNull(constraintSet, "Constraint set should not be null");
+    assertEquals(source, constraintSet.getSource(), "Source should match");
+  }
+
+  @Test
+  void testConstraintSetWithCardinalityConstraint() {
+    // Given
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create(TEST_NAMESPACE));
+
+    // When
+    IConstraintSet constraintSet = mocking.constraintSet()
+        .source(source)
+        .context(ctx -> ctx
+            .metapath("//parent")
+            .constraint(ICardinalityConstraint.builder()
+                .source(source)
+                .target(IMetapathExpression.compile("child"))
+                .minOccurs(1)
+                .maxOccurs(5)))
+        .build();
+
+    // Then
+    assertNotNull(constraintSet, "Constraint set should not be null");
+    assertEquals(source, constraintSet.getSource(), "Source should match");
+  }
+
+  @Test
+  void testConstraintSetWithIndexConstraint() {
+    // Given
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create(TEST_NAMESPACE));
+
+    // When
+    IConstraintSet constraintSet = mocking.constraintSet()
+        .source(source)
+        .context(ctx -> ctx
+            .metapath("//items")
+            .constraint(IIndexConstraint.builder("item-index")
+                .source(source)
+                .target(IMetapathExpression.compile("item"))
+                .keyField(IKeyField.of(IMetapathExpression.compile("@id"), null, null))))
+        .build();
+
+    // Then
+    assertNotNull(constraintSet, "Constraint set should not be null");
+    assertEquals(source, constraintSet.getSource(), "Source should match");
+  }
+
+  @Test
+  void testConstraintSetWithIndexHasKeyConstraint() {
+    // Given
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create(TEST_NAMESPACE));
+
+    // When
+    IConstraintSet constraintSet = mocking.constraintSet()
+        .source(source)
+        .context(ctx -> ctx
+            .metapath("//reference")
+            .constraint(IIndexHasKeyConstraint.builder("item-index")
+                .source(source)
+                .target(IMetapathExpression.compile("."))
+                .keyField(IKeyField.of(IMetapathExpression.compile("@item-ref"), null, null))))
+        .build();
+
+    // Then
+    assertNotNull(constraintSet, "Constraint set should not be null");
+    assertEquals(source, constraintSet.getSource(), "Source should match");
+  }
+
+  @Test
+  void testConstraintSetWithUniqueConstraint() {
+    // Given
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create(TEST_NAMESPACE));
+
+    // When
+    IConstraintSet constraintSet = mocking.constraintSet()
+        .source(source)
+        .context(ctx -> ctx
+            .metapath("//collection")
+            .constraint(IUniqueConstraint.builder()
+                .source(source)
+                .target(IMetapathExpression.compile("entry"))
+                .keyField(IKeyField.of(IMetapathExpression.compile("@key"), null, null))))
         .build();
 
     // Then

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/tests/ConstraintSetBuilderTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/tests/ConstraintSetBuilderTest.java
@@ -75,6 +75,10 @@ class ConstraintSetBuilderTest {
 
     // Then
     assertNotNull(constraintSet, "Constraint set should not be null");
+    assertEquals(source, constraintSet.getSource(), "Source should match");
+    // Note: Verifying the constraint was actually added requires applying the
+    // constraint set to a module, which is tested in
+    // ExternalConstraintsModulePostProcessorTest
   }
 
   @Test
@@ -102,6 +106,7 @@ class ConstraintSetBuilderTest {
 
     // Then
     assertNotNull(constraintSet, "Constraint set should not be null");
+    assertEquals(source, constraintSet.getSource(), "Source should match");
   }
 
   @Test
@@ -129,6 +134,7 @@ class ConstraintSetBuilderTest {
 
     // Then
     assertNotNull(constraintSet, "Constraint set should not be null");
+    assertEquals(source, constraintSet.getSource(), "Source should match");
   }
 
   @Test
@@ -180,5 +186,6 @@ class ConstraintSetBuilderTest {
 
     // Then
     assertNotNull(constraintSet, "Constraint set should not be null");
+    assertEquals(source, constraintSet.getSource(), "Source should match");
   }
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/tests/ConstraintSetBuilderTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/testsupport/tests/ConstraintSetBuilderTest.java
@@ -1,0 +1,184 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.testsupport.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import gov.nist.secauto.metaschema.core.datatype.adapter.MetaschemaDataTypeProvider;
+import gov.nist.secauto.metaschema.core.datatype.markup.MarkupLine;
+import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
+import gov.nist.secauto.metaschema.core.model.ISource;
+import gov.nist.secauto.metaschema.core.model.constraint.IAllowedValue;
+import gov.nist.secauto.metaschema.core.model.constraint.IAllowedValuesConstraint;
+import gov.nist.secauto.metaschema.core.model.constraint.IConstraintSet;
+import gov.nist.secauto.metaschema.core.model.constraint.IMatchesConstraint;
+import gov.nist.secauto.metaschema.core.testsupport.MockedModelTestSupport;
+import gov.nist.secauto.metaschema.core.testsupport.builder.IConstraintSetBuilder;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+/**
+ * Unit tests for {@link IConstraintSetBuilder}.
+ */
+class ConstraintSetBuilderTest {
+
+  private static final String TEST_NAMESPACE = "http://example.com/ns/constraint-test";
+
+  @Test
+  void testBasicConstraintSetCreation() {
+    // Given
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create(TEST_NAMESPACE));
+
+    // When
+    IConstraintSet constraintSet = mocking.constraintSet()
+        .source(source)
+        .build();
+
+    // Then
+    assertNotNull(constraintSet, "Constraint set should not be null");
+    assertEquals(source, constraintSet.getSource(), "Source should match");
+    assertTrue(constraintSet.getImportedConstraintSets().isEmpty(), "Should have no imports");
+  }
+
+  @Test
+  void testConstraintSetWithAllowedValuesContext() {
+    // Given - simulating issue184-constraints.xml:
+    // <context>
+    // <metapath target="//*"/>
+    // <constraints>
+    // <allowed-values target="@value">
+    // <enum value="value1">Value #1</enum>
+    // </allowed-values>
+    // </constraints>
+    // </context>
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create(TEST_NAMESPACE));
+
+    // When
+    IConstraintSet constraintSet = mocking.constraintSet()
+        .source(source)
+        .context(ctx -> ctx
+            .metapath("//*")
+            .constraint(IAllowedValuesConstraint.builder()
+                .source(source)
+                .target(IMetapathExpression.compile("@value"))
+                .allowedValue(IAllowedValue.of("value1", MarkupLine.fromMarkdown("Value #1"), null))))
+        .build();
+
+    // Then
+    assertNotNull(constraintSet, "Constraint set should not be null");
+  }
+
+  @Test
+  void testConstraintSetWithMatchesContext() {
+    // Given - simulating computer-metaschema-meta-constraints.xml:
+    // <context>
+    // <metapath target="/(computer|vendor)/@id"/>
+    // <constraints>
+    // <matches target="." datatype="uuid"/>
+    // </constraints>
+    // </context>
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create(TEST_NAMESPACE));
+
+    // When
+    IConstraintSet constraintSet = mocking.constraintSet()
+        .source(source)
+        .context(ctx -> ctx
+            .metapath("/(computer|vendor)/@id")
+            .constraint(IMatchesConstraint.builder()
+                .source(source)
+                .target(IMetapathExpression.compile("."))
+                .datatype(MetaschemaDataTypeProvider.UUID)))
+        .build();
+
+    // Then
+    assertNotNull(constraintSet, "Constraint set should not be null");
+  }
+
+  @Test
+  void testConstraintSetWithNestedContexts() {
+    // Given - test nested context hierarchy
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create(TEST_NAMESPACE));
+
+    // When
+    IConstraintSet constraintSet = mocking.constraintSet()
+        .source(source)
+        .context(ctx -> ctx
+            .metapath("//parent")
+            .constraint(IAllowedValuesConstraint.builder()
+                .source(source)
+                .target(IMetapathExpression.compile("@type"))
+                .allowedValue(IAllowedValue.of("typeA", MarkupLine.fromMarkdown("Type A"), null)))
+            .childContext(child -> child
+                .metapath("child")
+                .constraint(IAllowedValuesConstraint.builder()
+                    .source(source)
+                    .target(IMetapathExpression.compile("@name"))
+                    .allowedValue(IAllowedValue.of("nameX", MarkupLine.fromMarkdown("Name X"), null)))))
+        .build();
+
+    // Then
+    assertNotNull(constraintSet, "Constraint set should not be null");
+  }
+
+  @Test
+  void testConstraintSetWithImports() {
+    // Given
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source1 = ISource.externalSource(URI.create(TEST_NAMESPACE + "/imported"));
+    ISource source2 = ISource.externalSource(URI.create(TEST_NAMESPACE + "/main"));
+
+    // Create an imported constraint set
+    IConstraintSet importedSet = mocking.constraintSet()
+        .source(source1)
+        .build();
+
+    // When - create main constraint set that imports the first
+    IConstraintSet mainSet = mocking.constraintSet()
+        .source(source2)
+        .imports(importedSet)
+        .build();
+
+    // Then
+    assertNotNull(mainSet, "Main constraint set should not be null");
+    assertEquals(1, mainSet.getImportedConstraintSets().size(), "Should have one import");
+    assertTrue(mainSet.getImportedConstraintSets().contains(importedSet), "Should contain imported set");
+  }
+
+  @Test
+  void testConstraintSetWithMultipleContexts() {
+    // Given
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create(TEST_NAMESPACE));
+
+    // When
+    IConstraintSet constraintSet = mocking.constraintSet()
+        .source(source)
+        .context(ctx -> ctx
+            .metapath("//assembly1")
+            .constraint(IAllowedValuesConstraint.builder()
+                .source(source)
+                .target(IMetapathExpression.compile("@attr1"))
+                .allowedValue(IAllowedValue.of("val1", MarkupLine.fromMarkdown("Value 1"), null))))
+        .context(ctx -> ctx
+            .metapath("//assembly2")
+            .constraint(IMatchesConstraint.builder()
+                .source(source)
+                .target(IMetapathExpression.compile("@attr2"))
+                .datatype(MetaschemaDataTypeProvider.STRING)))
+        .build();
+
+    // Then
+    assertNotNull(constraintSet, "Constraint set should not be null");
+  }
+}


### PR DESCRIPTION
## Summary

- Introduces a fluent builder API for creating `IConstraintSet` instances programmatically in tests
- Eliminates the need for XMLBeans dependency when testing constraint-related functionality
- Migrates `ExternalConstraintsModulePostProcessorTest` to use the new programmatic builder

## New Classes

- `IConstraintSetBuilder`: Main builder interface for constraint sets
- `IContextBuilder`: Builder for constraint contexts with metapath targeting
- `ConstraintSetBuilder`: Implementation that builds `MetaConstraintSet`
- `ContextBuilder`: Implementation that builds `MetaConstraintSet.Context`

## Design

The builder leverages existing constraint builders (`IAllowedValuesConstraint.builder()`, `IMatchesConstraint.builder()`, etc.) via a generic `constraint()` method that accepts any `AbstractConstraintBuilder`.

Example usage:
```java
IConstraintSet constraintSet = mocking.constraintSet()
    .source(constraintSource)
    .context(ctx -> ctx
        .metapath("//*")
        .constraint(IAllowedValuesConstraint.builder()
            .source(constraintSource)
            .target(IMetapathExpression.compile("@value"))
            .allowedValue(IAllowedValue.of("value1", MarkupLine.fromMarkdown("Value #1"), null))))
    .build();
```

## Test plan

- [x] New unit tests in `ConstraintSetBuilderTest` verify builder functionality
- [x] `ExternalConstraintsModulePostProcessorTest` migrated and passing
- [x] CI build passes (`mvn install -PCI -Prelease`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Tests now construct external constraint sets programmatically (no XML loading), improving reliability and isolation.
  * Test method signatures simplified (removed checked exception declarations).
  * Added comprehensive tests covering allowed-values, matches, nested contexts, imports, multi-contexts, and other constraint scenarios.

* **New Features**
  * Added fluent builders and context builders for composing constraint sets and nested contexts to simplify test setup.
  * Test utilities expose a convenience method to obtain constraint-set builders.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->