### PR TITLE
Add comprehensive Javadoc documentation to core module

### DIFF
--- a/core/src/main/java/gov/nist/secauto/metaschema/core/configuration/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/configuration/package-info.java
@@ -4,9 +4,42 @@
  */
 
 /**
- * Provides support for generalized configuration based on a set of
- * {@link gov.nist.secauto.metaschema.core.configuration.IConfigurationFeature}
- * values.
+ * Provides a type-safe configuration framework for processors and parsers.
+ * <p>
+ * This package implements a feature-based configuration system inspired by
+ * Jackson's configuration model. Configuration options are defined as
+ * strongly-typed features that can be queried and modified through immutable or
+ * mutable configuration interfaces.
+ * <p>
+ * Key interfaces and classes:
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.configuration.IConfigurationFeature}
+ * - Defines a configuration option with a name, type, and default value</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.configuration.IConfiguration} -
+ * Immutable view of configuration state for querying feature values</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.configuration.IMutableConfiguration}
+ * - Mutable view allowing feature values to be modified</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.configuration.DefaultConfiguration}
+ * - Standard implementation of mutable configuration</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.configuration.AbstractConfigurationFeature}
+ * - Base class for implementing configuration features</li>
+ * </ul>
+ * <p>
+ * Usage example:
+ *
+ * <pre>
+ * // Define a feature
+ * IConfigurationFeature&lt;Boolean&gt; PRETTY_PRINT = ...;
+ *
+ * // Create and configure
+ * IMutableConfiguration&lt;MyFeature&gt; config = new DefaultConfiguration&lt;&gt;();
+ * config.enableFeature(PRETTY_PRINT);
+ *
+ * // Query configuration
+ * boolean enabled = config.isFeatureEnabled(PRETTY_PRINT);
+ * </pre>
+ *
+ * @see gov.nist.secauto.metaschema.core.configuration.IConfigurationFeature
  */
 
 package gov.nist.secauto.metaschema.core.configuration;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/adapter/MetaschemaDataTypeProvider.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/adapter/MetaschemaDataTypeProvider.java
@@ -160,6 +160,7 @@ public final class MetaschemaDataTypeProvider // NOPMD - Used for service initia
    * "https://pages.nist.gov/metaschema/specification/datatypes/#ncname">ncname</a>
    * data type instance.
    */
+  @SuppressWarnings("deprecation")
   @Deprecated(since = "0.7.0")
   @NonNull
   public static final NcNameAdapter NCNAME = new NcNameAdapter();

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/adapter/NcNameAdapter.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/adapter/NcNameAdapter.java
@@ -21,6 +21,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * "https://pages.nist.gov/metaschema/specification/datatypes/#ncname">ncname</a>
  * data type.
  */
+@SuppressWarnings("removal")
 @Deprecated(since = "0.7.0")
 public class NcNameAdapter
     extends AbstractStringAdapter<INcNameItem> {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/adapter/QNameAdapter.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/adapter/QNameAdapter.java
@@ -20,7 +20,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Support for the Metaschema <a href=
- * "https://pages.nist.gov/metaschema/specification/datatypes/#uri-reference">uri-reference</a>
+ * "https://pages.nist.gov/metaschema/specification/datatypes/#qname">qname</a>
  * data type.
  */
 public class QNameAdapter

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/adapter/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/adapter/package-info.java
@@ -4,13 +4,59 @@
  */
 
 /**
- * Built-in Metaschema data types.
+ * Built-in Metaschema data type adapters and implementations.
  * <p>
- * These built-in data types align with the data types defined by Metaschema.
+ * This package provides concrete implementations of
+ * {@link gov.nist.secauto.metaschema.core.datatype.IDataTypeAdapter} for all
+ * standard Metaschema data types, including primitives, temporal types, URIs,
+ * and binary data.
+ * <h2>Abstract Base Classes</h2>
  * <p>
- * This package provides abstract implementation classes for different kinds of
- * {@link gov.nist.secauto.metaschema.core.datatype.IDataTypeAdapter}, which
- * must be implemented by a new date type to be used in this API.
+ * The package includes specialized abstract adapters for common type families:
+ * <ul>
+ * <li>{@link AbstractStringAdapter} - Base for string-based types with
+ * whitespace handling (e.g., {@link StringAdapter}, {@link TokenAdapter},
+ * {@link NcNameAdapter})</li>
+ * <li>{@link AbstractIntegerAdapter} - Base for arbitrary-precision integer
+ * types (e.g., {@link IntegerAdapter}, {@link NonNegativeIntegerAdapter})</li>
+ * <li>{@link AbstractBinaryAdapter} - Base for binary data types (e.g.,
+ * {@link Base64Adapter}, {@link HexBinaryAdapter})</li>
+ * <li>{@link AbstractDurationAdapter} - Base for duration types (e.g.,
+ * {@link DayTimeAdapter}, {@link YearMonthAdapter})</li>
+ * </ul>
+ * <h2>Standard Type Adapters</h2>
+ * <p>
+ * Concrete adapters include:
+ * <ul>
+ * <li>Primitives: {@link BooleanAdapter}, {@link DecimalAdapter}</li>
+ * <li>Strings: {@link StringAdapter}, {@link TokenAdapter},
+ * {@link NcNameAdapter}, {@link QNameAdapter}</li>
+ * <li>Temporal: {@link DateAdapter}, {@link DateTimeAdapter},
+ * {@link TimeAdapter} (with timezone variants)</li>
+ * <li>Network: {@link UriAdapter}, {@link UriReferenceAdapter},
+ * {@link EmailAddressAdapter}, {@link HostnameAdapter},
+ * {@link IPv4AddressAdapter}, {@link IPv6AddressAdapter}</li>
+ * <li>Binary: {@link Base64Adapter}, {@link HexBinaryAdapter}</li>
+ * <li>Identifiers: {@link UuidAdapter}</li>
+ * </ul>
+ * <h2>Type Provider</h2>
+ * <ul>
+ * <li>{@link MetaschemaDataTypeProvider} - Registers all built-in Metaschema
+ * types with the
+ * {@link gov.nist.secauto.metaschema.core.datatype.DataTypeService}</li>
+ * </ul>
+ * <h2>Usage Context</h2>
+ * <p>
+ * These adapters handle conversion between Java objects and their serialized
+ * representations in XML, JSON, and YAML formats. Each adapter defines:
+ * <ul>
+ * <li>Parsing logic to convert string/stream data to Java objects</li>
+ * <li>Serialization methods for XML, JSON, and YAML output</li>
+ * <li>Validation rules and constraints for the data type</li>
+ * <li>Metapath atomic item creation for use in expressions</li>
+ * </ul>
+ *
+ * @see gov.nist.secauto.metaschema.core.datatype.IDataTypeAdapter
  */
 
 package gov.nist.secauto.metaschema.core.datatype.adapter;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/flexmark/impl/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/flexmark/impl/package-info.java
@@ -41,10 +41,7 @@
  * <ul>
  * <li>{@link HtmlCodeRenderExtension} - Custom rendering for inline
  * {@code <code>} elements to properly handle special characters</li>
- * <li>{@link SuppressPTagExtension} - Suppresses {@code
- *
-<p>
- * } paragraph tags in single-line markup content</li>
+ * <li>{@link SuppressPTagExtension} - Suppresses paragraph tags in single-line markup content</li>
  * <li>{@link FixedEmphasisDelimiterProcessor} - Fixed implementation of
  * emphasis delimiter processing to handle edge cases in Markdown emphasis
  * parsing</li>

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/flexmark/impl/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/flexmark/impl/package-info.java
@@ -1,0 +1,85 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+/**
+ * Internal implementation classes for Flexmark-based markup processing.
+ * <p>
+ * This package contains the low-level implementation components that power
+ * Metaschema's markup processing capabilities using the Flexmark Markdown
+ * parser library. These classes handle the details of parsing, visiting, and
+ * rendering markup content in various formats (HTML, XML, etc.).
+ * <h2>Configuration</h2>
+ * <ul>
+ * <li>{@link FlexmarkConfiguration} - Centralized singleton configuration for
+ * Flexmark parser, renderer, and formatter with Metaschema-specific
+ * extensions</li>
+ * </ul>
+ * <h2>Visitors</h2>
+ * <ul>
+ * <li>{@link IMarkupVisitor} - Interface for visiting and processing markup
+ * Abstract Syntax Tree (AST) nodes</li>
+ * <li>{@link MarkupVisitor} - Default implementation that dispatches to
+ * appropriate handler methods based on node type</li>
+ * <li>{@link AstCollectingVisitor} - Visitor that collects AST nodes for
+ * further processing</li>
+ * </ul>
+ * <h2>Writers</h2>
+ * <ul>
+ * <li>{@link IMarkupWriter} - Interface for writing markup to various output
+ * formats with support for elements, text, entities, and special
+ * constructs</li>
+ * <li>{@link AbstractMarkupWriter} - Base implementation providing common
+ * functionality for markup writers</li>
+ * <li>{@link MarkupXmlStreamWriter} - Writes markup as XML using StAX
+ * {@link javax.xml.stream.XMLStreamWriter}</li>
+ * <li>{@link MarkupXmlEventWriter} - Writes markup as XML using StAX
+ * {@link javax.xml.stream.XMLEventWriter}</li>
+ * </ul>
+ * <h2>Custom Extensions</h2>
+ * <ul>
+ * <li>{@link HtmlCodeRenderExtension} - Custom rendering for inline
+ * {@code <code>} elements to properly handle special characters</li>
+ * <li>{@link SuppressPTagExtension} - Suppresses {@code
+ * <p>
+ * } paragraph tags in single-line markup content</li>
+ * <li>{@link FixedEmphasisDelimiterProcessor} - Fixed implementation of
+ * emphasis delimiter processing to handle edge cases in Markdown emphasis
+ * parsing</li>
+ * </ul>
+ * <h2>Design Patterns</h2>
+ * <p>
+ * The package follows several design patterns:
+ * <ul>
+ * <li><b>Visitor Pattern</b> - {@link IMarkupVisitor} and implementations
+ * traverse the Flexmark AST</li>
+ * <li><b>Strategy Pattern</b> - {@link IMarkupWriter} allows different output
+ * strategies (stream vs. event-based XML)</li>
+ * <li><b>Template Method</b> - {@link AbstractMarkupWriter} provides common
+ * structure with extension points</li>
+ * <li><b>Singleton</b> - {@link FlexmarkConfiguration} manages shared parser
+ * configuration</li>
+ * </ul>
+ * <h2>Thread Safety</h2>
+ * <p>
+ * The {@link FlexmarkConfiguration} is thread-safe and immutable after
+ * initialization. Writer and visitor implementations are typically not
+ * thread-safe and should be used within a single thread or processing context.
+ * <h2>Usage Context</h2>
+ * <p>
+ * This package is internal implementation detail used by:
+ * <ul>
+ * <li>Parent {@link gov.nist.secauto.metaschema.core.datatype.markup.flexmark}
+ * package for public markup processing APIs</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.datatype.markup} for higher-level
+ * markup data type support</li>
+ * <li>XML and JSON serialization components that need to render markup
+ * content</li>
+ * </ul>
+ *
+ * @see gov.nist.secauto.metaschema.core.datatype.markup.flexmark
+ * @see gov.nist.secauto.metaschema.core.datatype.markup
+ */
+
+package gov.nist.secauto.metaschema.core.datatype.markup.flexmark.impl;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/flexmark/impl/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/flexmark/impl/package-info.java
@@ -41,7 +41,8 @@
  * <ul>
  * <li>{@link HtmlCodeRenderExtension} - Custom rendering for inline
  * {@code <code>} elements to properly handle special characters</li>
- * <li>{@link SuppressPTagExtension} - Suppresses paragraph tags in single-line markup content</li>
+ * <li>{@link SuppressPTagExtension} - Suppresses paragraph tags in single-line
+ * markup content</li>
  * <li>{@link FixedEmphasisDelimiterProcessor} - Fixed implementation of
  * emphasis delimiter processing to handle edge cases in Markdown emphasis
  * parsing</li>

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/flexmark/impl/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/flexmark/impl/package-info.java
@@ -42,7 +42,8 @@
  * <li>{@link HtmlCodeRenderExtension} - Custom rendering for inline
  * {@code <code>} elements to properly handle special characters</li>
  * <li>{@link SuppressPTagExtension} - Suppresses {@code
- * <p>
+ *
+<p>
  * } paragraph tags in single-line markup content</li>
  * <li>{@link FixedEmphasisDelimiterProcessor} - Fixed implementation of
  * emphasis delimiter processing to handle edge cases in Markdown emphasis

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/flexmark/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/flexmark/package-info.java
@@ -23,7 +23,8 @@
  * Metaschema-specific Flexmark extensions:
  * <ul>
  * <li>{@link HtmlQuoteTagExtension} - Supports HTML {@code
- * <q>} tag parsing and rendering</li>
+ *
+<q>} tag parsing and rendering</li>
  * <li>{@link InsertAnchorExtension} - Enables insertion of anchor elements for
  * headings</li>
  * <li>{@link gov.nist.secauto.metaschema.core.datatype.markup.flexmark.impl.HtmlCodeRenderExtension}

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/flexmark/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/flexmark/package-info.java
@@ -4,8 +4,55 @@
  */
 
 /**
- * Support for parsing HTML and Markdown text used in Metaschema fields using
- * <a href="https://github.com/vsch/flexmark-java">Flexmark</a>.
+ * Support for parsing and rendering HTML and Markdown text using Flexmark.
+ * <p>
+ * This package provides Flexmark-based infrastructure for Metaschema markup
+ * processing, including custom extensions, visitors, and writers for
+ * specialized Metaschema markup requirements. The implementation uses the
+ * <a href="https://github.com/vsch/flexmark-java">Flexmark</a> library for
+ * Markdown parsing and HTML rendering.
+ * <h2>Core Components</h2>
+ * <ul>
+ * <li>{@link FlexmarkFactory} - Factory for creating configured Flexmark parser
+ * and renderer instances with Metaschema-specific extensions</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.datatype.markup.flexmark.impl.FlexmarkConfiguration}
+ * - Centralized configuration for Flexmark options and extensions</li>
+ * </ul>
+ * <h2>Custom Extensions</h2>
+ * <p>
+ * Metaschema-specific Flexmark extensions:
+ * <ul>
+ * <li>{@link HtmlQuoteTagExtension} - Supports HTML {@code
+ * <q>} tag parsing and rendering</li>
+ * <li>{@link InsertAnchorExtension} - Enables insertion of anchor elements for
+ * headings</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.datatype.markup.flexmark.impl.HtmlCodeRenderExtension}
+ * - Custom rendering for inline code elements</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.datatype.markup.flexmark.impl.SuppressPTagExtension}
+ * - Suppresses paragraph tags in single-line markup</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.datatype.markup.flexmark.impl.FixedEmphasisDelimiterProcessor}
+ * - Fixes emphasis delimiter processing for Metaschema requirements</li>
+ * </ul>
+ * <h2>Visitors and Writers</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.datatype.markup.flexmark.impl.IMarkupVisitor}
+ * - Interface for visiting markup AST nodes</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.datatype.markup.flexmark.impl.MarkupVisitor}
+ * - Default visitor implementation for processing markup nodes</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.datatype.markup.flexmark.impl.IMarkupWriter}
+ * - Interface for writing markup to various output formats</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.datatype.markup.flexmark.impl.MarkupXmlEventWriter}
+ * - Writes markup as XML events (StAX event-based API)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.datatype.markup.flexmark.impl.MarkupXmlStreamWriter}
+ * - Writes markup as XML stream (StAX stream-based API)</li>
+ * </ul>
+ * <h2>Usage Context</h2>
+ * <p>
+ * This package is primarily used internally by the
+ * {@link gov.nist.secauto.metaschema.core.datatype.markup} package to handle
+ * the low-level parsing and rendering of markup content. The Flexmark
+ * extensions ensure that Metaschema markup conforms to specification
+ * requirements while supporting a rich subset of Markdown and HTML features.
  */
 
 package gov.nist.secauto.metaschema.core.datatype.markup.flexmark;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/package-info.java
@@ -44,7 +44,7 @@
  * The Flexmark library is used for Markdown parsing and rendering, with custom
  * extensions provided in the {@code flexmark} subpackage.
  *
- * @see gov.nist.secauto.metaschema.core.datatype.markup.flexmark
+ * @see gov.nist.secauto.metaschema.core.datatype.markup.flexmark.FlexmarkFactory
  */
 
 package gov.nist.secauto.metaschema.core.datatype.markup;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/package-info.java
@@ -4,7 +4,47 @@
  */
 
 /**
- * Data type support for HTML and Markdown markup.
+ * Data type support for HTML and Markdown markup in Metaschema fields.
+ * <p>
+ * This package provides specialized data types for handling rich text markup,
+ * supporting both single-line and multi-line formatted content in Metaschema
+ * documents. Markup is internally represented using Flexmark AST nodes and can
+ * be serialized to XML, JSON, or Markdown formats.
+ * <h2>Key Interfaces and Classes</h2>
+ * <ul>
+ * <li>{@link IMarkupString} - Common interface for all markup implementations,
+ * providing access to the Flexmark document tree and conversion methods</li>
+ * <li>{@link MarkupLine} - Represents single-line markup content (no
+ * block-level elements)</li>
+ * <li>{@link MarkupMultiline} - Represents multi-line markup content with full
+ * block structure support (paragraphs, lists, tables, etc.)</li>
+ * <li>{@link AbstractMarkupAdapter} - Base adapter for markup data types,
+ * handling parsing and serialization</li>
+ * <li>{@link MarkupLineAdapter} - Adapter for single-line markup</li>
+ * <li>{@link MarkupMultilineAdapter} - Adapter for multi-line markup</li>
+ * </ul>
+ * <h2>Type Provider</h2>
+ * <ul>
+ * <li>{@link MarkupDataTypeProvider} - Registers markup types with the data
+ * type service</li>
+ * </ul>
+ * <h2>Usage Context</h2>
+ * <p>
+ * Markup types are used in Metaschema definitions where fields need to support
+ * formatted text with emphasis, links, code snippets, and other inline or block
+ * formatting. The package handles:
+ * <ul>
+ * <li>Parsing Markdown syntax into a structured AST</li>
+ * <li>Rendering markup to HTML for XML serialization</li>
+ * <li>Converting markup to plain text or Markdown</li>
+ * <li>Validating markup constraints (e.g., no block elements in single-line
+ * markup)</li>
+ * </ul>
+ * <p>
+ * The Flexmark library is used for Markdown parsing and rendering, with custom
+ * extensions provided in the {@code flexmark} subpackage.
+ *
+ * @see gov.nist.secauto.metaschema.core.datatype.markup.flexmark
  */
 
 package gov.nist.secauto.metaschema.core.datatype.markup;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/object/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/object/package-info.java
@@ -4,7 +4,41 @@
  */
 
 /**
- * Bound objects used by the Metaschema type system.
+ * Specialized data objects for ambiguous temporal values in the Metaschema type
+ * system.
+ * <p>
+ * This package provides custom Java types for representing temporal values
+ * (dates, times, and datetimes) that may or may not include timezone
+ * information. These ambiguous temporal types preserve the original timezone
+ * presence/absence from parsed data, ensuring round-trip fidelity when
+ * serializing back to XML or JSON.
+ * <h2>Ambiguous Temporal Types</h2>
+ * <ul>
+ * <li>{@link AmbiguousDate} - Represents a date value that may lack timezone
+ * information</li>
+ * <li>{@link AmbiguousTime} - Represents a time value that may lack timezone
+ * information</li>
+ * <li>{@link AmbiguousDateTime} - Represents a datetime value that may lack
+ * timezone information</li>
+ * <li>{@link AbstractAmbiguousTemporal} - Base class providing common
+ * functionality for ambiguous temporal values</li>
+ * </ul>
+ * <h2>Usage Context</h2>
+ * <p>
+ * These types are used by the temporal data type adapters in
+ * {@link gov.nist.secauto.metaschema.core.datatype.adapter} when parsing dates,
+ * times, and datetimes from Metaschema documents. The ambiguous temporal types:
+ * <ul>
+ * <li>Preserve whether the original value included a timezone</li>
+ * <li>Store the underlying temporal value as a {@link java.time.ZonedDateTime}
+ * or similar</li>
+ * <li>Support comparison operations while respecting timezone ambiguity</li>
+ * <li>Enable accurate serialization that matches the original input format</li>
+ * </ul>
+ * <p>
+ * This approach ensures that Metaschema documents with mixed
+ * timezone/non-timezone temporal values maintain their original semantics
+ * through parse-serialize cycles.
  */
 
 package gov.nist.secauto.metaschema.core.datatype.object;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/package-info.java
@@ -5,6 +5,48 @@
 
 /**
  * The Metaschema and Metapath data type system API.
+ * <p>
+ * This package provides the core framework for the Metaschema type system,
+ * enabling type definitions, conversions, and serialization across XML, JSON,
+ * and YAML formats. The type system supports both built-in Metaschema types and
+ * custom type extensions.
+ * <h2>Key Interfaces</h2>
+ * <ul>
+ * <li>{@link IDataTypeAdapter} - Defines conversion operations between Java
+ * types and Metaschema data representations, including parsing, serialization,
+ * and validation.</li>
+ * <li>{@link IDataTypeProvider} - Service provider interface for registering
+ * data type adapters and abstract types, supporting pluggable type
+ * extensions.</li>
+ * <li>{@link ICustomJavaDataType} - Marker interface for custom Java types that
+ * require specialized handling beyond simple primitives.</li>
+ * </ul>
+ * <h2>Key Classes</h2>
+ * <ul>
+ * <li>{@link DataTypeService} - Central registry for data type discovery using
+ * Java SPI, managing all available type adapters.</li>
+ * <li>{@link AbstractDataTypeAdapter} - Base implementation providing common
+ * adapter functionality for concrete type implementations.</li>
+ * <li>{@link AbstractDataTypeProvider} - Base implementation for type providers
+ * with support for registering multiple adapters.</li>
+ * </ul>
+ * <h2>Usage Context</h2>
+ * <p>
+ * The data type system is used throughout the Metaschema framework for:
+ * <ul>
+ * <li>Parsing and validating field values in Metaschema documents</li>
+ * <li>Converting between Java objects and XML/JSON/YAML representations</li>
+ * <li>Supporting Metapath expressions with typed atomic values</li>
+ * <li>Enabling custom type extensions through the SPI mechanism</li>
+ * </ul>
+ * <p>
+ * Concrete type implementations are provided in the {@code adapter} subpackage,
+ * while specialized types for markup and temporal values are in their
+ * respective subpackages.
+ *
+ * @see gov.nist.secauto.metaschema.core.datatype.adapter
+ * @see gov.nist.secauto.metaschema.core.datatype.markup
+ * @see gov.nist.secauto.metaschema.core.datatype.object
  */
 
 package gov.nist.secauto.metaschema.core.datatype;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/mdm/impl/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/mdm/impl/package-info.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+/**
+ * Provides implementation classes for the Metaschema Document Model (MDM)
+ * interfaces defined in {@link gov.nist.secauto.metaschema.core.mdm}.
+ * <p>
+ * This package contains the concrete implementations that support creating and
+ * managing in-memory document structures backed by Metaschema module
+ * definitions. These implementations handle the relationships between parent
+ * and child nodes, manage location information, and provide factory methods for
+ * creating new node instances.
+ * <p>
+ * Key implementation classes include:
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.mdm.impl.AbstractDMNodeItem} -
+ * Base abstract implementation for all MDM node items</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.mdm.impl.AbstractDMModelNodeItem}
+ * - Base for model node items (assemblies and fields) that support flags</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.mdm.impl.DocumentNodeItem} -
+ * Implementation of document root nodes</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.mdm.impl.DefinitionAssemblyNodeItem}
+ * - Assemblies created directly from definitions (orphaned from documents)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.mdm.impl.ChildAssemblyNodeItem} -
+ * Assemblies created as children of other nodes</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.mdm.impl.DefinitionFieldNodeItem}
+ * - Fields created directly from definitions</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.mdm.impl.ChildFieldNodeItem} -
+ * Fields created as children of other nodes</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.mdm.impl.DefinitionFlagNodeItem}
+ * - Flags created directly from definitions</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.mdm.impl.ChildFlagNodeItem} -
+ * Flags created as children of other nodes</li>
+ * </ul>
+ * <p>
+ * Supporting interfaces in this package include:
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.mdm.impl.IDMModelNodeItem} -
+ * Interface for model nodes that support creating child flags</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.mdm.impl.IFeatureChildNodeItem} -
+ * Interface for nodes that have a parent-child relationship</li>
+ * </ul>
+ * <p>
+ * The implementation distinguishes between two types of node creation:
+ * <ul>
+ * <li><strong>Definition-based nodes</strong> - Created directly from
+ * Metaschema definitions, orphaned from any document or parent node. These are
+ * typically used as entry points for creating new document structures.</li>
+ * <li><strong>Child nodes</strong> - Created as children of existing nodes
+ * through instance references. These maintain parent-child relationships and
+ * are part of a larger document structure.</li>
+ * </ul>
+ */
+
+package gov.nist.secauto.metaschema.core.mdm.impl;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/mdm/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/mdm/package-info.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+/**
+ * Provides interfaces for the Metaschema Document Model (MDM), a simple
+ * module-based data model implementation for representing Metapath node items
+ * backed by Metaschema definitions.
+ * <p>
+ * The MDM provides a way to create in-memory document structures that conform
+ * to Metaschema module definitions. These structures can be queried and
+ * manipulated using Metapath expressions and serve as node items in the
+ * Metapath data model.
+ * <p>
+ * Key interfaces in this package include:
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.mdm.IDMNodeItem} - Base interface
+ * for all MDM node items with location tracking support</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.mdm.IDMDocumentNodeItem} -
+ * Represents a document root that contains the node tree</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.mdm.IDMRootAssemblyNodeItem} -
+ * Represents the root assembly of a document</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.mdm.IDMAssemblyNodeItem} -
+ * Represents an assembly (complex object) with methods to add child nodes</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.mdm.IDMFieldNodeItem} -
+ * Represents a field (simple content with possible flags)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.mdm.IDMFlagNodeItem} - Represents
+ * a flag (attribute-like value)</li>
+ * </ul>
+ * <p>
+ * The MDM can be used to:
+ * <ul>
+ * <li>Create new document structures programmatically from Metaschema
+ * definitions</li>
+ * <li>Build test data for validation and processing</li>
+ * <li>Construct data models for transformation and query operations</li>
+ * <li>Represent detached node items that can be queried with Metapath</li>
+ * </ul>
+ * <p>
+ * Implementation classes for these interfaces are provided in the
+ * {@link gov.nist.secauto.metaschema.core.mdm.impl} package.
+ */
+
+package gov.nist.secauto.metaschema.core.mdm;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/IErrorCode.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/IErrorCode.java
@@ -16,6 +16,15 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * Implementations of this interface are expected to be immutable.
  */
 public interface IErrorCode {
+  /**
+   * Create a new error code with the provided prefix and code value.
+   *
+   * @param prefix
+   *          the error code prefix
+   * @param code
+   *          the error code value
+   * @return a new error code instance
+   */
   @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   static IErrorCode of(@NonNull String prefix, int code) {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/InvalidTreatTypeDynamicMetapathException.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/InvalidTreatTypeDynamicMetapathException.java
@@ -10,14 +10,23 @@ import java.util.Deque;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * Raised when a Metapath treat expression fails because the sequence does not
+ * match the required type.
+ * <p>
+ * This corresponds to XPath 3.1 error XPDY0050.
+ */
 public class InvalidTreatTypeDynamicMetapathException
     extends DynamicMetapathException {
 
   private static final long serialVersionUID = 1L;
 
   /**
-   * Constructs a new exception with the provided {@code message} and no cause.
+   * Constructs a new exception with the provided {@code evaluationStack} and
+   * {@code message} and no cause.
    *
+   * @param evaluationStack
+   *          the evaluation stack recording the expressions being evaluated
    * @param message
    *          the exception message
    */

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/InvalidTreatTypeDynamicMetapathException.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/InvalidTreatTypeDynamicMetapathException.java
@@ -34,6 +34,7 @@ public class InvalidTreatTypeDynamicMetapathException
       @NonNull Deque<IExpression> evaluationStack,
       @Nullable String message) {
     super(TREAT_DOES_NOT_MATCH_TYPE, message);
+    registerEvaluationContext(evaluationStack);
   }
 
   /**

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/MetapathException.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/MetapathException.java
@@ -103,6 +103,22 @@ public class MetapathException
   }
 
   /**
+   * Registers the evaluation context from the provided evaluation stack.
+   * <p>
+   * A snapshot of the stack is captured if not already set.
+   *
+   * @param stack
+   *          the evaluation stack recording the expressions being evaluated
+   * @return this exception instance for chaining
+   */
+  public MetapathException registerEvaluationContext(@NonNull Deque<? extends IExpression> stack) {
+    if (evaluationStack == null) {
+      evaluationStack = new ArrayDeque<>(stack);
+    }
+    return this;
+  }
+
+  /**
    * Registers the evaluation context from the provided metapath expression.
    * <p>
    * The expression is recorded as the evaluation context if not already set.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/MetapathException.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/MetapathException.java
@@ -89,14 +89,17 @@ public class MetapathException
   /**
    * Registers the evaluation context from the provided dynamic context.
    * <p>
-   * The execution stack is captured from the dynamic context if not already set.
+   * A snapshot of the execution stack is captured from the dynamic context if not
+   * already set. This ensures the recorded state reflects the stack at the time
+   * of registration, avoiding confusion from post-throw mutations.
    *
    * @param dynamicContext
    *          the dynamic context containing the execution stack
    * @return this exception instance for chaining
    */
-  public MetapathException registerEvaluationContext(@NonNull DynamicContext dynamicContext) {
+  public final MetapathException registerEvaluationContext(@NonNull DynamicContext dynamicContext) {
     if (evaluationStack == null) {
+      // getExecutionStack() returns a defensive copy
       evaluationStack = dynamicContext.getExecutionStack();
     }
     return this;
@@ -111,7 +114,7 @@ public class MetapathException
    *          the evaluation stack recording the expressions being evaluated
    * @return this exception instance for chaining
    */
-  public MetapathException registerEvaluationContext(@NonNull Deque<? extends IExpression> stack) {
+  public final MetapathException registerEvaluationContext(@NonNull Deque<? extends IExpression> stack) {
     if (evaluationStack == null) {
       evaluationStack = new ArrayDeque<>(stack);
     }
@@ -127,7 +130,7 @@ public class MetapathException
    *          the metapath expression being evaluated
    * @return this exception instance for chaining
    */
-  public MetapathException registerEvaluationContext(@NonNull IMetapathExpression metapath) {
+  public final MetapathException registerEvaluationContext(@NonNull IMetapathExpression metapath) {
     if (evaluationStack == null) {
       evaluationStack = new ArrayDeque<>(Collections.singleton(metapath));
     }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/MetapathException.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/MetapathException.java
@@ -28,6 +28,10 @@ public class MetapathException
   @NonNull
   private final IErrorCode errorCode;
 
+  /**
+   * The evaluation stack recording the expressions being evaluated when the
+   * exception occurred.
+   */
   @Nullable
   private Deque<IExpression> evaluationStack = null;
 
@@ -82,6 +86,15 @@ public class MetapathException
     this.errorCode = errorCode;
   }
 
+  /**
+   * Registers the evaluation context from the provided dynamic context.
+   * <p>
+   * The execution stack is captured from the dynamic context if not already set.
+   *
+   * @param dynamicContext
+   *          the dynamic context containing the execution stack
+   * @return this exception instance for chaining
+   */
   public MetapathException registerEvaluationContext(@NonNull DynamicContext dynamicContext) {
     if (evaluationStack == null) {
       evaluationStack = dynamicContext.getExecutionStack();
@@ -89,6 +102,15 @@ public class MetapathException
     return this;
   }
 
+  /**
+   * Registers the evaluation context from the provided metapath expression.
+   * <p>
+   * The expression is recorded as the evaluation context if not already set.
+   *
+   * @param metapath
+   *          the metapath expression being evaluated
+   * @return this exception instance for chaining
+   */
   public MetapathException registerEvaluationContext(@NonNull IMetapathExpression metapath) {
     if (evaluationStack == null) {
       evaluationStack = new ArrayDeque<>(Collections.singleton(metapath));
@@ -96,6 +118,11 @@ public class MetapathException
     return this;
   }
 
+  /**
+   * Retrieves the evaluation stack recording the expressions being evaluated.
+   *
+   * @return the evaluation stack, or {@code null} if not set
+   */
   @Nullable
   protected Deque<IExpression> getEvaluationStack() {
     return evaluationStack;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/StaticContext.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/StaticContext.java
@@ -54,43 +54,6 @@ public final class StaticContext {
   private final IFunctionResolver functionResolver;
 
   /**
-   * Get the mapping of prefix to namespace URI for all well-known namespaces
-   * provided by default to the static context.
-   * <p>
-   * These namespaces can be overridden using the
-   * {@link Builder#namespace(String, URI)} method.
-   * <p>
-   * This method has been deprecated. While
-   * {@link WellKnown#getWellKnownPrefixesToNamespaces()} can be used in place of
-   * this method, it is generally preferred to call
-   * {@link WellKnown#getWellKnownUriForPrefix(String)} instead.
-   *
-   * @return the mapping of prefix to namespace URI for all well-known namespaces
-   */
-  @NonNull
-  @Deprecated(since = "2.2.0", forRemoval = true)
-  public static Map<String, String> getWellKnownNamespacesMap() {
-    return WellKnown.getWellKnownPrefixesToNamespaces();
-  }
-
-  /**
-   * Get the mapping of namespace URIs to prefixes for all well-known namespaces
-   * provided by default to the static context.
-   * <p>
-   * This method has been deprecated. While
-   * {@link WellKnown#getWellKnownURIsToPrefixes()} can be used in place of this
-   * method, it is generally preferred to call
-   * {@link WellKnown#getWellKnownPrefixForUri(String)} instead.
-   *
-   * @return the mapping of namespace URI to prefix for all well-known namespaces
-   */
-  @NonNull
-  @Deprecated(since = "2.2.0", forRemoval = true)
-  public static Map<String, String> getWellKnownURIToPrefixMap() {
-    return WellKnown.getWellKnownURIsToPrefixes();
-  }
-
-  /**
    * Get the namespace prefix associated with the provided URI, if the URI is
    * well-known.
    * <p>

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/antlr/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/antlr/package-info.java
@@ -3,4 +3,47 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
+/**
+ * Provides ANTLR4-based parsing infrastructure for the Metapath expression
+ * language.
+ * <p>
+ * This package contains classes that support parsing Metapath expression
+ * strings into abstract syntax trees (ASTs) using the ANTLR4 parser generator
+ * framework. The ANTLR4 grammar definition is located in
+ * {@code core/src/main/antlr4} and generates lexer and parser classes during
+ * the Maven build process.
+ * <p>
+ * Key classes:
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.antlr.AbstractAstVisitor}
+ * - Base visitor class for traversing and transforming ANTLR parse trees into
+ * executable Metapath expression objects using the visitor pattern</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.antlr.FailingErrorListener}
+ * - ANTLR error listener that converts syntax errors into
+ * {@link org.antlr.v4.runtime.misc.ParseCancellationException} instances with
+ * detailed position information</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.antlr.ParseTreePrinter}
+ * - Utility for generating textual representations of ANTLR parse trees for
+ * debugging purposes</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.antlr.Metapath10ParserBase}
+ * - Base parser class providing custom parsing logic and helper methods</li>
+ * </ul>
+ * <p>
+ * Generated ANTLR4 classes (created during build):
+ * <ul>
+ * <li>{@code Metapath10Lexer} - Tokenizes Metapath expression strings</li>
+ * <li>{@code Metapath10Parser} - Parses token streams into concrete syntax
+ * trees</li>
+ * <li>{@code Metapath10BaseVisitor} - Base visitor interface for traversing
+ * parse trees</li>
+ * </ul>
+ * <p>
+ * This package is primarily used internally by the Metapath compiler and should
+ * not be directly invoked by application code. Use
+ * {@link gov.nist.secauto.metaschema.core.metapath.IMetapathExpression} for
+ * compiling and evaluating Metapath expressions.
+ *
+ * @see gov.nist.secauto.metaschema.core.metapath.IMetapathExpression#compile(String)
+ */
+
 package gov.nist.secauto.metaschema.core.metapath.antlr;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/items/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/items/package-info.java
@@ -1,0 +1,104 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+/**
+ * Provides concrete syntax tree (CST) node implementations for Metapath item
+ * expressions and sequence operations.
+ * <p>
+ * This package implements various expression types as defined by
+ * <a href="https://www.w3.org/TR/xpath-31/">XPath 3.1</a> that operate on items
+ * and sequences, including literals, sequence constructors, set operations, and
+ * quantified expressions.
+ *
+ * <h2>Key Classes and Interfaces</h2>
+ *
+ * <h3>Literal Expressions</h3>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.items.ILiteralExpression}
+ * - Common interface for all literal value expressions</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.items.AbstractLiteralExpression}
+ * - Base class for literal implementations</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.items.IntegerLiteral}
+ * - Integer literal values</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.items.DecimalLiteral}
+ * - Decimal literal values</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.items.StringLiteral}
+ * - String literal values</li>
+ * </ul>
+ *
+ * <h3>Sequence Operations</h3>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.items.EmptySequence}
+ * - Empty parenthesized expression {@code ()}</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.items.SequenceExpression}
+ * - Comma-separated sequence of expressions</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.items.Range} - Range
+ * expression ({@code to} operator)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.items.StringConcat}
+ * - String concatenation operator ({@code ||})</li>
+ * </ul>
+ *
+ * <h3>Set Operations</h3>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.items.Union} - Union
+ * of sequences ({@code union}, {@code |})</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.items.Intersect} -
+ * Intersection of sequences ({@code intersect})</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.items.Except} -
+ * Difference of sequences ({@code except})</li>
+ * </ul>
+ *
+ * <h3>Map and Filter Operations</h3>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.items.SimpleMap} -
+ * Simple map operator ({@code !})</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.items.AbstractFilterExpression}
+ * - Base class for filter expressions</li>
+ * </ul>
+ *
+ * <h3>Lookup Operations</h3>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.items.AbstractLookup}
+ * - Base class for lookup operations</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.items.PostfixLookup}
+ * - Postfix lookup expression</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.items.UnaryLookup} -
+ * Unary lookup expression ({@code ?})</li>
+ * </ul>
+ *
+ * <h3>Array and Map Constructors</h3>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.items.ArraySquareConstructor}
+ * - Square array constructor ({@code [ ]})</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.items.ArraySequenceConstructor}
+ * - Curly array constructor ({@code array { }})</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.items.MapConstructor}
+ * - Map constructor ({@code map { }})</li>
+ * </ul>
+ *
+ * <h3>Quantified Expressions</h3>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.items.Quantified} -
+ * Quantified expressions ({@code some} and {@code every})</li>
+ * </ul>
+ *
+ * <h2>Usage Examples</h2>
+ *
+ * <pre>
+ * // Literals: 42, 3.14, "hello"
+ * // Empty sequence: ()
+ * // Sequence: (1, 2, 3)
+ * // Range: 1 to 10
+ * // Union: $seq1 | $seq2
+ * // Simple map: $items ! string(.)
+ * // Quantified: some $x in $seq satisfies $x &gt; 10
+ * </pre>
+ *
+ * @see gov.nist.secauto.metaschema.core.metapath.item.IItem
+ * @see gov.nist.secauto.metaschema.core.metapath.item.ISequence
+ * @see gov.nist.secauto.metaschema.core.metapath.cst
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.cst.items;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/logic/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/logic/package-info.java
@@ -1,0 +1,96 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+/**
+ * Provides concrete syntax tree (CST) node implementations for Metapath logical
+ * and comparison expressions.
+ * <p>
+ * This package implements logical operations, conditional expressions, and
+ * comparison operators as defined by
+ * <a href="https://www.w3.org/TR/xpath-31/#id-logical-expressions">XPath 3.1
+ * logical expressions</a>,
+ * <a href="https://www.w3.org/TR/xpath-31/#id-comparisons">XPath 3.1
+ * comparisons</a>, and
+ * <a href="https://www.w3.org/TR/xpath-31/#id-conditionals">XPath 3.1
+ * conditional expressions</a>.
+ *
+ * <h2>Key Classes and Interfaces</h2>
+ *
+ * <h3>Logical Expressions</h3>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.logic.IBooleanLogicExpression}
+ * - Common interface for expressions that produce boolean results</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.logic.And} - Logical
+ * "and" expression with short-circuit evaluation</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.logic.Or} - Logical
+ * "or" expression with short-circuit evaluation</li>
+ * </ul>
+ *
+ * <h3>Conditional Expressions</h3>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.logic.If} -
+ * If-then-else conditional expression</li>
+ * </ul>
+ *
+ * <h3>Comparison Expressions</h3>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.logic.AbstractComparison}
+ * - Base class for all comparison operations</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.logic.GeneralComparison}
+ * - General comparisons ({@code =}, {@code !=}, {@code <}, {@code <=},
+ * {@code >}, {@code >=})</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.logic.ValueComparison}
+ * - Value comparisons ({@code eq}, {@code ne}, {@code lt}, {@code le},
+ * {@code gt}, {@code ge})</li>
+ * </ul>
+ *
+ * <h3>Predicate Expressions</h3>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.logic.PredicateExpression}
+ * - Predicate filter expression ({@code [predicate]})</li>
+ * </ul>
+ *
+ * <h2>Logical Expression Behavior</h2>
+ *
+ * <h3>And Expression</h3>
+ * <p>
+ * The {@code and} operator performs short-circuit evaluation, returning
+ * {@code false} as soon as the first operand evaluates to {@code false}.
+ *
+ * <h3>Or Expression</h3>
+ * <p>
+ * The {@code or} operator performs short-circuit evaluation, returning
+ * {@code true} as soon as the first operand evaluates to {@code true}.
+ *
+ * <h2>Comparison Types</h2>
+ *
+ * <h3>General Comparisons</h3>
+ * <p>
+ * General comparisons ({@code =}, {@code !=}, etc.) compare sequences by
+ * checking if any pair of items from the left and right sequences satisfies the
+ * comparison. They perform existential quantification.
+ *
+ * <h3>Value Comparisons</h3>
+ * <p>
+ * Value comparisons ({@code eq}, {@code ne}, etc.) compare single atomic
+ * values. If either operand is an empty sequence or contains more than one
+ * item, the comparison raises an error.
+ *
+ * <h2>Usage Examples</h2>
+ *
+ * <pre>
+ * // Logical: $a and $b, $x or $y
+ * // Conditional: if ($count &gt; 10) then "many" else "few"
+ * // General comparison: $items = 'value'
+ * // Value comparison: $price gt 100
+ * // Predicate: $items[position() &lt; 5]
+ * </pre>
+ *
+ * @see gov.nist.secauto.metaschema.core.metapath.item.atomic.IBooleanItem
+ * @see gov.nist.secauto.metaschema.core.metapath.function.ComparisonFunctions
+ * @see gov.nist.secauto.metaschema.core.metapath.cst
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.cst.logic;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/math/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/math/package-info.java
@@ -2,8 +2,58 @@
  * SPDX-FileCopyrightText: none
  * SPDX-License-Identifier: CC0-1.0
  */
+
 /**
- * Compact syntax tree expressions supporting Metapath math operations.
+ * Provides concrete syntax tree (CST) node implementations for Metapath
+ * arithmetic expressions.
+ * <p>
+ * This package implements arithmetic operations as defined by the
+ * <a href="https://www.w3.org/TR/xpath-31/#id-arithmetic">XPath 3.1 arithmetic
+ * expressions</a> specification. These operations support numeric calculations,
+ * date/time arithmetic, and duration operations.
+ *
+ * <h2>Key Classes</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.math.AbstractArithmeticExpression}
+ * - Base class for all arithmetic operations</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.math.AbstractBasicArithmeticExpression}
+ * - Base class for basic binary arithmetic operations</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.math.Addition} -
+ * Addition operator (+)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.math.Subtraction} -
+ * Subtraction operator (-)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.math.Multiplication}
+ * - Multiplication operator (*)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.math.Division} -
+ * Division operator (div)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.math.IntegerDivision}
+ * - Integer division operator (idiv)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.math.Modulo} -
+ * Modulo operator (mod)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.math.Negate} - Unary
+ * negation operator (-)</li>
+ * </ul>
+ *
+ * <h2>Supported Operations</h2>
+ * <p>
+ * Arithmetic expressions in this package support operations on:
+ * <ul>
+ * <li>Numeric types (integer, decimal, float, double)</li>
+ * <li>Date and time types (date, dateTime, time)</li>
+ * <li>Duration types (yearMonthDuration, dayTimeDuration)</li>
+ * </ul>
+ *
+ * <h2>Usage Example</h2>
+ *
+ * <pre>
+ * // Numeric: 1 + 2 evaluates to 3
+ * // Date arithmetic: xs:date('2023-01-01') + xs:yearMonthDuration('P1M')
+ * // Evaluates to xs:date('2023-02-01')
+ * </pre>
+ *
+ * @see gov.nist.secauto.metaschema.core.metapath.item.atomic.INumericItem
+ * @see gov.nist.secauto.metaschema.core.metapath.item.atomic.IDateItem
+ * @see gov.nist.secauto.metaschema.core.metapath.item.atomic.IDayTimeDurationItem
  */
 
 package gov.nist.secauto.metaschema.core.metapath.cst.math;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/package-info.java
@@ -4,15 +4,57 @@
  */
 
 /**
- * Provides compact syntax tree (CST) node implementation for the Metapath
- * syntax.
+ * Provides concrete syntax tree (CST) node implementations for Metapath
+ * expressions.
  * <p>
- * The {@link gov.nist.secauto.metaschema.core.metapath.cst.BuildCSTVisitor}
- * class is responsible for converting the abstract syntax tree (AST) generated
- * by <a href="https://www.antlr.org/">ANTLRv4</a> into a CST.
+ * Metapath is an XPath 3.1-based query language for navigating and querying
+ * Metaschema-based data. This package contains the expression implementations
+ * that form the executable representation of parsed Metapath queries.
+ *
+ * <h2>Package Structure</h2>
  * <p>
- * The {@link gov.nist.secauto.metaschema.core.metapath.cst.CSTPrinter} can be
- * used to visualize the CST as a string. This can be useful for debugging.
+ * This package is organized into several subpackages:
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.math} - Arithmetic
+ * expressions (addition, subtraction, multiplication, division, etc.)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.path} - Path
+ * navigation expressions (axes, steps, node tests)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.type} - Type
+ * operations (cast, castable, instance of, treat)</li>
+ * <li>{@code gov.nist.secauto.metaschema.core.metapath.cst.logic} - Boolean
+ * logic and comparison expressions</li>
+ * <li>{@code gov.nist.secauto.metaschema.core.metapath.cst.items} - Literal
+ * values, sequences, and collection operations</li>
+ * </ul>
+ *
+ * <h2>Key Classes and Interfaces</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.AbstractExpression}
+ * - Base class for all CST expression nodes</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.BuildCSTVisitor} -
+ * Transforms ANTLRv4 abstract syntax tree (AST) into executable CST nodes</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.IExpressionVisitor}
+ * - Visitor pattern interface for processing CST nodes</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.CSTPrinter} -
+ * Debugging utility for visualizing CST structure</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.For} - For loop
+ * expressions</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.Let} - Variable
+ * binding expressions</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.StaticFunctionCall}
+ * - Static function invocation</li>
+ * </ul>
+ *
+ * <h2>Usage Context</h2>
+ * <p>
+ * CST nodes are created by
+ * {@link gov.nist.secauto.metaschema.core.metapath.cst.BuildCSTVisitor} during
+ * Metapath expression compilation. Each CST node implements
+ * {@link gov.nist.secauto.metaschema.core.metapath.IExpression} and can be
+ * evaluated against a dynamic context to produce results.
+ *
+ * @see gov.nist.secauto.metaschema.core.metapath.IExpression
+ * @see gov.nist.secauto.metaschema.core.metapath.DynamicContext
  */
 
 package gov.nist.secauto.metaschema.core.metapath.cst;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/path/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/path/package-info.java
@@ -2,8 +2,75 @@
  * SPDX-FileCopyrightText: none
  * SPDX-License-Identifier: CC0-1.0
  */
+
 /**
- * Compact syntax tree expressions supporting Metapath path traversal.
+ * Provides concrete syntax tree (CST) node implementations for Metapath path
+ * navigation expressions.
+ * <p>
+ * This package implements path expressions as defined by
+ * <a href="https://www.w3.org/TR/xpath-31/#id-path-expressions">XPath 3.1 path
+ * expressions</a> and <a href="https://www.w3.org/TR/xpath-31/#axes">XPath 3.1
+ * axes</a>. Path expressions enable navigation through Metaschema document
+ * structures using axes, steps, and predicates.
+ *
+ * <h2>Key Classes and Interfaces</h2>
+ *
+ * <h3>Path Expression Nodes</h3>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.path.AbstractPathExpression}
+ * - Base class for all path expressions</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.path.RootSlashPath}
+ * - Absolute path starting with {@code /}</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.path.RootSlashOnlyPath}
+ * - Root-only path expression {@code /}</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.path.RootDoubleSlashPath}
+ * - Absolute descendant path starting with {@code //}</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.path.RelativeSlashPath}
+ * - Relative path using {@code /} separator</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.path.RelativeDoubleSlashPath}
+ * - Relative descendant path using {@code //} separator</li>
+ * </ul>
+ *
+ * <h3>Step Expressions</h3>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.path.Step} -
+ * Individual step in a path expression combining axis and node test</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.path.Axis} -
+ * Enumeration of XPath axes (child, parent, ancestor, descendant, etc.)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.path.ModelInstanceStep}
+ * - Step for navigating model instances (assembly/field children)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.path.FlagStep} -
+ * Step for navigating flag children</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.path.ContextItem} -
+ * The context item expression {@code .}</li>
+ * </ul>
+ *
+ * <h3>Node Tests</h3>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.path.INodeTestExpression}
+ * - Interface for node test expressions</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.path.NameNodeTest} -
+ * Tests nodes by qualified name</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.path.KindNodeTest} -
+ * Tests nodes by kind (element, attribute, etc.)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.path.WildcardNodeTest}
+ * - Wildcard node test ({@code *}, {@code prefix:*}, {@code *:local})</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.path.IWildcardMatcher}
+ * - Interface for wildcard matching strategies</li>
+ * </ul>
+ *
+ * <h2>Usage Example</h2>
+ *
+ * <pre>
+ * // Absolute path: /catalog/group/control
+ * // Descendant search: //control[@id='ac-1']
+ * // Relative path: parent/child
+ * // Context item: .
+ * // Wildcard: control/*
+ * </pre>
+ *
+ * @see gov.nist.secauto.metaschema.core.metapath.item.node.INodeItem
+ * @see gov.nist.secauto.metaschema.core.metapath.cst
  */
 
 package gov.nist.secauto.metaschema.core.metapath.cst.path;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/type/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/type/package-info.java
@@ -4,7 +4,78 @@
  */
 
 /**
- * Compact syntax tree expressions supporting Metapath type introspection.
+ * Provides concrete syntax tree (CST) node implementations for Metapath type
+ * operations.
+ * <p>
+ * This package implements type-related expressions as defined by XPath 3.1,
+ * including type testing, type casting, and type assertion operations. These
+ * expressions enable runtime type introspection and conversion of Metapath
+ * values.
+ *
+ * <h2>Key Classes</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.type.AbstractCastingExpression}
+ * - Base class for casting-related expressions</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.type.Cast} -
+ * Implements the <a href="https://www.w3.org/TR/xpath-31/#id-cast">"cast as"
+ * operator</a> for explicit type conversion</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.type.Castable} -
+ * Implements the
+ * <a href="https://www.w3.org/TR/xpath-31/#id-castable">"castable as"
+ * operator</a> for testing type conversion feasibility</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.type.InstanceOf} -
+ * Implements the
+ * <a href="https://www.w3.org/TR/xpath-31/#id-instance-of">"instance of"
+ * operator</a> for runtime type testing</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.type.Treat} -
+ * Implements the <a href="https://www.w3.org/TR/xpath-31/#id-treat">"treat as"
+ * operator</a> for type assertion with runtime verification</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.cst.type.TypeTestSupport}
+ * - Utility class for type testing operations</li>
+ * </ul>
+ *
+ * <h2>Type Operations</h2>
+ *
+ * <h3>Cast Expression ({@code cast as})</h3>
+ * <p>
+ * Converts a value to a specified atomic type, raising an error if conversion
+ * fails:
+ *
+ * <pre>
+ * "123" cast as xs:integer  → 123
+ * "abc" cast as xs:integer  → error
+ * </pre>
+ *
+ * <h3>Castable Expression ({@code castable as})</h3>
+ * <p>
+ * Tests whether a value can be successfully cast to a specified type:
+ *
+ * <pre>
+ * "123" castable as xs:integer  → true
+ * "abc" castable as xs:integer  → false
+ * </pre>
+ *
+ * <h3>Instance Of Expression ({@code instance of})</h3>
+ * <p>
+ * Tests whether a value matches a specified sequence type:
+ *
+ * <pre>
+ * 5 instance of xs:integer          → true
+ * (1, 2, 3) instance of xs:integer+ → true
+ * "hello" instance of xs:integer    → false
+ * </pre>
+ *
+ * <h3>Treat Expression ({@code treat as})</h3>
+ * <p>
+ * Asserts that a value has a specified type, raising an error if it doesn't:
+ *
+ * <pre>
+ * $value treat as xs:integer  → returns $value if it's an integer, error otherwise
+ * </pre>
+ *
+ * @see gov.nist.secauto.metaschema.core.metapath.type
+ * @see gov.nist.secauto.metaschema.core.metapath.item.atomic
+ * @see gov.nist.secauto.metaschema.core.metapath.cst
  */
 
 package gov.nist.secauto.metaschema.core.metapath.cst.type;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/format/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/format/package-info.java
@@ -4,7 +4,50 @@
  */
 
 /**
- * Support for defining and evaluating Metapath functions.
+ * Provides formatters for generating path expressions from Metaschema node
+ * items.
+ * <p>
+ * This package contains interfaces and implementations for converting sequences
+ * of path segments (representing navigation through a Metaschema document
+ * structure) into formatted path strings. Different formatters can produce
+ * paths in various syntaxes, such as Metapath expressions or JSON path
+ * notation.
+ * <p>
+ * Key interfaces and classes:
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.format.IPathFormatter} -
+ * Core interface defining the contract for path formatters with implementations
+ * for different path syntaxes</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.format.IPathSegment} -
+ * Represents a single segment in a path, providing navigation to parent
+ * segments and access to associated node items</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.format.MetapathFormatter}
+ * - Produces Metapath expression syntax for paths (e.g.,
+ * {@code /root/assembly/field})</li>
+ * </ul>
+ * <p>
+ * Path formatters are primarily used for:
+ * <ul>
+ * <li>Generating human-readable error messages that indicate the location of
+ * schema validation failures</li>
+ * <li>Creating navigational references for documentation and debugging</li>
+ * <li>Providing context when reporting constraint violations</li>
+ * </ul>
+ * <p>
+ * Typical usage:
+ *
+ * <pre>{@code
+ * // Get a path formatter
+ * IPathFormatter formatter = IPathFormatter.METAPATH_PATH_FORMATER;
+ *
+ * // Format a path from a node item
+ * INodeItem nodeItem = ...; // some node in a document
+ * String path = nodeItem.toPath(formatter);
+ * // Result: "/root-assembly/child-assembly/field[@name='value']"
+ * }</pre>
+ * <p>
+ * Path formatters are designed to be stateless and thread-safe, allowing reuse
+ * across multiple formatting operations.
  */
 
 package gov.nist.secauto.metaschema.core.metapath.format;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/CastFunctionException.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/CastFunctionException.java
@@ -39,6 +39,9 @@ public class CastFunctionException
    */
   private static final long serialVersionUID = 1L;
 
+  /**
+   * The atomic item that could not be cast to the target type.
+   */
   @NonNull
   private final IAnyAtomicItem item;
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/FunctionMetapathError.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/FunctionMetapathError.java
@@ -11,6 +11,9 @@ import gov.nist.secauto.metaschema.core.metapath.MetapathException;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * Represents an error that occurs during Metapath function evaluation.
+ */
 // TODO: remove this intermediate exception?
 public class FunctionMetapathError
     extends MetapathException {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/IArgument.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/IArgument.java
@@ -23,6 +23,15 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * Represents a single function argument signature.
  */
 public interface IArgument {
+  /**
+   * Create a new argument with the provided name and sequence type.
+   *
+   * @param name
+   *          the argument's name
+   * @param sequenceType
+   *          the argument's sequence type
+   * @return a new argument instance
+   */
   @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   static IArgument of(@NonNull IEnhancedQName name, @NonNull ISequenceType sequenceType) {
@@ -63,6 +72,15 @@ public interface IArgument {
     return new Builder();
   }
 
+  /**
+   * Resolve an argument name from a prefix.
+   *
+   * @param prefix
+   *          the prefix to resolve
+   * @return the resolved argument name
+   * @throws UnsupportedOperationException
+   *           if a non-empty prefix is provided
+   */
   @NonNull
   static String resolveArgumentName(@NonNull String prefix) {
     if (!"".equals(prefix)) {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/IFunctionLibrary.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/IFunctionLibrary.java
@@ -11,6 +11,9 @@ import java.util.stream.Stream;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Provides access to a collection of Metapath function signatures.
+ */
 public interface IFunctionLibrary {
 
   /**

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/IFunctionResolver.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/IFunctionResolver.java
@@ -17,14 +17,14 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public interface IFunctionResolver {
   /**
    * Retrieve the function with the provided name that supports the signature of
-   * the provided methods, if such a function exists.
+   * the provided methods.
    *
    * @param name
    *          the name of a group of functions
    * @param arity
    *          the count of arguments for use in determining an argument signature
    *          match
-   * @return the matching function or {@code null} if no match exists
+   * @return the matching function
    * @throws StaticMetapathException
    *           with the code {@link StaticMetapathException#NO_FUNCTION_MATCH} if
    *           a matching function was not found

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/IFunctionResolver.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/IFunctionResolver.java
@@ -10,6 +10,9 @@ import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Resolves Metapath function signatures based on name and arity.
+ */
 @FunctionalInterface
 public interface IFunctionResolver {
   /**

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/InvalidValueForCastFunctionException.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/InvalidValueForCastFunctionException.java
@@ -5,6 +5,10 @@
 
 package gov.nist.secauto.metaschema.core.metapath.function;
 
+/**
+ * FORG0001: Thrown when a cast operation fails because the supplied value
+ * cannot be converted to the target datatype.
+ */
 public class InvalidValueForCastFunctionException
     extends InvalidArgumentFunctionException {
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/JsonFunctionException.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/JsonFunctionException.java
@@ -9,6 +9,9 @@ import gov.nist.secauto.metaschema.core.metapath.IErrorCode;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * FOJS: Exceptions related to JSON function operations in XPath.
+ */
 public class JsonFunctionException
     extends FunctionMetapathError {
   @NonNull

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/UnidentifiedFunctionError.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/UnidentifiedFunctionError.java
@@ -10,6 +10,10 @@ import gov.nist.secauto.metaschema.core.metapath.IErrorCode;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * FOER0000: Thrown when an unidentified error occurs during function
+ * evaluation.
+ */
 public class UnidentifiedFunctionError
     extends FunctionMetapathError {
   @NonNull

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/impl/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/impl/package-info.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+/**
+ * Internal implementation classes for Metapath function support.
+ * <p>
+ * This package contains base classes and utilities used internally by the
+ * function library implementations in
+ * {@link gov.nist.secauto.metaschema.core.metapath.function.library}. These
+ * classes provide common functionality for function execution, argument
+ * conversion, and type checking based on the XPath 3.1 function calling
+ * conventions.
+ * <p>
+ * Key implementation classes:
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.function.impl.AbstractFunction}
+ * - Base class for all function implementations, providing argument conversion,
+ * type promotion, focus dependency handling, and result caching for
+ * deterministic functions</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.function.impl.OperationFunctions}
+ * - Utility class for registering mathematical and logical operation functions
+ * used by Metapath operators</li>
+ * </ul>
+ * <p>
+ * The {@code AbstractFunction} class handles critical aspects of XPath 3.1
+ * function semantics including:
+ * <ul>
+ * <li>Function conversion rules (atomization, type promotion, URI-to-string
+ * conversion)</li>
+ * <li>Argument sequence occurrence validation (zero-or-one, one-or-more,
+ * etc.)</li>
+ * <li>Focus item management for context-dependent functions</li>
+ * <li>Result caching for deterministic functions to avoid redundant
+ * computation</li>
+ * <li>Error handling with proper exception context registration</li>
+ * </ul>
+ * <p>
+ * This package is considered an implementation detail and should not be
+ * directly referenced by application code. Function implementations should
+ * extend {@code AbstractFunction} and be registered in a function library.
+ *
+ * @see gov.nist.secauto.metaschema.core.metapath.function
+ * @see gov.nist.secauto.metaschema.core.metapath.function.library
+ * @see <a href="https://www.w3.org/TR/xpath-31/#id-function-calls">XPath 3.1:
+ *      Function Calls</a>
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.function.impl;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/package-info.java
@@ -4,13 +4,63 @@
  */
 
 /**
- * Built-in Metapath functions based on the XPath 3.1 specification. Any XPath
- * functions that operate on an underlying XML document model (XDM) have been
- * adapted to work with an underlying Metaschema module-base model instead.
+ * Built-in Metapath function implementations based on the XPath 3.1
+ * specification.
  * <p>
- * The
- * {@link gov.nist.secauto.metaschema.core.metapath.function.library.MpRecurseDepth}
- * functions are new Metapath functions that are not present in XPath 3.1.
+ * This package provides concrete implementations of standard XPath 3.1
+ * functions adapted to work with the Metaschema document model. Functions that
+ * operate on an XML document model (XDM) in XPath have been adapted to work
+ * with the Metaschema module-based model instead.
+ *
+ * <h2>Function Categories</h2>
+ * <ul>
+ * <li><b>String Functions:</b> {@code fn:string}, {@code fn:concat},
+ * {@code fn:contains}, {@code fn:starts-with}, {@code fn:ends-with},
+ * {@code fn:substring}, {@code fn:normalize-space}, {@code fn:upper-case},
+ * {@code fn:lower-case}, {@code fn:tokenize}</li>
+ * <li><b>Numeric Functions:</b> {@code fn:abs}, {@code fn:ceiling},
+ * {@code fn:floor}, {@code fn:round}</li>
+ * <li><b>Sequence Functions:</b> {@code fn:count}, {@code fn:empty},
+ * {@code fn:exists}, {@code fn:head}, {@code fn:tail}, {@code fn:reverse},
+ * {@code fn:distinct-values}, {@code fn:index-of}, {@code fn:insert-before},
+ * {@code fn:remove}</li>
+ * <li><b>Date/Time Functions:</b> {@code fn:current-date},
+ * {@code fn:current-time}, {@code fn:current-dateTime},
+ * {@code fn:year-from-date}, {@code fn:month-from-date},
+ * {@code fn:day-from-date}, and related component extraction functions</li>
+ * <li><b>Boolean Functions:</b> {@code fn:boolean}, {@code fn:true},
+ * {@code fn:false}, {@code fn:not}</li>
+ * <li><b>Array Functions:</b> {@code array:size}, {@code array:get},
+ * {@code array:head}, {@code array:tail}, {@code array:reverse},
+ * {@code array:flatten}, {@code array:join}</li>
+ * <li><b>Map Functions:</b> {@code map:contains}, {@code map:get},
+ * {@code map:keys}, {@code map:put}, {@code map:remove}, {@code map:merge}</li>
+ * <li><b>Document Functions:</b> {@code fn:doc}, {@code fn:doc-available},
+ * {@code fn:base-uri}, {@code fn:document-uri}</li>
+ * </ul>
+ *
+ * <h2>Metaschema-Specific Extensions</h2>
+ * <p>
+ * This package also includes Metapath-specific functions not present in XPath
+ * 3.1:
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.function.library.MpRecurseDepth}
+ * - Recursively evaluates a Metapath expression to a specified depth</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.function.library.MpBase64Encode}
+ * - Encodes strings to Base64</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.function.library.MpBase64Decode}
+ * - Decodes Base64 strings</li>
+ * </ul>
+ *
+ * <h2>Function Registration</h2>
+ * <p>
+ * All built-in functions are registered in
+ * {@link gov.nist.secauto.metaschema.core.metapath.function.library.DefaultFunctionLibrary},
+ * which is loaded via the Java ServiceLoader mechanism.
+ *
+ * @see <a href="https://www.w3.org/TR/xpath-functions-31/">XPath and XQuery
+ *      Functions and Operators 3.1</a>
+ * @see gov.nist.secauto.metaschema.core.metapath.function
  */
 
 package gov.nist.secauto.metaschema.core.metapath.function.library;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/package-info.java
@@ -4,8 +4,44 @@
  */
 
 /**
- * Support for rendering paths to bound object nodes and Metaschema definitions
- * resulting from evaluating a Metapath.
+ * Provides the core framework for defining and executing Metapath functions.
+ * <p>
+ * This package contains the foundational interfaces and classes for
+ * implementing functions that can be called within Metapath expressions. It
+ * supports function registration, resolution, and execution based on the XPath
+ * 3.1 function model.
+ *
+ * <h2>Key Interfaces</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.function.IFunction} -
+ * Represents a function signature with its name, arguments, return type, and
+ * properties</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.function.IFunctionLibrary}
+ * - Provides access to a collection of function signatures</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.function.IFunctionExecutor}
+ * - Executes a function with provided arguments</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.function.IArgument} -
+ * Represents a single function argument signature</li>
+ * </ul>
+ *
+ * <h2>Key Classes</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.function.DefaultFunction}
+ * - Concrete implementation of a function signature</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.function.FunctionService}
+ * - Service-based function discovery using Java ServiceLoader</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.function.FunctionLibrary}
+ * - Registry for organizing and looking up functions</li>
+ * </ul>
+ *
+ * <h2>Usage</h2>
+ * <p>
+ * Functions are registered in libraries and resolved by name and arity during
+ * Metapath expression evaluation. The {@code FunctionService} loads function
+ * libraries using the Java ServiceLoader mechanism, making them available to
+ * the Metapath evaluator.
+ *
+ * @see gov.nist.secauto.metaschema.core.metapath.function.library
  */
 
 package gov.nist.secauto.metaschema.core.metapath.function;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/regex/RegexUtil.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/regex/RegexUtil.java
@@ -9,6 +9,9 @@ import java.util.regex.Pattern;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Utility methods for regular expression processing in Metapath functions.
+ */
 public final class RegexUtil {
 
   /**

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/regex/RegularExpressionMetapathException.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/regex/RegularExpressionMetapathException.java
@@ -11,6 +11,10 @@ import gov.nist.secauto.metaschema.core.metapath.MetapathException;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * MPRX: Exceptions related to regular expression processing in Metapath
+ * functions.
+ */
 public class RegularExpressionMetapathException
     extends MetapathException {
   @NonNull

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/regex/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/regex/package-info.java
@@ -4,8 +4,43 @@
  */
 
 /**
- * Provides regular expression support for use in implementing Metapath
- * functions based on the XPath 3.1 specification.
+ * Provides regular expression support for implementing Metapath functions.
+ * <p>
+ * This package contains utilities for processing regular expressions in
+ * accordance with the XPath 3.1 specification. It handles the translation of
+ * XPath-style regex flags to Java Pattern flags and provides error handling for
+ * invalid regular expressions.
+ *
+ * <h2>Key Classes</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.function.regex.RegexUtil}
+ * - Utility methods for parsing XPath regex flags and creating Java Pattern
+ * objects</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.function.regex.RegularExpressionMetapathException}
+ * - Exception thrown when regular expression processing fails</li>
+ * </ul>
+ *
+ * <h2>XPath Regex Flags</h2>
+ * <p>
+ * The package supports XPath 3.1 regex flags as defined in the specification:
+ * <ul>
+ * <li>{@code s} - Dot-all mode (. matches newlines)</li>
+ * <li>{@code m} - Multiline mode (^ and $ match line boundaries)</li>
+ * <li>{@code i} - Case-insensitive matching</li>
+ * <li>{@code x} - Comments mode (whitespace and comments ignored)</li>
+ * <li>{@code q} - Literal mode (metacharacters treated as ordinary
+ * characters)</li>
+ * </ul>
+ *
+ * <h2>Usage</h2>
+ * <p>
+ * This package is used internally by Metapath functions that perform pattern
+ * matching, such as {@code fn:matches}, {@code fn:replace}, and
+ * {@code fn:tokenize}.
+ *
+ * @see <a href="https://www.w3.org/TR/xpath-functions-31/#regex-syntax">XPath
+ *      3.1 Regular Expression Syntax</a>
+ * @see gov.nist.secauto.metaschema.core.metapath.function.library
  */
 
 package gov.nist.secauto.metaschema.core.metapath.function.regex;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/impl/AbstractMetapathExpression.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/impl/AbstractMetapathExpression.java
@@ -25,6 +25,14 @@ public abstract class AbstractMetapathExpression implements IMetapathExpression 
   @NonNull
   private final StaticContext staticContext;
 
+  /**
+   * Construct a new Metapath expression.
+   *
+   * @param path
+   *          the Metapath expression string
+   * @param context
+   *          the static context for expression evaluation
+   */
   public AbstractMetapathExpression(
       @NonNull String path,
       @NonNull StaticContext context) {
@@ -42,6 +50,11 @@ public abstract class AbstractMetapathExpression implements IMetapathExpression 
     return staticContext;
   }
 
+  /**
+   * Get the compiled expression tree for this Metapath expression.
+   *
+   * @return the root expression node
+   */
   @NonNull
   protected abstract IExpression getExpression();
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/impl/AbstractSequence.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/impl/AbstractSequence.java
@@ -46,11 +46,6 @@ public abstract class AbstractSequence<ITEM extends IItem>
     return (ISequence<T>) EMPTY;
   }
 
-  @Override
-  public List<ITEM> getValue() {
-    return asList();
-  }
-
   /**
    * Get the unmodifiable list backing this sequence.
    *

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/impl/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/impl/package-info.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+/**
+ * Internal implementation classes supporting the Metapath expression engine.
+ * <p>
+ * This package contains concrete implementations of core Metapath abstractions
+ * including expression compilation, evaluation, sequence management, and error
+ * handling. These classes are primarily used internally by the Metapath
+ * evaluator and are subject to change between releases.
+ * <p>
+ * Key implementation classes:
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.impl.MetapathExpression}
+ * - Main implementation of
+ * {@link gov.nist.secauto.metaschema.core.metapath.IMetapathExpression},
+ * providing expression compilation from Metapath strings using ANTLR4 parsing
+ * and CST generation</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.impl.LazyCompilationMetapathExpression}
+ * - Defers expression compilation until first evaluation for performance
+ * optimization</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.impl.AbstractSequence} -
+ * Base class for immutable sequence implementations backed by unmodifiable
+ * lists</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.impl.SingletonSequence}
+ * - Optimized sequence containing exactly one item</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.impl.SequenceN} -
+ * General-purpose sequence containing zero or more items</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.impl.StreamSequence} -
+ * Lazy sequence backed by a stream for efficient memory usage with large result
+ * sets</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.impl.ErrorCodeImpl} -
+ * Implementation of
+ * {@link gov.nist.secauto.metaschema.core.metapath.IErrorCode} for Metapath
+ * error reporting</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.impl.AbstractMapKey} -
+ * Base class for map key implementations used in Metapath map operations</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.impl.IFeatureCollectionFunctionItem}
+ * - Support for function items in map/array collections</li>
+ * </ul>
+ * <p>
+ * This package is considered an implementation detail and should not be
+ * directly referenced by application code. Use the public API in
+ * {@link gov.nist.secauto.metaschema.core.metapath} instead.
+ *
+ * @see gov.nist.secauto.metaschema.core.metapath
+ * @see gov.nist.secauto.metaschema.core.metapath.IMetapathExpression
+ * @see gov.nist.secauto.metaschema.core.metapath.item.ISequence
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.impl;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/ISequence.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/ISequence.java
@@ -54,15 +54,6 @@ public interface ISequence<ITEM extends IItem> extends List<ITEM>, ICollectionVa
   }
 
   /**
-   * Get the items in this sequence as a {@link List}.
-   *
-   * @return a list containing all the items of the sequence
-   */
-  @Deprecated(since = "2.2.0", forRemoval = true)
-  @NonNull
-  List<ITEM> getValue();
-
-  /**
    * Ensure the sequence is able to be iterated over multiple times.
    * <p>
    * This method can be used to ensure that the sequence can be streamed or

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/ItemUtils.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/ItemUtils.java
@@ -90,6 +90,8 @@ public final class ItemUtils {
    * The resulting sequence has items of the {@link IDocumentBasedNodeItem} to
    * allow for both module and document querying.
    *
+   * @param dynamicContext
+   *          the dynamic evaluation context
    * @param items
    *          the node items to get the document roots for
    * @return the document root node items

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/NcNameItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/NcNameItemImpl.java
@@ -15,6 +15,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * An implementation of a Metapath atomic item containing a non-colonized name
  * data value.
  */
+@SuppressWarnings("removal")
 @Deprecated(forRemoval = true, since = "0.7.0")
 public class NcNameItemImpl
     extends AbstractStringItem

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/package-info.java
@@ -1,0 +1,141 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+/**
+ * Concrete implementations of atomic item types for the Metapath type system.
+ * <p>
+ * This package provides the internal implementation classes for all atomic item
+ * types defined in
+ * {@link gov.nist.secauto.metaschema.core.metapath.item.atomic}. Each
+ * implementation class wraps a native Java value and provides Metapath
+ * operations, comparisons, and type conversions according to XPath 3.1
+ * semantics.
+ *
+ * <h2>Base Implementation Classes</h2>
+ * <p>
+ * The package includes abstract base classes that provide common functionality
+ * for related atomic types:
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.AbstractStringItem}
+ * - Base for string-based types providing whitespace normalization and string
+ * operations</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.AbstractIntegerItem}
+ * - Base for integer types providing numeric operations and conversions</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.AbstractDecimalItem}
+ * - Base for decimal numeric types</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.AbstractTemporalItem}
+ * - Base for date/time types</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.AbstractDateItem}
+ * - Base for date values with optional timezone</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.AbstractTimeItem}
+ * - Base for time values with optional timezone</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.AbstractDateTimeItem}
+ * - Base for combined date/time values</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.AbstractDurationItem}
+ * - Base for duration types</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.AbstractBinaryItem}
+ * - Base for binary data types (base64 and hex)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.AbstractUriItem}
+ * - Base for URI-related types</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.AbstractMarkupItem}
+ * - Base for markup content types</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.AbstractIPAddressItem}
+ * - Base for IP address types (v4 and v6)</li>
+ * </ul>
+ *
+ * <h2>String and Text Types</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.StringItemImpl}
+ * - Standard string values</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.TokenItemImpl}
+ * - Normalized whitespace strings</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.NcNameItemImpl}
+ * - XML NCNames (non-colonized names)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.MarkupLineItemImpl}
+ * - Single-line formatted text</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.MarkupMultiLineItemImpl}
+ * - Multi-line formatted text</li>
+ * </ul>
+ *
+ * <h2>Numeric Types</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.IntegerItemImpl}
+ * - Arbitrary-precision integer values</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.NonNegativeIntegerItemImpl}
+ * - Non-negative integers (zero or positive)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.PositiveIntegerItemImpl}
+ * - Strictly positive integers</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.DecimalItemImpl}
+ * - Decimal numeric values</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.BooleanItemImpl}
+ * - Boolean true/false values</li>
+ * </ul>
+ *
+ * <h2>Temporal Types</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.DateTimeWithTimeZoneItemImpl}
+ * - Date/time values with explicit timezone</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.DateTimeWithoutTimeZoneItemImpl}
+ * - Date/time values without timezone</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.DateWithTimeZoneItemImpl}
+ * - Date values with timezone</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.DateWithoutTimeZoneItemImpl}
+ * - Date values without timezone</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.TimeWithTimeZoneItemImpl}
+ * - Time values with timezone</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.TimeWithoutTimeZoneItemImpl}
+ * - Time values without timezone</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.DayTimeDurationItemImpl}
+ * - Durations measured in days/hours/minutes/seconds</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.YearMonthDurationItemImpl}
+ * - Durations measured in years/months</li>
+ * </ul>
+ *
+ * <h2>URI and Network Types</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.AnyUriItemImpl}
+ * - Arbitrary URI values</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.UriReferenceItemImpl}
+ * - URI references (absolute or relative)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.EmailAddressItemImpl}
+ * - Email address values</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.HostnameItemImpl}
+ * - DNS hostname values</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.IPv4AddressItemImpl}
+ * - IPv4 address values</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.IPv6AddressItemImpl}
+ * - IPv6 address values</li>
+ * </ul>
+ *
+ * <h2>Binary and Other Types</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.Base64BinaryItemImpl}
+ * - Base64-encoded binary data</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.HexBinaryItem}
+ * - Hex-encoded binary data</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.QNameItemImpl}
+ * - Qualified names with namespace</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.impl.UuidItemImpl}
+ * - UUID/GUID values</li>
+ * </ul>
+ * <p>
+ * Each implementation class is paired with a corresponding
+ * {@link gov.nist.secauto.metaschema.core.datatype.IDataTypeAdapter} that
+ * handles parsing from string representations, validation, and serialization
+ * for XML/JSON output.
+ * <p>
+ * This package is considered an implementation detail. Application code should
+ * use the public interfaces in
+ * {@link gov.nist.secauto.metaschema.core.metapath.item.atomic} and factory
+ * methods like {@code IStringItem.valueOf()} rather than directly instantiating
+ * these implementation classes.
+ *
+ * @see gov.nist.secauto.metaschema.core.metapath.item.atomic
+ * @see gov.nist.secauto.metaschema.core.datatype
+ * @see <a href="https://www.w3.org/TR/xpath-datamodel-31/#atomic-values">XPath
+ *      3.1 Data Model: Atomic Values</a>
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.item.atomic.impl;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/package-info.java
@@ -4,7 +4,58 @@
  */
 
 /**
- * Provides implementations of Metapath atomic data type items.
+ * Atomic item types representing indivisible values in the Metapath type
+ * system.
+ * <p>
+ * This package provides interfaces and implementations for atomic items, which
+ * are fundamental data values that cannot be decomposed into smaller units.
+ * Atomic items correspond to simple types in XPath 3.1 and include primitive
+ * types, numeric types, temporal types, and Metaschema-specific types.
+ * <p>
+ * Core atomic type interfaces include:
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.IAnyAtomicItem}
+ * - Base interface for all atomic items</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem}
+ * - Text values</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.INumericItem}
+ * - Numeric value base interface</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.IIntegerItem}
+ * - Integer values</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.IDecimalItem}
+ * - Decimal values</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.IBooleanItem}
+ * - Boolean values</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.IDateTimeItem}
+ * - Date and time values</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.IUriReferenceItem}
+ * - URI references</li>
+ * </ul>
+ * <p>
+ * Metaschema-specific atomic types include:
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.IMarkupItem}
+ * - Formatted text with inline markup</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.IEmailAddressItem}
+ * - Email addresses</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.IHostnameItem}
+ * - Hostnames</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.IIPAddressItem}
+ * - IP addresses (v4 and v6)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.atomic.IUuidItem} -
+ * UUIDs</li>
+ * </ul>
+ * <p>
+ * Atomic items support type conversions, comparisons, and operations as defined
+ * by the XPath 3.1 Functions and Operators specification. Each atomic type is
+ * backed by a corresponding
+ * {@link gov.nist.secauto.metaschema.core.datatype.IDataTypeAdapter} that
+ * handles value parsing, validation, and serialization.
+ *
+ * @see <a href="https://www.w3.org/TR/xpath-datamodel-31/#atomic-values">XPath
+ *      3.1 Data Model: Atomic Values</a>
+ * @see <a href="https://www.w3.org/TR/xpath-functions-31/">XPath 3.1 Functions
+ *      and Operators</a>
  */
 
 package gov.nist.secauto.metaschema.core.metapath.item.atomic;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/IMapKey.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/IMapKey.java
@@ -25,5 +25,12 @@ public interface IMapKey {
   @Override
   int hashCode();
 
+  /**
+   * Determine if this key is the same as another key.
+   *
+   * @param other
+   *          the other key to compare
+   * @return {@code true} if the keys are the same, or {@code false} otherwise
+   */
   boolean isSameKey(@NonNull IMapKey other);
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/impl/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/impl/package-info.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+/**
+ * Provides concrete implementations of Metapath function items (arrays and
+ * maps).
+ * <p>
+ * This package contains the implementation classes for the function item
+ * interfaces defined in
+ * {@link gov.nist.secauto.metaschema.core.metapath.item.function}. These
+ * classes provide immutable, efficient implementations of arrays and maps for
+ * use in Metapath expressions.
+ *
+ * <h2>Array Implementations</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.function.impl.AbstractArrayItem}
+ * - Base class for all array item implementations, providing common utility
+ * methods</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.function.impl.ArrayItemN}
+ * - Array implementation that supports an unbounded number of members</li>
+ * </ul>
+ *
+ * <h2>Map Implementations</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.function.impl.AbstractMapItem}
+ * - Base class for all map item implementations, providing common utility
+ * methods including the function call interface for map lookup</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.function.impl.MapItemN}
+ * - Map implementation that supports an unbounded number of entries</li>
+ * </ul>
+ *
+ * <h2>Map Key Implementations</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.function.impl.AbstractStringMapKey}
+ * - Base implementation for string-based map keys</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.function.impl.AbstractKeySpecifier}
+ * - Base implementation for key specifier that computes keys from items</li>
+ * </ul>
+ *
+ * <h2>Utility Classes</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.function.impl.ImmutableCollections}
+ * - Utility classes for creating immutable collection wrappers</li>
+ * </ul>
+ *
+ * <h2>Exceptions</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.function.impl.ArrayMetapathException}
+ * - Base exception for array-related errors</li>
+ * </ul>
+ *
+ * <h2>Implementation Notes</h2>
+ * <p>
+ * All array and map implementations in this package are immutable. Attempts to
+ * modify them through the {@link java.util.List} or {@link java.util.Map}
+ * interfaces will throw {@link UnsupportedOperationException}.
+ * <p>
+ * Array indices in the public API are 1-based (following XPath 3.1
+ * conventions), but are converted to 0-based indices internally when accessing
+ * the underlying Java collections.
+ *
+ * @see gov.nist.secauto.metaschema.core.metapath.item.function
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.item.function.impl;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/package-info.java
@@ -66,7 +66,8 @@
  * - Thrown when attempting to create an array with a negative length</li>
  * </ul>
  *
- * @see gov.nist.secauto.metaschema.core.metapath.item.function.impl
+ * @see gov.nist.secauto.metaschema.core.metapath.item.function.IArrayItem
+ * @see gov.nist.secauto.metaschema.core.metapath.item.function.IMapItem
  */
 
 package gov.nist.secauto.metaschema.core.metapath.item.function;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/package-info.java
@@ -1,0 +1,72 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+/**
+ * Provides support for Metapath function items, including arrays and maps.
+ * <p>
+ * This package implements the XPath 3.1 function item types, including arrays
+ * and maps. These are first-class values in Metapath that can be passed as
+ * arguments, returned from functions, and stored in sequences.
+ *
+ * <h2>Array Items</h2>
+ * <p>
+ * Arrays are ordered collections of values, where each value is a sequence.
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.function.IArrayItem}
+ * - The main interface for array items, implementing
+ * {@link java.util.List}</li>
+ * </ul>
+ * <p>
+ * Arrays are immutable once created and support operations like getting members
+ * by position (1-indexed), determining size, and conversion to sequences.
+ * Factory methods are provided for creating arrays with various numbers of
+ * members.
+ *
+ * <h2>Map Items</h2>
+ * <p>
+ * Maps are unordered collections of key-value pairs, where keys must be atomic
+ * items and values are sequences.
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.function.IMapItem}
+ * - The main interface for map items, implementing {@link java.util.Map}</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.function.IMapKey} -
+ * The key type used in maps, wrapping atomic items with proper equality
+ * semantics</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.function.IKeySpecifier}
+ * - Interface for computing map keys from items</li>
+ * </ul>
+ * <p>
+ * Maps are immutable once created and support operations like getting values by
+ * key, determining size, and merging maps. Factory methods are provided for
+ * creating maps with various numbers of entries.
+ *
+ * <h2>Map Key Types</h2>
+ * <p>
+ * Different atomic types use different equality semantics for map keys:
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.function.IStringMapKey}
+ * - Keys for string-based types (string, anyURI)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.function.IDecimalMapKey}
+ * - Keys for numeric types (decimal, integer, float, double)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.function.ITemporalMapKey}
+ * - Keys for date/time types (date, dateTime, time)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.function.ICalendarMapKey}
+ * - Keys for calendar-based types</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.function.IOpaqueMapKey}
+ * - Keys for types with identity-based equality (boolean, QName, etc.)</li>
+ * </ul>
+ *
+ * <h2>Exceptions</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.function.IndexOutOfBoundsArrayMetapathException}
+ * - Thrown when accessing an array with an out-of-bounds index</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.function.NegativeLengthArrayMetapathException}
+ * - Thrown when attempting to create an array with a negative length</li>
+ * </ul>
+ *
+ * @see gov.nist.secauto.metaschema.core.metapath.item.function.impl
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.item.function;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AbstractDefinitionNodeItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AbstractDefinitionNodeItem.java
@@ -6,6 +6,14 @@ import gov.nist.secauto.metaschema.core.model.INamedInstance;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * A base implementation of a node item backed by a Metaschema definition.
+ *
+ * @param <D>
+ *          the Java type of the definition
+ * @param <I>
+ *          the Java type of the instance
+ */
 public abstract class AbstractDefinitionNodeItem<D extends IDefinition, I extends INamedInstance>
     extends AbstractNodeItem
     implements IFeatureOrhpanedDefinitionNodeItem<D, I> {
@@ -13,6 +21,12 @@ public abstract class AbstractDefinitionNodeItem<D extends IDefinition, I extend
   @NonNull
   private final D definition;
 
+  /**
+   * Construct a new node item for the provided definition.
+   *
+   * @param definition
+   *          the Metaschema definition this node represents
+   */
   public AbstractDefinitionNodeItem(@NonNull D definition) {
     this.definition = definition;
   }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AbstractFlagInstanceNodeItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AbstractFlagInstanceNodeItem.java
@@ -13,6 +13,14 @@ public abstract class AbstractFlagInstanceNodeItem
     extends AbstractInstanceNodeItem<IFlagDefinition, IFlagInstance, IModelNodeItem<?, ?>>
     implements IFlagNodeItem {
 
+  /**
+   * Construct a new flag instance node item.
+   *
+   * @param instance
+   *          the flag instance this node represents
+   * @param parent
+   *          the parent node item containing this flag
+   */
   public AbstractFlagInstanceNodeItem(@NonNull IFlagInstance instance, @NonNull IModelNodeItem<?, ?> parent) {
     super(instance, parent);
   }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AbstractInstanceNodeItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AbstractInstanceNodeItem.java
@@ -7,6 +7,16 @@ import gov.nist.secauto.metaschema.core.model.INamedInstance;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * A base implementation of a node item backed by a Metaschema instance.
+ *
+ * @param <D>
+ *          the Java type of the definition
+ * @param <I>
+ *          the Java type of the instance
+ * @param <P>
+ *          the Java type of the parent node item
+ */
 public abstract class AbstractInstanceNodeItem<
     D extends IDefinition,
     I extends INamedInstance,
@@ -19,6 +29,14 @@ public abstract class AbstractInstanceNodeItem<
   @NonNull
   private final P parent;
 
+  /**
+   * Construct a new instance node item.
+   *
+   * @param instance
+   *          the Metaschema instance this node represents
+   * @param parent
+   *          the parent node item containing this instance
+   */
   public AbstractInstanceNodeItem(
       @NonNull I instance,
       @NonNull P parent) {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AbstractNodeItemFactory.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AbstractNodeItemFactory.java
@@ -23,6 +23,10 @@ import java.util.stream.Stream;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * A base implementation of a node item factory that creates node items for
+ * Metaschema definitions and instances.
+ */
 public abstract class AbstractNodeItemFactory implements INodeItemFactory, INodeItemGenerator {
   @Override
   public IDocumentNodeItem newDocumentNodeItem(

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AbstractOrphanedDefinitionNodeItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AbstractOrphanedDefinitionNodeItem.java
@@ -11,6 +11,15 @@ import java.net.URI;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * A base implementation of a node item for a Metaschema definition that exists
+ * without a parent context (orphaned).
+ *
+ * @param <D>
+ *          the Java type of the definition
+ * @param <I>
+ *          the Java type of the instance
+ */
 public abstract class AbstractOrphanedDefinitionNodeItem<D extends IDefinition, I extends INamedInstance>
     extends AbstractDefinitionNodeItem<D, I> {
 
@@ -19,6 +28,15 @@ public abstract class AbstractOrphanedDefinitionNodeItem<D extends IDefinition, 
   @NonNull
   private final StaticContext staticContext;
 
+  /**
+   * Construct a new orphaned definition node item.
+   *
+   * @param definition
+   *          the Metaschema definition this node represents
+   * @param baseUri
+   *          the base URI for resolving relative references, or {@code null} if
+   *          not applicable
+   */
   public AbstractOrphanedDefinitionNodeItem(
       @NonNull D definition,
       @Nullable URI baseUri) {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AbstractRecursionPreventingNodeItemVisitor.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/AbstractRecursionPreventingNodeItemVisitor.java
@@ -3,6 +3,15 @@ package gov.nist.secauto.metaschema.core.metapath.item.node;
 
 import gov.nist.secauto.metaschema.core.model.IAssemblyDefinition;
 
+/**
+ * A node item visitor that prevents infinite recursion when traversing assembly
+ * nodes by detecting and avoiding cycles in the node hierarchy.
+ *
+ * @param <CONTEXT>
+ *          the Java type of the visiting context
+ * @param <RESULT>
+ *          the Java type of the visiting result
+ */
 public abstract class AbstractRecursionPreventingNodeItemVisitor<CONTEXT, RESULT>
     extends AbstractNodeItemVisitor<CONTEXT, RESULT> {
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/IAssemblyInstanceGroupedNodeItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/IAssemblyInstanceGroupedNodeItem.java
@@ -3,7 +3,10 @@ package gov.nist.secauto.metaschema.core.metapath.item.node;
 
 import gov.nist.secauto.metaschema.core.metapath.format.IPathFormatter;
 
-//REFACTOR: Check if this is used, delete?
+/**
+ * Represents a Metapath assembly node item for a grouped assembly instance.
+ */
+// REFACTOR: Check if this is used, delete?
 public interface IAssemblyInstanceGroupedNodeItem
     extends IAssemblyNodeItem {
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/IAtomicValuedNodeItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/IAtomicValuedNodeItem.java
@@ -6,6 +6,9 @@ import gov.nist.secauto.metaschema.core.metapath.type.IAtomicOrUnionType;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Represents a Metapath node item that has an atomic value.
+ */
 public interface IAtomicValuedNodeItem extends IAtomicValuedItem, INodeItem {
   /**
    * Get the item type of the item's value.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/IDocumentBasedNodeItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/IDocumentBasedNodeItem.java
@@ -8,6 +8,9 @@ import java.net.URI;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * Represents a Metapath node item that is associated with a document.
+ */
 public interface IDocumentBasedNodeItem extends INodeItem {
 
   @Override

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/IFeatureNoDataAtomicValuedItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/IFeatureNoDataAtomicValuedItem.java
@@ -7,6 +7,10 @@ import gov.nist.secauto.metaschema.core.metapath.item.atomic.IAtomicValuedItem;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * A feature interface representing an atomic-valued item that has no associated
+ * value data.
+ */
 public interface IFeatureNoDataAtomicValuedItem extends IFeatureNoDataValuedItem, IAtomicValuedItem {
   @Override
   @Nullable

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/IModelNodeItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/IModelNodeItem.java
@@ -9,6 +9,15 @@ import java.util.stream.Stream;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Represents a Metapath node item for a Metaschema model instance (assembly or
+ * field).
+ *
+ * @param <D>
+ *          the Java type of the model definition
+ * @param <I>
+ *          the Java type of the model instance
+ */
 public interface IModelNodeItem<D extends IModelDefinition, I extends INamedModelInstance>
     extends IDefinitionNodeItem<D, I> {
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/INodeItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/INodeItem.java
@@ -27,10 +27,15 @@ public interface INodeItem extends IItem, IPathSegment, INodeItemVisitable {
    * The type of node.
    */
   enum NodeType {
+    /** A Metaschema module node. */
     MODULE,
+    /** A document node representing the root of a data instance. */
     DOCUMENT,
+    /** An assembly node containing fields and other assemblies. */
     ASSEMBLY,
+    /** A field node containing flags and a value. */
     FIELD,
+    /** A flag node containing a simple value. */
     FLAG;
   }
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/INodeItemGenerator.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/INodeItemGenerator.java
@@ -8,6 +8,13 @@ import java.util.function.Supplier;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Generates child node items for Metapath node items.
+ * <p>
+ * Provides methods to create lazy suppliers that generate child node items for
+ * field, assembly, and module node items in both data model and metaschema
+ * model contexts.
+ */
 public interface INodeItemGenerator {
 
   /**

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/INodeItemVisitable.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/INodeItemVisitable.java
@@ -3,6 +3,9 @@ package gov.nist.secauto.metaschema.core.metapath.item.node;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Marks a node item as visitable by a {@link INodeItemVisitor}.
+ */
 public interface INodeItemVisitable {
   /**
    * A visitor callback.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/NodeItemKind.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/NodeItemKind.java
@@ -15,7 +15,16 @@ public enum NodeItemKind {
    * (@link {@link IDocumentNodeItem}}).
    */
   DOCUMENT,
+  /**
+   * An {@link INodeItem} representing an assembly instance.
+   */
   ASSEMBLY,
+  /**
+   * An {@link INodeItem} representing a field instance.
+   */
   FIELD,
+  /**
+   * An {@link INodeItem} representing a flag instance.
+   */
   FLAG;
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/RecursionCollectingNodeItemVisitor.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/RecursionCollectingNodeItemVisitor.java
@@ -18,6 +18,14 @@ import java.util.stream.Collectors;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Analyzes a Metaschema module to identify assembly definitions that are
+ * recursive.
+ * <p>
+ * This visitor traverses the module structure and tracks assembly definitions
+ * that contain themselves as descendants, collecting locations where recursion
+ * occurs.
+ */
 public class RecursionCollectingNodeItemVisitor
     extends AbstractRecursionPreventingNodeItemVisitor<Void, Void> {
 
@@ -74,6 +82,10 @@ public class RecursionCollectingNodeItemVisitor
     return null;
   }
 
+  /**
+   * Records information about an assembly definition, including whether it is
+   * recursive and where it is used.
+   */
   public static final class AssemblyRecord {
     @NonNull
     private final IAssemblyDefinition definition;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/package-info.java
@@ -1,7 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
 /**
- * This package provides the Metapath node item implementations and interfaces
- * needed to perform Metapath queries over both Metaschema models and data
- * represented using a Metaschema model.
+ * Node item types representing structured data in the Metapath type system.
+ * <p>
+ * This package provides interfaces and implementations for node items, which
+ * form tree-structured graphs representing both Metaschema models (module
+ * definitions) and data instances conforming to those models. Node items enable
+ * navigation and querying of hierarchical data using Metapath expressions.
+ * <p>
+ * Core node type interfaces include:
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.node.INodeItem} -
+ * Base interface for all node items</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.node.IDocumentNodeItem}
+ * - Document root node representing a data instance</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.node.IAssemblyNodeItem}
+ * - Assembly nodes containing nested structures</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.node.IFieldNodeItem}
+ * - Field nodes containing values and flags</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.node.IFlagNodeItem}
+ * - Flag nodes containing simple values</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.node.IModuleNodeItem}
+ * - Module definition nodes representing Metaschema schemas</li>
+ * </ul>
+ * <p>
+ * Node items support:
+ * <ul>
+ * <li>XPath-style navigation (parent, child, ancestor, descendant
+ * relationships)</li>
+ * <li>Document order traversal for predictable query results</li>
+ * <li>Access to typed values through
+ * {@link gov.nist.secauto.metaschema.core.metapath.item.node.IAtomicValuedNodeItem}</li>
+ * <li>Visitor pattern traversal via
+ * {@link gov.nist.secauto.metaschema.core.metapath.item.node.INodeItemVisitor}</li>
+ * <li>Factory-based creation through
+ * {@link gov.nist.secauto.metaschema.core.metapath.item.node.INodeItemFactory}</li>
+ * </ul>
+ * <p>
+ * Node items integrate with Metaschema model definitions in
+ * {@link gov.nist.secauto.metaschema.core.model}, providing runtime
+ * representations that can be queried using Metapath expressions. Each node
+ * maintains references to its definition (schema-level metadata) and its
+ * position within the document tree.
+ *
+ * @see <a href="https://www.w3.org/TR/xpath-datamodel-31/#Node">XPath 3.1 Data
+ *      Model: Nodes</a>
+ * @see gov.nist.secauto.metaschema.core.model
  */
 
 package gov.nist.secauto.metaschema.core.metapath.item.node;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/package-info.java
@@ -4,8 +4,33 @@
  */
 
 /**
- * The Metapath type system, which overlays the Metaschema type system defined
- * in {@link gov.nist.secauto.metaschema.core.datatype}.
+ * Core interfaces and classes for the Metapath item type system.
+ * <p>
+ * This package provides the foundational abstractions for representing values
+ * in Metapath expressions, aligning with the XPath 3.1 Data Model. All Metapath
+ * values are either items or sequences of items.
+ * <p>
+ * Key interfaces include:
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.IItem} - Base
+ * interface for all Metapath items (atomic values, nodes, functions, arrays,
+ * and maps)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.ISequence} -
+ * Ordered collection of items representing expression evaluation results</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.ICollectionValue} -
+ * Common interface for values that can be stored in arrays or maps</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.item.IItemVisitor} -
+ * Visitor pattern interface for traversing item hierarchies</li>
+ * </ul>
+ * <p>
+ * The type system integrates with Metaschema data types defined in
+ * {@link gov.nist.secauto.metaschema.core.datatype} while extending them to
+ * support the full XPath 3.1 type hierarchy including atomic items, node items,
+ * and function items.
+ *
+ * @see <a href="https://www.w3.org/TR/xpath-31/">XPath 3.1 Specification</a>
+ * @see <a href="https://www.w3.org/TR/xpath-datamodel-31/">XPath 3.1 Data
+ *      Model</a>
  */
 
 package gov.nist.secauto.metaschema.core.metapath.item;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/package-info.java
@@ -4,7 +4,52 @@
  */
 
 /**
- * Support for working with Metapath expressions.
+ * Provides the core Metapath expression language implementation.
+ * <p>
+ * Metapath is an XPath 3.1-based expression language for querying and
+ * navigating Metaschema-based data models. This package provides the primary
+ * API for compiling and evaluating Metapath expressions against Metaschema
+ * content.
+ * <p>
+ * Key interfaces and classes:
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.IMetapathExpression} -
+ * Main interface for compiled Metapath expressions with methods for compilation
+ * and evaluation</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.StaticContext} - XPath
+ * 3.1 static context containing namespace bindings, function resolver, and
+ * other compile-time information</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.DynamicContext} - XPath
+ * 3.1 dynamic context containing runtime state such as focus items, variables,
+ * and current date/time</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.MetapathException} -
+ * Base exception type for all Metapath evaluation errors</li>
+ * </ul>
+ * <p>
+ * Typical usage pattern:
+ *
+ * <pre>{@code
+ * // Compile a Metapath expression
+ * IMetapathExpression expr = IMetapathExpression.compile("//assembly[@name='foo']");
+ *
+ * // Evaluate against a document node
+ * ISequence<?> results = expr.evaluate(documentNode);
+ *
+ * // Or evaluate with type conversion
+ * Boolean result = expr.evaluateAs(documentNode, ResultType.BOOLEAN);
+ * }</pre>
+ * <p>
+ * This package also contains subpackages for:
+ * <ul>
+ * <li>{@code antlr} - ANTLR4-based parser infrastructure</li>
+ * <li>{@code cst} - Concrete syntax tree expression implementations</li>
+ * <li>{@code format} - Path formatting utilities</li>
+ * <li>{@code function} - Metapath function library</li>
+ * <li>{@code item} - Metapath item types (atomic values, nodes, sequences)</li>
+ * <li>{@code type} - Metapath type system</li>
+ * </ul>
+ *
+ * @see <a href="https://www.w3.org/TR/xpath-31/">XPath 3.1 Specification</a>
  */
 
 package gov.nist.secauto.metaschema.core.metapath;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/type/InvalidTypeMetapathException.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/type/InvalidTypeMetapathException.java
@@ -22,6 +22,10 @@ public class InvalidTypeMetapathException
    */
   private static final long serialVersionUID = 1L;
 
+  /**
+   * The item associated with this invalid type error, or {@code null} if no
+   * specific item was provided.
+   */
   @Nullable
   private final IItem item;
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/type/impl/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/type/impl/package-info.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+/**
+ * Provides concrete implementations of the Metapath type system interfaces.
+ * <p>
+ * This package contains the implementation classes for the Metapath type system
+ * defined in {@link gov.nist.secauto.metaschema.core.metapath.type}. These
+ * classes provide the runtime type checking, validation, and testing mechanisms
+ * used throughout the Metapath implementation.
+ *
+ * <h2>Item Type Implementations</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.type.impl.AnyItemType} -
+ * A type that matches any item (item())</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.type.impl.AnyFunctionItemType}
+ * - A type that matches any function item</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.type.impl.AbstractItemType}
+ * - Base class for custom item type implementations</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.type.impl.NonAdapterAtomicItemType}
+ * - Item type for atomic types that are not backed by data type adapters</li>
+ * </ul>
+ *
+ * <h2>Node Kind Tests</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.type.impl.AnyKindTest} -
+ * Singleton tests for matching any node, document, assembly, field, or
+ * flag</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.type.impl.AbstractDefinitionTest}
+ * - Base class for tests that match nodes by name and/or definition type</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.type.impl.KindDocumentTestImpl}
+ * - Tests for matching document nodes with optional root element type
+ * constraints</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.type.impl.KindAssemblyTestImpl}
+ * - Tests for matching assembly nodes by name and/or type</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.type.impl.KindFieldTestImpl}
+ * - Tests for matching field nodes by name and/or type</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.type.impl.KindFlagTestImpl}
+ * - Tests for matching flag nodes by name and/or type</li>
+ * </ul>
+ *
+ * <h2>Collection Type Tests</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.type.impl.ArrayTestImpl}
+ * - Tests for matching array items with optional member type constraints</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.type.impl.MapTestImpl} -
+ * Tests for matching map items with key and value type constraints</li>
+ * </ul>
+ *
+ * <h2>Sequence Types</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.type.impl.SequenceTypeImpl}
+ * - Implementation of sequence type testing with occurrence validation</li>
+ * </ul>
+ *
+ * <h2>Type Constants</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.type.impl.TypeConstants}
+ * - Provides singleton instances for abstract atomic types (any-atomic-type,
+ * duration, ip-address, numeric)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.type.impl.DynamicTypeSupport}
+ * - Utility methods for dynamic type operations</li>
+ * </ul>
+ *
+ * @see gov.nist.secauto.metaschema.core.metapath.type
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.type.impl;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/type/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/type/package-info.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+/**
+ * Provides support for Metapath type system and sequence type testing.
+ * <p>
+ * This package implements the Metapath type system, which is based on the XPath
+ * 3.1 type system. It provides mechanisms for type testing, type matching, and
+ * type validation of Metapath items and sequences.
+ * <p>
+ * The core interfaces define type information that can be used to:
+ * <ul>
+ * <li>Test if an item or sequence matches a specific type</li>
+ * <li>Validate sequences against expected types and cardinality</li>
+ * <li>Perform type casting and conversion operations</li>
+ * <li>Generate type signatures for error messages and debugging</li>
+ * </ul>
+ *
+ * <h2>Key Interfaces</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.type.IItemType} - The
+ * base type interface for all item types, providing factory methods for
+ * creating tests for atomic types, node kinds, functions, arrays, and maps</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.type.ISequenceType} -
+ * Represents a sequence type with cardinality constraints (occurrence
+ * indicators)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.type.IKindTest} - A
+ * specialized item type for testing node items by their kind (document,
+ * assembly, field, flag)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.type.IAtomicOrUnionType}
+ * - Represents atomic types and union types that can be used for type testing
+ * and value conversion</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.type.IArrayTest} -
+ * Specialized item type for testing array items with member type
+ * constraints</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.type.IMapTest} -
+ * Specialized item type for testing map items with key and value type
+ * constraints</li>
+ * </ul>
+ *
+ * <h2>Supporting Classes</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.type.Occurrence} - Enum
+ * representing sequence cardinality indicators (zero, one, zero-or-one,
+ * one-or-more, zero-or-more)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.type.DataTypeItemType} -
+ * Item type implementation for Metaschema data types backed by adapters</li>
+ * </ul>
+ *
+ * <h2>Exceptions</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.type.TypeMetapathException}
+ * - Base exception for type-related errors</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath.type.InvalidTypeMetapathException}
+ * - Thrown when a value does not match the expected type</li>
+ * </ul>
+ *
+ * @see gov.nist.secauto.metaschema.core.metapath.type.impl
+ */
+
+package gov.nist.secauto.metaschema.core.metapath.type;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/type/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/type/package-info.java
@@ -57,7 +57,8 @@
  * - Thrown when a value does not match the expected type</li>
  * </ul>
  *
- * @see gov.nist.secauto.metaschema.core.metapath.type.impl
+ * @see gov.nist.secauto.metaschema.core.metapath.type.IItemType
+ * @see gov.nist.secauto.metaschema.core.metapath.type.ISequenceType
  */
 
 package gov.nist.secauto.metaschema.core.metapath.type;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/AbstractInstance.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/AbstractInstance.java
@@ -7,6 +7,13 @@ package gov.nist.secauto.metaschema.core.model;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Base implementation of {@link IInstance} providing parent container
+ * management.
+ *
+ * @param <P>
+ *          the Java type of the parent container
+ */
 public abstract class AbstractInstance<P extends IContainer> implements IInstance {
   @NonNull
   private final P parent;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/AbstractLoader.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/AbstractLoader.java
@@ -28,6 +28,17 @@ import java.util.stream.Collectors;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Base implementation of {@link ILoader} providing resource loading with
+ * caching and cycle detection.
+ * <p>
+ * This loader maintains a cache of loaded resources keyed by URI to avoid
+ * redundant parsing. It tracks visited resources during import chains to detect
+ * and prevent circular dependencies.
+ *
+ * @param <T>
+ *          the Java type of the resource being loaded
+ */
 public abstract class AbstractLoader<T> implements ILoader<T> {
   private static final Logger LOGGER = LogManager.getLogger(AbstractLoader.class);
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/AbstractNamedInstance.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/AbstractNamedInstance.java
@@ -12,6 +12,16 @@ import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import nl.talsmasoftware.lazy4j.Lazy;
 
+/**
+ * Base implementation of {@link INamedInstance} providing qualified name
+ * management.
+ * <p>
+ * This class lazily computes and caches both the instance's effective qualified
+ * name and its referenced definition qualified name.
+ *
+ * @param <PARENT>
+ *          the Java type of the parent container
+ */
 public abstract class AbstractNamedInstance<
     PARENT extends IContainer>
     extends AbstractInstance<PARENT>

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/AbstractResourceResolver.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/AbstractResourceResolver.java
@@ -7,6 +7,13 @@ package gov.nist.secauto.metaschema.core.model;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Base implementation of {@link IResourceResolver} providing URI resolution
+ * support.
+ * <p>
+ * This class maintains an optional {@link IUriResolver} that can be configured
+ * to customize URI resolution behavior.
+ */
 public class AbstractResourceResolver implements IResourceResolver {
   /**
    * An {@link IUriResolver} is not provided by default.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/FlagContainerBuilder.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/FlagContainerBuilder.java
@@ -22,6 +22,16 @@ import java.util.Map;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * Default implementation of {@link IFlagContainerBuilder}.
+ * <p>
+ * This builder collects flag instances and constructs an immutable flag
+ * container. It handles duplicate flags (shadowing) by logging errors and using
+ * the last instance encountered. An optional JSON key flag can be specified.
+ *
+ * @param <T>
+ *          the Java type of flag instances
+ */
 public class FlagContainerBuilder<T extends IFlagInstance> implements IFlagContainerBuilder<T> {
   private static final Logger LOGGER = LogManager.getLogger(FlagContainerBuilder.class);
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IAssemblyDefinition.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IAssemblyDefinition.java
@@ -13,8 +13,18 @@ import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * Represents an assembly definition in a Metaschema module.
+ * <p>
+ * An assembly is a complex structured data object that may contain flags,
+ * fields, and other nested assemblies. Assembly definitions may be designated
+ * as root elements for documents.
+ */
 public interface IAssemblyDefinition
     extends IModelDefinition, IContainerModelAssembly, IAssembly, IFeatureModelConstrained {
+  /**
+   * The qualified name for the model property in Metaschema.
+   */
   IEnhancedQName MODEL_QNAME = IEnhancedQName.of(MetaschemaConstants.METASCHEMA_NAMESPACE, "model");
 
   /**

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IAssemblyInstance.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IAssemblyInstance.java
@@ -5,8 +5,19 @@
 
 package gov.nist.secauto.metaschema.core.model;
 
+/**
+ * Represents an assembly instance within another assembly definition.
+ * <p>
+ * An assembly instance references an assembly definition and specifies how that
+ * assembly is used within its containing assembly.
+ */
 public interface IAssemblyInstance extends IAssembly, INamedModelInstance {
 
+  /**
+   * Retrieves the assembly definition referenced by this instance.
+   *
+   * @return the assembly definition
+   */
   @Override
   IAssemblyDefinition getDefinition();
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IAssemblyInstanceAbsolute.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IAssemblyInstanceAbsolute.java
@@ -7,6 +7,13 @@ package gov.nist.secauto.metaschema.core.model;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Represents an assembly instance that appears directly within an assembly
+ * definition.
+ * <p>
+ * An absolute assembly instance is not part of a choice or other grouping
+ * construct, and has its own distinct cardinality settings.
+ */
 public interface IAssemblyInstanceAbsolute extends IAssemblyInstance, INamedModelInstanceAbsolute {
 
   /**

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IAssemblyInstanceGrouped.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IAssemblyInstanceGrouped.java
@@ -7,6 +7,12 @@ package gov.nist.secauto.metaschema.core.model;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Represents an assembly instance that appears within a choice or other
+ * grouping construct.
+ * <p>
+ * Grouped assembly instances inherit cardinality from their containing group.
+ */
 public interface IAssemblyInstanceGrouped extends INamedModelInstanceGrouped, IAssemblyInstance {
 
   /**

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IConstraintLoader.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IConstraintLoader.java
@@ -9,6 +9,12 @@ import gov.nist.secauto.metaschema.core.model.constraint.IConstraintSet;
 
 import java.util.List;
 
+/**
+ * Provides loading capabilities for Metaschema constraint sets.
+ * <p>
+ * Loads constraint definitions that can be applied to Metaschema modules to
+ * enforce validation rules.
+ */
 public interface IConstraintLoader extends ILoader<List<IConstraintSet>> {
   // no additional methods
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IContainer.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IContainer.java
@@ -5,6 +5,12 @@
 
 package gov.nist.secauto.metaschema.core.model;
 
+/**
+ * Represents a model element that can contain child instances.
+ * <p>
+ * This interface is implemented by model definitions that may contain flags,
+ * fields, or assemblies as part of their structure.
+ */
 public interface IContainer {
   /**
    * Identifies if the container allows child instances or not.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IContainerModelAbsolute.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IContainerModelAbsolute.java
@@ -7,6 +7,13 @@ package gov.nist.secauto.metaschema.core.model;
 
 import java.util.Collection;
 
+/**
+ * Represents a model container with absolute (non-grouped) instances.
+ * <p>
+ * Absolute instances are identified by their effective name (index) rather than
+ * a use name. This interface narrows the return types of
+ * {@link IContainerModel} methods to absolute instance types.
+ */
 public interface IContainerModelAbsolute extends IContainerModel {
 
   @Override

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IContainerModelAssembly.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IContainerModelAssembly.java
@@ -11,6 +11,13 @@ import java.util.Map;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * Represents a model container for assembly definitions.
+ * <p>
+ * Assembly containers extend absolute containers by adding support for choice
+ * instances and choice group instances, which allow for alternative content
+ * models within the assembly.
+ */
 public interface IContainerModelAssembly extends IContainerModelAbsolute {
 
   /**

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IContainerModelGrouped.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IContainerModelGrouped.java
@@ -10,6 +10,13 @@ import java.util.Collection;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * Represents a model container with grouped instances.
+ * <p>
+ * Grouped instances are part of a choice group and share a common group-as
+ * name. This interface narrows the return types of {@link IContainerModel}
+ * methods to grouped instance types.
+ */
 public interface IContainerModelGrouped extends IContainerModel {
 
   @Override

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IContainerModelGrouped.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IContainerModelGrouped.java
@@ -31,7 +31,7 @@ public interface IContainerModelGrouped extends IContainerModel {
   /**
    * Get all named model instances within the container.
    *
-   * @return an ordered mapping of use name to model instance
+   * @return the named model instances in this container
    */
   @Override
   @NonNull
@@ -53,7 +53,7 @@ public interface IContainerModelGrouped extends IContainerModel {
   /**
    * Get all field instances within the container.
    *
-   * @return a mapping of use name to field instance
+   * @return the field instances in this container
    */
   @Override
   @NonNull
@@ -75,7 +75,7 @@ public interface IContainerModelGrouped extends IContainerModel {
   /**
    * Get all assembly instances within the container.
    *
-   * @return a mapping of use name to assembly instance
+   * @return the assembly instances in this container
    */
   @Override
   @NonNull

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IDefinition.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IDefinition.java
@@ -13,6 +13,13 @@ import java.util.Locale;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * Represents a definition of a flag, field, or assembly in a Metaschema module.
+ * <p>
+ * Definitions are reusable components that specify the structure and
+ * constraints for data elements. They can be referenced by instances or defined
+ * inline.
+ */
 public interface IDefinition extends INamedModelElement, IAttributable, IFeatureValueConstrained {
   /**
    * Describes the visibility of a definition to other modules.
@@ -28,6 +35,9 @@ public interface IDefinition extends INamedModelElement, IAttributable, IFeature
     PUBLIC;
   }
 
+  /**
+   * The default module scope for definitions.
+   */
   @NonNull
   ModuleScope DEFAULT_MODULE_SCOPE = ModuleScope.PUBLIC;
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IDescribable.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IDescribable.java
@@ -9,6 +9,12 @@ import gov.nist.secauto.metaschema.core.datatype.markup.MarkupLine;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * Represents a model element that has a formal name and description.
+ * <p>
+ * This interface provides access to human-readable documentation properties
+ * that describe the purpose and usage of a model element.
+ */
 public interface IDescribable {
   /**
    * The formal display name.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IFeatureContainerModelAssembly.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IFeatureContainerModelAssembly.java
@@ -10,6 +10,27 @@ import java.util.Map;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Provides assembly-specific container model functionality through delegation.
+ * <p>
+ * This interface extends absolute container model features with
+ * assembly-specific capabilities, including choice and choice group instances.
+ * Implementations delegate to an {@link IContainerModelAssemblySupport}
+ * instance.
+ *
+ * @param <MI>
+ *          the Java type of model instances
+ * @param <NMI>
+ *          the Java type of named model instances
+ * @param <FI>
+ *          the Java type of field instances
+ * @param <AI>
+ *          the Java type of assembly instances
+ * @param <CI>
+ *          the Java type of choice instances
+ * @param <CGI>
+ *          the Java type of choice group instances
+ */
 public interface IFeatureContainerModelAssembly<
     MI extends IModelInstanceAbsolute,
     NMI extends INamedModelInstanceAbsolute,

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IFeatureContainerModelGrouped.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IFeatureContainerModelGrouped.java
@@ -9,6 +9,19 @@ import java.util.Collection;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Provides grouped container model functionality through delegation.
+ * <p>
+ * This interface provides default implementations for grouped container model
+ * operations by delegating to an {@link IContainerModelSupport} instance.
+ *
+ * @param <NMI>
+ *          the Java type of named model instances
+ * @param <FI>
+ *          the Java type of field instances
+ * @param <AI>
+ *          the Java type of assembly instances
+ */
 public interface IFeatureContainerModelGrouped<
     NMI extends INamedModelInstanceGrouped,
     FI extends IFieldInstanceGrouped,

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IFeatureDefinitionReferenceInstance.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IFeatureDefinitionReferenceInstance.java
@@ -10,6 +10,19 @@ import gov.nist.secauto.metaschema.core.datatype.markup.MarkupLine;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * Represents an instance that references a definition.
+ * <p>
+ * This interface provides common functionality for instances that reference
+ * definitions rather than defining their own inline structure. It handles
+ * effective value resolution by delegating to the referenced definition when
+ * the instance does not override a value.
+ *
+ * @param <DEFINITION>
+ *          the Java type of the referenced definition
+ * @param <INSTANCE>
+ *          the Java type of the inline instance (when definition is inline)
+ */
 public interface IFeatureDefinitionReferenceInstance<
     DEFINITION extends IDefinition,
     INSTANCE extends INamedInstance>

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IFeatureValueless.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IFeatureValueless.java
@@ -5,6 +5,12 @@
 
 package gov.nist.secauto.metaschema.core.model;
 
+/**
+ * Represents an instance that has no value.
+ * <p>
+ * This interface marks instances that do not produce a value when queried,
+ * always returning {@code null} from {@link #getValue(Object)}.
+ */
 // REFACTOR: rename to IFeatureValuelessInstance
 public interface IFeatureValueless extends IInstanceAbsolute {
   @Override

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IFieldDefinition.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IFieldDefinition.java
@@ -8,6 +8,13 @@ package gov.nist.secauto.metaschema.core.model;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * Represents a field definition in a Metaschema module.
+ * <p>
+ * A field is a structured data object that may have flags (attributes) and a
+ * simple typed value. Field definitions specify the allowed flags, value type,
+ * and JSON serialization behavior for field instances.
+ */
 public interface IFieldDefinition extends IModelDefinition, IValuedDefinition, IField {
 
   @Override

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IFieldDefinition.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IFieldDefinition.java
@@ -54,7 +54,7 @@ public interface IFieldDefinition extends IModelDefinition, IValuedDefinition, I
   }
 
   /**
-   * Retrieves the flag instance who's value will be used as the "value key".
+   * Retrieves the flag instance whose value will be used as the "value key".
    *
    * @return the configured flag instance, or {@code null} if a flag is not
    *         configured as the "value key"

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IFieldInstance.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IFieldInstance.java
@@ -5,9 +5,23 @@
 
 package gov.nist.secauto.metaschema.core.model;
 
+/**
+ * Represents a field instance within an assembly definition.
+ * <p>
+ * A field instance references a field definition and specifies how that field
+ * is used within its containing assembly, including XML wrapping behavior.
+ */
 public interface IFieldInstance extends IField, INamedModelInstance, IValuedInstance {
+  /**
+   * The default value for whether a field is wrapped in XML.
+   */
   boolean DEFAULT_FIELD_IN_XML_WRAPPED = true;
 
+  /**
+   * Retrieves the field definition referenced by this instance.
+   *
+   * @return the field definition
+   */
   @Override
   IFieldDefinition getDefinition();
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IFieldInstanceAbsolute.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IFieldInstanceAbsolute.java
@@ -7,6 +7,13 @@ package gov.nist.secauto.metaschema.core.model;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Represents a field instance that appears directly within an assembly
+ * definition.
+ * <p>
+ * An absolute field instance is not part of a choice or other grouping
+ * construct, and has its own distinct cardinality and XML wrapping settings.
+ */
 public interface IFieldInstanceAbsolute extends IFieldInstance, INamedModelInstanceAbsolute {
 
   @Override

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IFieldInstanceGrouped.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IFieldInstanceGrouped.java
@@ -7,6 +7,13 @@ package gov.nist.secauto.metaschema.core.model;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Represents a field instance that appears within a choice or other grouping
+ * construct.
+ * <p>
+ * Grouped field instances always have XML wrapping enabled and inherit
+ * cardinality from their containing group.
+ */
 public interface IFieldInstanceGrouped extends INamedModelInstanceGrouped, IFieldInstance {
 
   /**

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IFlagContainerBuilder.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IFlagContainerBuilder.java
@@ -7,6 +7,15 @@ package gov.nist.secauto.metaschema.core.model;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Builder for constructing flag container instances.
+ * <p>
+ * This interface provides a fluent API for building flag containers by adding
+ * flag instances and then building the final container.
+ *
+ * @param <T>
+ *          the Java type of flag instances
+ */
 public interface IFlagContainerBuilder<T extends IFlagInstance> {
   /**
    * Add a flag instance to the flag container.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IFlagDefinition.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IFlagDefinition.java
@@ -7,6 +7,13 @@ package gov.nist.secauto.metaschema.core.model;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Represents a flag definition in a Metaschema module.
+ * <p>
+ * A flag is a simple named data value that can be associated with a field or
+ * assembly. Flag definitions define the data type and constraints for flag
+ * values.
+ */
 public interface IFlagDefinition extends IValuedDefinition, IFlag {
   @Override
   IFlagInstance getInlineInstance();

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IFlagInstance.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IFlagInstance.java
@@ -7,13 +7,33 @@ package gov.nist.secauto.metaschema.core.model;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Represents a flag instance within a field or assembly definition.
+ * <p>
+ * A flag instance references a flag definition and specifies how that flag is
+ * used within its containing definition, including whether the flag is
+ * required.
+ */
 public interface IFlagInstance extends IFlag, IValuedInstance, IInstanceAbsolute {
 
+  /**
+   * The default value for whether a flag is required.
+   */
   boolean DEFAULT_FLAG_REQUIRED = false;
 
+  /**
+   * Retrieves the parent container that contains this flag instance.
+   *
+   * @return the parent model definition
+   */
   @Override
   IModelDefinition getParentContainer();
 
+  /**
+   * Retrieves the flag definition referenced by this instance.
+   *
+   * @return the flag definition
+   */
   @Override
   IFlagDefinition getDefinition();
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IInstanceAbsolute.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IInstanceAbsolute.java
@@ -5,6 +5,12 @@
 
 package gov.nist.secauto.metaschema.core.model;
 
+/**
+ * Represents an instance with an absolute path and an associated value.
+ * <p>
+ * Combines instance characteristics with value semantics for use in absolute
+ * positioning contexts within a Metaschema model.
+ */
 public interface IInstanceAbsolute extends IInstance, IValued {
   // no additional methods
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IJsonInstance.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IJsonInstance.java
@@ -7,7 +7,18 @@ package gov.nist.secauto.metaschema.core.model;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Represents a model instance that has a JSON property name.
+ * <p>
+ * This interface provides access to the name used when the instance appears in
+ * JSON or YAML serialization.
+ */
 public interface IJsonInstance {
+  /**
+   * Get the name used for the instance in JSON/YAML serialization.
+   *
+   * @return the JSON property name
+   */
   @NonNull
   String getJsonName();
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IJsonNamed.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IJsonNamed.java
@@ -7,6 +7,12 @@ package gov.nist.secauto.metaschema.core.model;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Represents a model element that has a JSON property name.
+ * <p>
+ * This interface provides access to the name used when serializing or
+ * deserializing the element in JSON or YAML format.
+ */
 public interface IJsonNamed {
 
   /**

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/ILoader.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/ILoader.java
@@ -16,6 +16,14 @@ import java.util.Collection;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Provides loading capabilities for resources of type {@code T}.
+ * <p>
+ * Supports loading from various sources including URIs, paths, files, and URLs.
+ *
+ * @param <T>
+ *          the type of resource loaded by this loader
+ */
 public interface ILoader<T> {
   /**
    * Retrieve the set of loaded resources.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IMetapathQueryable.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IMetapathQueryable.java
@@ -9,6 +9,12 @@ import gov.nist.secauto.metaschema.core.metapath.item.node.INodeItem;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Represents a model element that can be queried using Metapath expressions.
+ * <p>
+ * This interface provides access to the node item representation required for
+ * Metapath evaluation.
+ */
 public interface IMetapathQueryable {
   /**
    * Get the Metapath node item for this Metaschema module construct, which can be

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IMetaschemaData.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IMetaschemaData.java
@@ -5,6 +5,12 @@
 
 package gov.nist.secauto.metaschema.core.model;
 
+/**
+ * Represents data associated with a Metaschema module.
+ * <p>
+ * This interface combines resource location information with
+ * Metaschema-specific metadata.
+ */
 public interface IMetaschemaData extends IResourceLocation {
   // no additional methods
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IModelDefinition.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IModelDefinition.java
@@ -66,7 +66,7 @@ public interface IModelDefinition extends IDefinition, IContainer {
   Collection<? extends IFlagInstance> getFlagInstances();
 
   /**
-   * Retrieves the flag instance to use as as the property name for the containing
+   * Retrieves the flag instance to use as the property name for the containing
    * object in JSON whose value will be the object containing the flag.
    *
    * @return the flag instance if a JSON key is configured, or {@code null}

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IModelDefinition.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IModelDefinition.java
@@ -67,7 +67,7 @@ public interface IModelDefinition extends IDefinition, IContainer {
 
   /**
    * Retrieves the flag instance to use as as the property name for the containing
-   * object in JSON who's value will be the object containing the flag.
+   * object in JSON whose value will be the object containing the flag.
    *
    * @return the flag instance if a JSON key is configured, or {@code null}
    *         otherwise

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IModelElementVisitable.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IModelElementVisitable.java
@@ -7,6 +7,12 @@ package gov.nist.secauto.metaschema.core.model;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Represents a model element that can be visited using the visitor pattern.
+ * <p>
+ * This interface supports traversal of model elements using implementations of
+ * {@link IModelElementVisitor}.
+ */
 public interface IModelElementVisitable {
   /**
    * A visitor callback.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IModelInstanceAbsolute.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IModelInstanceAbsolute.java
@@ -5,6 +5,12 @@
 
 package gov.nist.secauto.metaschema.core.model;
 
+/**
+ * Represents a model instance with an absolute path and an associated value.
+ * <p>
+ * Combines model instance characteristics with absolute positioning and value
+ * semantics for field and assembly instances in a Metaschema model.
+ */
 public interface IModelInstanceAbsolute extends IModelInstance, IInstanceAbsolute {
   // no additional methods
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IModuleLoader.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IModuleLoader.java
@@ -7,6 +7,12 @@ package gov.nist.secauto.metaschema.core.model;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Provides loading capabilities for Metaschema modules.
+ *
+ * @param <M>
+ *          the type of Metaschema module loaded by this loader
+ */
 public interface IModuleLoader<M extends IModuleExtended<M, ?, ?, ?, ?>> extends ILoader<M> {
   /**
    * Used to define a post-processing operation to perform on a module.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/INamed.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/INamed.java
@@ -12,6 +12,13 @@ import javax.xml.XMLConstants;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * Represents a model element that has a name and associated naming properties.
+ * <p>
+ * This interface provides methods for accessing the name, use name, qualified
+ * name, and index values used for XML and binary representations of model
+ * elements.
+ */
 public interface INamed {
 
   /**

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/INamedModelInstance.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/INamedModelInstance.java
@@ -10,6 +10,12 @@ import java.util.function.Predicate;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * Represents a named instance of a field or assembly within a model.
+ * <p>
+ * Provides access to the instance's definition and JSON key configuration for
+ * serialization purposes.
+ */
 public interface INamedModelInstance extends IModelInstance, INamedInstance {
 
   /**

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/INamedModelInstance.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/INamedModelInstance.java
@@ -47,7 +47,7 @@ public interface INamedModelInstance extends IModelInstance, INamedInstance {
 
   /**
    * Indicates if a flag's value can be used as a property name in the containing
-   * object in JSON who's value will be the object containing the flag. In such
+   * object in JSON whose value will be the object containing the flag. In such
    * cases, the flag will not appear in the object. This is only allowed if the
    * flag is required, as determined by a {@code true} result from
    * {@link IFlagInstance#isRequired()}. The {@link IFlagInstance} can be

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/INamedModelInstance.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/INamedModelInstance.java
@@ -65,7 +65,7 @@ public interface INamedModelInstance extends IModelInstance, INamedInstance {
   /**
    * Get the JSON key flag instance for this model instance, if one is configured.
    *
-   * @return the JSON key flag instance or {@code null} if a JSON key is
+   * @return the JSON key flag instance or {@code null} if no JSON key is
    *         configured
    */
   @Nullable

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/INamedModelInstanceAbsolute.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/INamedModelInstanceAbsolute.java
@@ -10,6 +10,13 @@ import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * Represents a named model instance with absolute positioning and JSON
+ * serialization support.
+ * <p>
+ * Provides JSON name resolution based on cardinality and grouping behavior,
+ * with support for JSON key configuration.
+ */
 public interface INamedModelInstanceAbsolute extends INamedModelInstance, IModelInstanceAbsolute, IJsonInstance {
   @Override
   default String getJsonName() {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IUriResolver.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IUriResolver.java
@@ -9,6 +9,9 @@ import java.net.URI;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Provides URI resolution capabilities for Metaschema resources.
+ */
 public interface IUriResolver {
   /**
    * Resolve the provided URI, producing a resolved URI, which may point to a

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IValuedInstance.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IValuedInstance.java
@@ -7,6 +7,10 @@ package gov.nist.secauto.metaschema.core.model;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Represents a Metaschema instance that has an associated value (i.e., field or
+ * flag instance).
+ */
 public interface IValuedInstance extends INamedInstance {
   @Override
   @NonNull

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/JsonGroupAsBehavior.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/JsonGroupAsBehavior.java
@@ -5,6 +5,9 @@
 
 package gov.nist.secauto.metaschema.core.model;
 
+/**
+ * Defines how repeated instances are grouped in JSON/YAML representations.
+ */
 public enum JsonGroupAsBehavior {
   /**
    * In JSON, the group of instances will be represented as a JSON object, with

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/JsonValueKeyTypeEnum.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/JsonValueKeyTypeEnum.java
@@ -18,7 +18,7 @@ public enum JsonValueKeyTypeEnum {
    */
   STATIC_LABEL,
   /**
-   * A flag is idenfied as the value key, who's value will be used.
+   * A flag is identified as the value key, whose value will be used.
    */
   FLAG;
 }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/JsonValueKeyTypeEnum.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/JsonValueKeyTypeEnum.java
@@ -5,6 +5,9 @@
 
 package gov.nist.secauto.metaschema.core.model;
 
+/**
+ * Defines the type of JSON value key used to identify data values.
+ */
 public enum JsonValueKeyTypeEnum {
   /**
    * No value key is defined, and a type specific value key will be used.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/MetaschemaException.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/MetaschemaException.java
@@ -5,6 +5,9 @@
 
 package gov.nist.secauto.metaschema.core.model;
 
+/**
+ * Indicates an error related to Metaschema processing.
+ */
 public class MetaschemaException
     extends Exception {
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/ModelType.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/ModelType.java
@@ -11,10 +11,25 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * An enumeration that identifies the type of a Metaschema construct.
  */
 public enum ModelType {
+  /**
+   * Represents an assembly definition.
+   */
   ASSEMBLY("assembly"),
+  /**
+   * Represents a field definition.
+   */
   FIELD("field"),
+  /**
+   * Represents a flag definition.
+   */
   FLAG("flag"),
+  /**
+   * Represents a choice between multiple definitions.
+   */
   CHOICE("choice"),
+  /**
+   * Represents a grouped choice construct.
+   */
   CHOICE_GROUP("choice-group");
 
   private final String name;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/XmlGroupAsBehavior.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/XmlGroupAsBehavior.java
@@ -5,6 +5,9 @@
 
 package gov.nist.secauto.metaschema.core.model;
 
+/**
+ * Defines how repeated instances are grouped in XML representations.
+ */
 public enum XmlGroupAsBehavior {
   /**
    * In XML, child element instances will be wrapped by a grouping element.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/ConstraintValidationException.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/ConstraintValidationException.java
@@ -7,6 +7,9 @@ package gov.nist.secauto.metaschema.core.model.constraint;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+/**
+ * Indicates a constraint validation failure.
+ */
 public class ConstraintValidationException
     extends Exception {
 
@@ -47,6 +50,20 @@ public class ConstraintValidationException
     super(cause);
   }
 
+  /**
+   * Constructs a new exception with the specified detail message and cause.
+   * <p>
+   * Note that the detail message associated with {@code cause} is <i>not</i>
+   * automatically incorporated in this exception's detail message.
+   *
+   * @param message
+   *          the detail message, which is saved for later retrieval by the
+   *          {@link #getMessage()} method.
+   * @param cause
+   *          the cause (which is saved for later retrieval by the
+   *          {@link #getCause()} method). A {@code null} value is permitted, and
+   *          indicates that the cause is nonexistent or unknown.
+   */
   public ConstraintValidationException(@Nullable String message, @Nullable Throwable cause) {
     super(message, cause);
   }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/IConstraint.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/IConstraint.java
@@ -28,12 +28,19 @@ public interface IConstraint extends IAttributable, IDescribable {
    * The type of constraint.
    */
   enum Type {
+    /** Constraint restricting the set of allowed values. */
     ALLOWED_VALUES("allowed-values"),
+    /** Constraint specifying occurrence requirements. */
     CARDINALITY("cardinality"),
+    /** Constraint expressing an expected condition. */
     EXPECT("expect"),
+    /** Constraint creating an index over items. */
     INDEX("index"),
+    /** Constraint requiring uniqueness across items. */
     UNIQUE("unique"),
+    /** Constraint verifying index key references. */
     INDEX_HAS_KEY("index-has-key"),
+    /** Constraint validating pattern matching. */
     MATCHES("matches");
 
     @NonNull
@@ -43,6 +50,11 @@ public interface IConstraint extends IAttributable, IDescribable {
       this.name = name;
     }
 
+    /**
+     * Get the name identifier for this constraint type.
+     *
+     * @return the name
+     */
     @NonNull
     public String getName() {
       return name;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/IConstraintValidator.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/IConstraintValidator.java
@@ -25,6 +25,7 @@ public interface IConstraintValidator {
    *          the Metapath dynamic execution context to use for Metapath
    *          evaluation
    * @throws ConstraintValidationException
+   *           if a constraint violation is detected
    * @throws MetapathException
    *           if an error occurred while evaluating a Metapath used in a
    *           constraint
@@ -40,6 +41,7 @@ public interface IConstraintValidator {
    *          the Metapath dynamic execution context to use for Metapath
    *          evaluation
    * @throws ConstraintValidationException
+   *           if a constraint violation is detected during finalization
    * @throws MetapathException
    *           if an error occurred while evaluating a Metapath used in a
    *           constraint

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/ModelTargetedConstraints.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/ModelTargetedConstraints.java
@@ -14,6 +14,10 @@ import java.util.function.Supplier;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Represents a set of constraints targeted at model definitions using Metapath
+ * expressions.
+ */
 public class ModelTargetedConstraints
     extends AbstractTargetedConstraints<IModelConstrained>
     implements IFeatureModelConstrained {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/impl/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/impl/package-info.java
@@ -3,4 +3,45 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
+/**
+ * Default implementations of Metaschema constraint types.
+ * <p>
+ * This package contains the concrete implementations of the constraint
+ * interfaces defined in the parent
+ * {@link gov.nist.secauto.metaschema.core.model.constraint} package. These
+ * implementations provide the runtime behavior for constraint evaluation and
+ * validation.
+ * <h2>Key Classes</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.constraint.impl.DefaultAllowedValuesConstraint}
+ * - Implementation of allowed values restrictions</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.constraint.impl.DefaultCardinalityConstraint}
+ * - Implementation of cardinality enforcement</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.constraint.impl.DefaultExpectConstraint}
+ * - Implementation of expectation validation</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.constraint.impl.DefaultMatchesConstraint}
+ * - Implementation of pattern matching</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.constraint.impl.DefaultUniqueConstraint}
+ * - Implementation of uniqueness checking</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.constraint.impl.DefaultIndexConstraint}
+ * - Implementation of index creation</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.constraint.impl.DefaultIndexHasKeyConstraint}
+ * - Implementation of referential integrity checking</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.constraint.impl.AbstractConstraint}
+ * - Base class providing common constraint functionality</li>
+ * </ul>
+ * <h2>Usage Context</h2>
+ * <p>
+ * These implementations are used internally by:
+ * <ul>
+ * <li>Metaschema module loaders when parsing constraint definitions</li>
+ * <li>The constraint validator during validation operations</li>
+ * <li>Builder classes for programmatic constraint construction</li>
+ * </ul>
+ * <p>
+ * External code should generally interact with constraints through the
+ * interface types in the parent package rather than directly using these
+ * implementation classes.
+ */
+
 package gov.nist.secauto.metaschema.core.model.constraint.impl;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/package-info.java
@@ -45,7 +45,8 @@
  * <li>Used to generate validation rules for JSON Schema and XML Schema</li>
  * </ul>
  *
- * @see gov.nist.secauto.metaschema.core.model.constraint.impl
+ * @see gov.nist.secauto.metaschema.core.model.constraint.IConstraint
+ * @see gov.nist.secauto.metaschema.core.model.constraint.IConstraintValidator
  */
 
 package gov.nist.secauto.metaschema.core.model.constraint;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/package-info.java
@@ -4,10 +4,48 @@
  */
 
 /**
- * Support for validating bound objects using Metaschema constraints.
+ * Metaschema constraint definitions and validation framework.
  * <p>
- * Validation support is provided by
- * {@link gov.nist.secauto.metaschema.core.model.constraint.DefaultConstraintValidator}.
+ * This package provides the constraint system for Metaschema, which allows
+ * defining and enforcing validation rules on model instances. Constraints can
+ * restrict allowed values, enforce cardinality, ensure uniqueness, validate
+ * patterns, and establish referential integrity through index relationships.
+ * <h2>Constraint Types</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.constraint.IAllowedValuesConstraint}
+ * - Restricts values to a defined set</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.constraint.ICardinalityConstraint}
+ * - Enforces occurrence requirements (min/max)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.constraint.IExpectConstraint}
+ * - Validates that a condition is true</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.constraint.IMatchesConstraint}
+ * - Validates values against regex patterns</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.constraint.IUniqueConstraint}
+ * - Ensures uniqueness of key field combinations</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.constraint.IIndexConstraint}
+ * - Creates an index over items for referential integrity</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.constraint.IIndexHasKeyConstraint}
+ * - Verifies that references exist in an index</li>
+ * </ul>
+ * <h2>Validation</h2>
+ * <p>
+ * The
+ * {@link gov.nist.secauto.metaschema.core.model.constraint.DefaultConstraintValidator}
+ * provides the main entry point for validating model instances against their
+ * constraints. Validation results are reported through
+ * {@link gov.nist.secauto.metaschema.core.model.constraint.IConstraintValidationHandler}
+ * implementations.
+ * <h2>Usage Context</h2>
+ * <p>
+ * Constraints can be:
+ * <ul>
+ * <li>Defined inline within Metaschema definitions</li>
+ * <li>Applied externally through constraint sets</li>
+ * <li>Evaluated during content validation and data binding</li>
+ * <li>Used to generate validation rules for JSON Schema and XML Schema</li>
+ * </ul>
+ *
+ * @see gov.nist.secauto.metaschema.core.model.constraint.impl
  */
 
 package gov.nist.secauto.metaschema.core.model.constraint;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/impl/DefaultContainerFlagSupport.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/impl/DefaultContainerFlagSupport.java
@@ -48,7 +48,7 @@ public class DefaultContainerFlagSupport<FI extends IFlagInstance> implements IC
 
   /**
    * Retrieves the flag instance to use as as the property name for the containing
-   * object in JSON who's value will be the object containing the flag.
+   * object in JSON whose value will be the object containing the flag.
    *
    * @return the flag instance if a JSON key is configured, or {@code null}
    *         otherwise

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/impl/DefaultContainerFlagSupport.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/impl/DefaultContainerFlagSupport.java
@@ -47,7 +47,7 @@ public class DefaultContainerFlagSupport<FI extends IFlagInstance> implements IC
   }
 
   /**
-   * Retrieves the flag instance to use as as the property name for the containing
+   * Retrieves the flag instance to use as the property name for the containing
    * object in JSON whose value will be the object containing the flag.
    *
    * @return the flag instance if a JSON key is configured, or {@code null}

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/impl/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/impl/package-info.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+/**
+ * Default implementations of Metaschema model container support interfaces.
+ * <p>
+ * This package provides reusable implementations for managing containers of
+ * flags, model instances, and choice groups within Metaschema definitions.
+ * These implementations are used by higher-level model implementations to
+ * handle the common patterns of containing and organizing child elements.
+ * <h2>Key Classes</h2>
+ * <ul>
+ * <li>{@link DefaultContainerFlagSupport} - Manages a collection of flag
+ * instances with optional JSON key flag support</li>
+ * <li>{@link DefaultContainerModelSupport} - Provides generic container support
+ * for model instances (fields and assemblies) with lookup by type and name</li>
+ * <li>{@link DefaultContainerModelAssemblySupport} - Specialized container
+ * support for assembly instances</li>
+ * <li>{@link DefaultContainerModelChoiceGroupSupport} - Container support for
+ * choice group model instances</li>
+ * <li>{@link EmptyFlagContainer} - Singleton implementation for definitions
+ * with no flag instances</li>
+ * </ul>
+ * <h2>Design Pattern</h2>
+ * <p>
+ * These classes follow a delegation pattern where Metaschema definition
+ * implementations (such as assemblies and fields) delegate container management
+ * responsibilities to these specialized support classes. This promotes code
+ * reuse and consistent behavior across different definition types.
+ * <p>
+ * The implementations use {@link java.util.LinkedHashMap} internally to
+ * preserve insertion order, which is important for maintaining the declaration
+ * order of model elements as they appear in Metaschema modules.
+ * <h2>Thread Safety</h2>
+ * <p>
+ * These container implementations are intended to be immutable once
+ * constructed. They are typically initialized during module loading and then
+ * used in a read-only manner throughout the lifecycle of the model.
+ * <h2>Usage Context</h2>
+ * <p>
+ * This package is used internally by:
+ * <ul>
+ * <li>Metaschema module loaders when constructing definition objects</li>
+ * <li>Definition implementations in the parent
+ * {@link gov.nist.secauto.metaschema.core.model} package</li>
+ * <li>Databinding implementations that need to navigate model structures</li>
+ * </ul>
+ *
+ * @see gov.nist.secauto.metaschema.core.model.IContainerFlagSupport
+ * @see gov.nist.secauto.metaschema.core.model.IContainerModelSupport
+ * @see gov.nist.secauto.metaschema.core.model.AbstractContainerModelSupport
+ */
+
+package gov.nist.secauto.metaschema.core.model.impl;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/package-info.java
@@ -4,8 +4,41 @@
  */
 
 /**
- * Provides interfaces, abstract implementation classes, and exceptions that are
- * used in Metaschema APIs for processing Metaschema-based models.
+ * Core Metaschema model interfaces and implementations.
+ * <p>
+ * This package defines the fundamental object model for Metaschema modules,
+ * including definitions (assemblies, fields, flags), instances, and their
+ * relationships. It provides both the API contracts and abstract base
+ * implementations for representing Metaschema structures.
+ * <h2>Key Interfaces</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.IModule} - Represents a
+ * Metaschema module containing definitions</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.IAssemblyDefinition} -
+ * Defines a complex assembly structure</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.IFieldDefinition} - Defines
+ * a field with optional value and flags</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.IFlagDefinition} - Defines
+ * a flag (simple name-value pair)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.IModelInstance} -
+ * Represents an instance of a definition within a model</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.IContainerModel} -
+ * Represents a container that can hold model instances</li>
+ * </ul>
+ * <h2>Usage Context</h2>
+ * <p>
+ * This package is used by:
+ * <ul>
+ * <li>Metaschema module loaders to construct in-memory representations of
+ * modules</li>
+ * <li>Databinding implementations to map between Java objects and Metaschema
+ * structures</li>
+ * <li>Code generators to produce Java classes from Metaschema definitions</li>
+ * <li>Validation and constraint processing to enforce structural rules</li>
+ * </ul>
+ *
+ * @see gov.nist.secauto.metaschema.core.model.constraint
+ * @see gov.nist.secauto.metaschema.core.model.validation
  */
 
 package gov.nist.secauto.metaschema.core.model;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/util/DefaultDiagramNode.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/util/DefaultDiagramNode.java
@@ -187,6 +187,9 @@ public class DefaultDiagramNode implements IDiagramNode {
     }
   }
 
+  /**
+   * Represents an edge based on a named model instance.
+   */
   public final class ModelEdge
       extends AbstractEdge<INamedModelInstanceAbsolute> {
     private ModelEdge(
@@ -200,6 +203,10 @@ public class DefaultDiagramNode implements IDiagramNode {
     }
   }
 
+  /**
+   * Represents an edge based on a named model instance that is a member of a
+   * choice.
+   */
   public final class ChoiceEdge
       extends AbstractEdge<INamedModelInstanceAbsolute> {
     @NonNull
@@ -228,6 +235,10 @@ public class DefaultDiagramNode implements IDiagramNode {
     }
   }
 
+  /**
+   * Represents an edge based on a named model instance that is a member of a
+   * choice group.
+   */
   public final class ChoiceGroupEdge
       extends AbstractEdge<INamedModelInstanceGrouped> {
     @NonNull

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/util/IDiagramNode.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/util/IDiagramNode.java
@@ -131,9 +131,13 @@ public interface IDiagramNode {
    * The nature of a relationship between two nodes.
    */
   enum Relationship {
+    /** Indicates a relationship with zero or one occurrences. */
     ZERO_OR_ONE,
+    /** Indicates a relationship with exactly one occurrence. */
     ONE,
+    /** Indicates a relationship with zero or more occurrences. */
     ZERO_OR_MORE,
+    /** Indicates a relationship with one or more occurrences. */
     ONE_OR_MORE;
 
     /**

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/util/IDiagramNodeVisitor.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/util/IDiagramNodeVisitor.java
@@ -12,6 +12,13 @@ import gov.nist.secauto.metaschema.core.model.INamedModelInstanceGrouped;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * A visitor for processing edges in a diagram node model.
+ * <p>
+ * Implementations of this interface can traverse and process different types of
+ * edges in a Metaschema diagram, dispatching to the appropriate method based on
+ * the edge type.
+ */
 public interface IDiagramNodeVisitor {
   /**
    * Handle an edge based on a {@link INamedModelInstanceAbsolute}.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/util/ModuleUtils.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/util/ModuleUtils.java
@@ -13,6 +13,10 @@ import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Provides utility methods for parsing qualified names within Metaschema
+ * modules.
+ */
 public final class ModuleUtils {
   /**
    * Parse a flag name.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/util/ModuleUtils.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/util/ModuleUtils.java
@@ -42,7 +42,7 @@ public final class ModuleUtils {
   }
 
   /**
-   * Parse the name of a field or assemvly.
+   * Parse the name of a field or assembly.
    * <p>
    * The namespace for the name will be determined according to
    * {@link StaticContext#parseModelName(String)}.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/util/XmlUtil.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/util/XmlUtil.java
@@ -13,6 +13,9 @@ import javax.xml.transform.stream.StreamSource;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Provides utility methods for working with XML sources and streams.
+ */
 public final class XmlUtil {
 
   private XmlUtil() {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/util/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/util/package-info.java
@@ -4,7 +4,33 @@
  */
 
 /**
- * Various utilities and helper methods.
+ * Utility classes for Metaschema model processing and manipulation.
+ * <p>
+ * This package provides helper classes and utilities for working with
+ * Metaschema models, including JSON/XML parsing utilities, diagram generation,
+ * and module manipulation tools.
+ * <h2>Key Classes</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.util.JsonUtil} - JSON
+ * parsing and utility methods</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.util.XmlUtil} - XML
+ * processing and utility methods</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.util.XmlEventUtil} - StAX
+ * XML event stream utilities</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.util.ModuleUtils} - Module
+ * traversal and manipulation utilities</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.util.MermaidErDiagramGenerator}
+ * - Generates Mermaid ER diagrams from Metaschema modules</li>
+ * </ul>
+ * <h2>Usage Context</h2>
+ * <p>
+ * These utilities support:
+ * <ul>
+ * <li>Content serialization and deserialization</li>
+ * <li>Model visualization and documentation</li>
+ * <li>Module analysis and traversal</li>
+ * <li>Low-level parsing operations</li>
+ * </ul>
  */
 
 package gov.nist.secauto.metaschema.core.model.util;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/validation/IValidationResult.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/validation/IValidationResult.java
@@ -16,6 +16,9 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * Provides data that is the result of a completed content validation.
  */
 public interface IValidationResult {
+  /**
+   * A validation result indicating no validation errors were found.
+   */
   @NonNull
   IValidationResult PASSING_RESULT = new IValidationResult() {
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/validation/JsonSchemaContentValidator.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/validation/JsonSchemaContentValidator.java
@@ -28,6 +28,9 @@ import java.util.stream.Stream;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Validates JSON content against a JSON schema.
+ */
 public class JsonSchemaContentValidator
     extends AbstractContentValidator {
   @NonNull

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/validation/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/validation/package-info.java
@@ -26,7 +26,8 @@
  * <h2>Usage Context</h2>
  * <p>
  * This validation framework differs from constraint validation
- * ({@link gov.nist.secauto.metaschema.core.model.constraint}) in that it:
+ * ({@link gov.nist.secauto.metaschema.core.model.constraint.IConstraint}) in
+ * that it:
  * <ul>
  * <li>Validates against schema documents (XSD/JSON Schema) rather than
  * constraint rules</li>
@@ -39,9 +40,10 @@
  * <p>
  * For constraint-based validation (e.g., allowed values, uniqueness,
  * cardinality), use the
- * {@link gov.nist.secauto.metaschema.core.model.constraint} package instead.
+ * {@link gov.nist.secauto.metaschema.core.model.constraint.IConstraint}
+ * instead.
  *
- * @see gov.nist.secauto.metaschema.core.model.constraint
+ * @see gov.nist.secauto.metaschema.core.model.constraint.IConstraint
  */
 
 package gov.nist.secauto.metaschema.core.model.validation;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/validation/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/validation/package-info.java
@@ -4,7 +4,44 @@
  */
 
 /**
- * Provides content validation support.
+ * Schema-based content validation for Metaschema instances.
+ * <p>
+ * This package provides validators for checking Metaschema-based content
+ * against generated XML Schema and JSON Schema documents. It supports
+ * validating content files to ensure they conform to the structure defined by a
+ * Metaschema module.
+ * <h2>Key Interfaces and Classes</h2>
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.validation.IContentValidator}
+ * - Common interface for content validators</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.validation.XmlSchemaContentValidator}
+ * - Validates XML content against XML Schema (XSD)</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.validation.JsonSchemaContentValidator}
+ * - Validates JSON content against JSON Schema</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.validation.IValidationResult}
+ * - Represents the outcome of a validation operation</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.model.validation.IValidationFinding}
+ * - Represents an individual validation issue or error</li>
+ * </ul>
+ * <h2>Usage Context</h2>
+ * <p>
+ * This validation framework differs from constraint validation
+ * ({@link gov.nist.secauto.metaschema.core.model.constraint}) in that it:
+ * <ul>
+ * <li>Validates against schema documents (XSD/JSON Schema) rather than
+ * constraint rules</li>
+ * <li>Checks structural conformance and data type compliance</li>
+ * <li>Is typically used for validating external content files before
+ * databinding</li>
+ * <li>Provides lower-level validation compared to Metaschema constraint
+ * validation</li>
+ * </ul>
+ * <p>
+ * For constraint-based validation (e.g., allowed values, uniqueness,
+ * cardinality), use the
+ * {@link gov.nist.secauto.metaschema.core.model.constraint} package instead.
+ *
+ * @see gov.nist.secauto.metaschema.core.model.constraint
  */
 
 package gov.nist.secauto.metaschema.core.model.validation;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/package-info.java
@@ -5,6 +5,34 @@
 
 /**
  * Core support for handling Metaschema-based models.
+ * <p>
+ * This package provides the foundation for working with Metaschema definitions
+ * and data. Metaschema is a framework for defining structured data models with
+ * rich validation constraints and multiple serialization formats (XML, JSON,
+ * YAML).
+ * <p>
+ * The core module is organized into several key subpackages:
+ * <ul>
+ * <li>{@code model} - Metaschema model interfaces ({@code IModule},
+ * {@code IAssemblyDefinition}, {@code IFieldDefinition},
+ * {@code IFlagDefinition})</li>
+ * <li>{@code metapath} - Metapath expression language (XPath 3.1 implementation
+ * for Metaschema)</li>
+ * <li>{@code datatype} - Data type adapters for Metaschema types (string,
+ * integer, date-time, etc.)</li>
+ * <li>{@code mdm} - Metaschema Document Model node items</li>
+ * <li>{@code configuration} - Configuration management for processors and
+ * parsers</li>
+ * <li>{@code util} - Common utility classes</li>
+ * </ul>
+ * <p>
+ * Key class in this package:
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.MetaschemaConstants} - Metaschema
+ * namespace and related constants</li>
+ * </ul>
+ *
+ * @see <a href="https://pages.nist.gov/metaschema/">Metaschema Project</a>
  */
 
 package gov.nist.secauto.metaschema.core;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/qname/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/qname/package-info.java
@@ -75,8 +75,8 @@
  * QName literals and namespace resolution</li>
  * <li>{@link gov.nist.secauto.metaschema.core.model} - For storing element and
  * attribute qualified names in model definitions</li>
- * <li>{@link gov.nist.secauto.metaschema.databind} - For mapping between Java
- * classes and XML/JSON element names</li>
+ * <li>The databind module - For mapping between Java classes and XML/JSON
+ * element names</li>
  * <li>XML/JSON serialization components throughout the framework</li>
  * </ul>
  * <h2>Performance Considerations</h2>

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/qname/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/qname/package-info.java
@@ -1,0 +1,101 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+/**
+ * Enhanced qualified name (QName) support with efficient caching and namespace
+ * management.
+ * <p>
+ * This package provides an optimized implementation of XML qualified names that
+ * reduces memory footprint through integer-based caching and instance reuse. It
+ * extends the standard {@link javax.xml.namespace.QName} functionality with
+ * additional features needed for Metaschema and XPath processing.
+ * <h2>Key Interfaces and Classes</h2>
+ * <ul>
+ * <li>{@link IEnhancedQName} - Enhanced qualified name interface with caching,
+ * namespace URI access, and extended QName formatting (EQName)</li>
+ * <li>{@link QNameCache} - Thread-safe cache for managing commonly reused
+ * qualified names with integer index-based lookup</li>
+ * <li>{@link NamespaceCache} - Thread-safe cache for namespace URIs to reduce
+ * memory duplication</li>
+ * <li>{@link EQNameFactory} - Factory for creating and retrieving cached
+ * qualified names</li>
+ * <li>{@link WellKnown} - Registry of well-known XML namespaces and their
+ * conventional prefixes (xml, xs, xsi, etc.)</li>
+ * </ul>
+ * <h2>Caching Strategy</h2>
+ * <p>
+ * The caching mechanism works on two levels:
+ * <ol>
+ * <li><b>Namespace Cache</b> - Assigns unique integer indices to namespace
+ * URIs</li>
+ * <li><b>QName Cache</b> - Uses namespace indices and local names as keys to
+ * cache qualified names</li>
+ * </ol>
+ * <p>
+ * Each {@link IEnhancedQName} is assigned a unique integer index position that
+ * can be used for efficient storage and lookup via
+ * {@link IEnhancedQName#of(int)}. This allows qualified names to be referenced
+ * by integer indices rather than full objects, reducing memory overhead in data
+ * structures that reference many qualified names.
+ * <h2>Extended QName Format (EQName)</h2>
+ * <p>
+ * The package supports the XPath 3.1 Extended QName format:
+ * <ul>
+ * <li><code>Q{namespace}localName</code> - For names in a namespace</li>
+ * <li><code>prefix:localName</code> - When a prefix is known</li>
+ * <li><code>localName</code> - For names in no namespace</li>
+ * </ul>
+ * <p>
+ * The {@link IEnhancedQName#toEQName()} method automatically resolves prefixes
+ * using well-known namespaces or falls back to the braced URI notation.
+ * <h2>Thread Safety</h2>
+ * <p>
+ * Both {@link QNameCache} and {@link NamespaceCache} use concurrent data
+ * structures ({@link java.util.concurrent.ConcurrentHashMap}) to ensure
+ * thread-safe operation in multi-threaded environments. The cache instances are
+ * singleton objects shared across the application.
+ * <h2>Well-Known Namespaces</h2>
+ * <p>
+ * The {@link WellKnown} class maintains a registry of standard XML namespaces
+ * including:
+ * <ul>
+ * <li>{@code xml} - XML namespace (http://www.w3.org/XML/1998/namespace)</li>
+ * <li>{@code xs} - XML Schema (http://www.w3.org/2001/XMLSchema)</li>
+ * <li>{@code xsi} - XML Schema Instance
+ * (http://www.w3.org/2001/XMLSchema-instance)</li>
+ * <li>Metaschema-specific namespaces</li>
+ * </ul>
+ * <h2>Usage Context</h2>
+ * <p>
+ * This package is used throughout the Metaschema framework:
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.metapath} - For XPath/Metapath
+ * QName literals and namespace resolution</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.model} - For storing element and
+ * attribute qualified names in model definitions</li>
+ * <li>{@link gov.nist.secauto.metaschema.databind} - For mapping between Java
+ * classes and XML/JSON element names</li>
+ * <li>XML/JSON serialization components throughout the framework</li>
+ * </ul>
+ * <h2>Performance Considerations</h2>
+ * <p>
+ * The caching strategy is optimized for read-heavy workloads common in
+ * Metaschema processing. The integer-based indexing allows for:
+ * <ul>
+ * <li>Reduced memory footprint when many references to the same QName
+ * exist</li>
+ * <li>Fast equality comparisons using index values</li>
+ * <li>Efficient storage in data structures</li>
+ * </ul>
+ * <p>
+ * <b>Note:</b> The global shared cache may grow large in long-running
+ * processes. Consider the implications for your use case (see
+ * {@link QNameCache} for details).
+ *
+ * @see javax.xml.namespace.QName
+ * @see gov.nist.secauto.metaschema.core.metapath.StaticContext
+ */
+
+package gov.nist.secauto.metaschema.core.qname;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/util/ExceptionUtils.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/util/ExceptionUtils.java
@@ -135,7 +135,7 @@ public final class ExceptionUtils {
         return unwrappedEx;
       }
       throw new IllegalArgumentException(
-          String.format("Wrapped exception '%s' did not match excpeted type '%s'.",
+          String.format("Wrapped exception '%s' did not match expected type '%s'.",
               cause.getClass().getName(),
               wrappedExceptionClass.getName()));
     }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/util/ExceptionUtils.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/util/ExceptionUtils.java
@@ -5,6 +5,7 @@
 
 package gov.nist.secauto.metaschema.core.util;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -97,7 +98,7 @@ public final class ExceptionUtils {
      *          the exception to wrap
      */
     public WrappedException(@NonNull Throwable cause) {
-      super(cause);
+      super(Objects.requireNonNull(cause, "cause"));
     }
 
     @Override
@@ -131,7 +132,12 @@ public final class ExceptionUtils {
       Throwable cause = unwrap();
       if (wrappedExceptionClass.isInstance(cause)) {
         E unwrappedEx = wrappedExceptionClass.cast(cause);
-        unwrappedEx.addSuppressed(this);
+        // Avoid adding duplicate suppressed exceptions on repeated unwraps
+        boolean alreadySuppressed = Arrays.stream(unwrappedEx.getSuppressed())
+            .anyMatch(s -> s == this);
+        if (!alreadySuppressed) {
+          unwrappedEx.addSuppressed(this);
+        }
         return unwrappedEx;
       }
       throw new IllegalArgumentException(

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/util/ExceptionUtils.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/util/ExceptionUtils.java
@@ -5,6 +5,8 @@
 
 package gov.nist.secauto.metaschema.core.util;
 
+import java.util.Objects;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -24,7 +26,7 @@ public final class ExceptionUtils {
    */
   @NonNull
   public static WrappedException wrap(@NonNull Throwable ex) {
-    return new WrappedException(ex);
+    return new WrappedException(Objects.requireNonNull(ex, "ex"));
   }
 
   /**
@@ -39,7 +41,7 @@ public final class ExceptionUtils {
    */
   @NonNull
   public static WrappedException wrapAndThrow(@NonNull Throwable ex) {
-    return new WrappedException(ex);
+    return wrap(ex);
   }
 
   /**

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/util/ExceptionUtils.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/util/ExceptionUtils.java
@@ -15,22 +15,59 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * circumstances.
  */
 public final class ExceptionUtils {
+  /**
+   * Wrap a checked exception in an unchecked {@link WrappedException}.
+   *
+   * @param ex
+   *          the exception to wrap
+   * @return a new wrapped exception containing the provided exception
+   */
   @NonNull
   public static WrappedException wrap(@NonNull Throwable ex) {
     return new WrappedException(ex);
   }
 
+  /**
+   * Wrap a checked exception in an unchecked {@link WrappedException}.
+   * <p>
+   * This method is identical to {@link #wrap(Throwable)} but named to indicate
+   * intent when used in throw statements.
+   *
+   * @param ex
+   *          the exception to wrap
+   * @return a new wrapped exception containing the provided exception
+   */
   @NonNull
   public static WrappedException wrapAndThrow(@NonNull Throwable ex) {
     return new WrappedException(ex);
   }
 
+  /**
+   * Unwrap a previously wrapped exception.
+   *
+   * @param ex
+   *          the wrapped exception to unwrap
+   * @return the original exception that was wrapped
+   */
   @NonNull
   public static Throwable unwrap(
       @NonNull WrappedException ex) {
     return ex.unwrap();
   }
 
+  /**
+   * Unwrap a previously wrapped exception, casting it to the expected type.
+   *
+   * @param <E>
+   *          the expected exception type
+   * @param ex
+   *          the wrapped exception to unwrap
+   * @param wrappedExceptionClass
+   *          the class of the expected exception type
+   * @return the original exception cast to the expected type
+   * @throws IllegalArgumentException
+   *           if the wrapped exception is not of the expected type
+   */
   @NonNull
   public static <E extends Throwable> E unwrap(
       @NonNull WrappedException ex,
@@ -38,6 +75,11 @@ public final class ExceptionUtils {
     return ex.unwrap(wrappedExceptionClass);
   }
 
+  /**
+   * A runtime exception that wraps a checked exception, allowing it to be thrown
+   * from contexts that do not allow checked exceptions (such as lambda
+   * expressions).
+   */
   public static final class WrappedException
       extends RuntimeException {
 
@@ -46,6 +88,12 @@ public final class ExceptionUtils {
      */
     private static final long serialVersionUID = 2L;
 
+    /**
+     * Construct a new wrapped exception.
+     *
+     * @param cause
+     *          the exception to wrap
+     */
     public WrappedException(@NonNull Throwable cause) {
       super(cause);
     }
@@ -55,11 +103,27 @@ public final class ExceptionUtils {
       throw new UnsupportedOperationException("must set cause in constructor");
     }
 
+    /**
+     * Get the wrapped exception.
+     *
+     * @return the original exception that was wrapped
+     */
     @NonNull
     public Throwable unwrap() {
       return ObjectUtils.notNull(getCause());
     }
 
+    /**
+     * Get the wrapped exception, casting it to the expected type.
+     *
+     * @param <E>
+     *          the expected exception type
+     * @param wrappedExceptionClass
+     *          the class of the expected exception type
+     * @return the original exception cast to the expected type
+     * @throws IllegalArgumentException
+     *           if the wrapped exception is not of the expected type
+     */
     @NonNull
     public <E extends Throwable> E unwrap(@NonNull Class<E> wrappedExceptionClass) {
       Throwable cause = unwrap();
@@ -74,10 +138,26 @@ public final class ExceptionUtils {
               wrappedExceptionClass.getName()));
     }
 
+    /**
+     * Unwrap and throw the original exception.
+     *
+     * @throws Throwable
+     *           the original wrapped exception
+     */
     public void unwrapAndThrow() throws Throwable {
       throw unwrap();
     }
 
+    /**
+     * Unwrap and throw the original exception, cast to the expected type.
+     *
+     * @param <E>
+     *          the expected exception type
+     * @param wrappedExceptionClass
+     *          the class of the expected exception type
+     * @throws E
+     *           the original wrapped exception cast to the expected type
+     */
     public <E extends Throwable> void unwrapAndThrow(@NonNull Class<E> wrappedExceptionClass) throws E {
       throw unwrap(wrappedExceptionClass);
     }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/util/package-info.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/util/package-info.java
@@ -4,7 +4,38 @@
  */
 
 /**
- * Provides a variety of utility classes and methods.
+ * Provides utility classes for common operations throughout the Metaschema
+ * framework.
+ * <p>
+ * This package contains helper classes for working with collections, objects,
+ * strings, URIs, and other common Java types. These utilities provide null-safe
+ * operations, type conversions, and enhanced functionality beyond standard Java
+ * libraries.
+ * <p>
+ * Key utility classes:
+ * <ul>
+ * <li>{@link gov.nist.secauto.metaschema.core.util.ObjectUtils} - Null-safety
+ * assertions and object validation ({@code notNull},
+ * {@code requireNonNull})</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.util.CollectionUtil} - Collection
+ * operations including unmodifiable wrappers, stream conversions, and null-safe
+ * accessors</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.util.CustomCollectors} - Custom
+ * stream collectors</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.util.AutoCloser} - Adapter for
+ * making resources {@link AutoCloseable}</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.util.StringUtils} - String
+ * manipulation and validation</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.util.UriUtils} - URI resolution
+ * and manipulation</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.util.DeleteOnShutdown} -
+ * Temporary file cleanup</li>
+ * <li>{@link gov.nist.secauto.metaschema.core.util.IVersionInfo} - Version
+ * information interface</li>
+ * </ul>
+ * <p>
+ * These utilities are primarily designed for internal framework use but may
+ * also be useful for applications built on the Metaschema framework.
  */
 
 package gov.nist.secauto.metaschema.core.util;

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/ExpressionUtilsTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/ExpressionUtilsTest.java
@@ -40,7 +40,7 @@ class ExpressionUtilsTest {
 
   @Test
   void testTwoFlags() {
-    Class<INodeItem> baseType = INodeItem.class;
+    final Class<INodeItem> baseType = INodeItem.class;
     basicFlagExpr1 = context.mock(IExpression.class, "basicFlagExpr1");
     basicFlagExpr2 = context.mock(IExpression.class, "basicFlagExpr2");
 
@@ -60,7 +60,7 @@ class ExpressionUtilsTest {
 
   @Test
   void testFlagAndAssembly() {
-    Class<INodeItem> baseType = INodeItem.class;
+    final Class<INodeItem> baseType = INodeItem.class;
     basicFlagExpr1 = context.mock(IExpression.class, "basicFlagExpr1");
     basicAssemblyExpr = context.mock(IExpression.class, "basicAssemblyExpr");
 
@@ -80,7 +80,7 @@ class ExpressionUtilsTest {
 
   @Test
   void testFieldAndAssembly() {
-    Class<INodeItem> baseType = INodeItem.class;
+    final Class<INodeItem> baseType = INodeItem.class;
     basicFieldExpr = context.mock(IExpression.class, "basicFieldExpr");
     basicAssemblyExpr = context.mock(IExpression.class, "basicAssemblyExpr");
 

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/TestUtils.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/TestUtils.java
@@ -306,11 +306,29 @@ public final class TestUtils {
     return IDayTimeDurationItem.valueOf(value);
   }
 
+  /**
+   * Create an enhanced QName with the given namespace and local name.
+   *
+   * @param namespace
+   *          the namespace URI
+   * @param localname
+   *          the local name
+   * @return the enhanced QName
+   */
   @NonNull
   public static IEnhancedQName eqname(@NonNull String namespace, @NonNull String localname) {
     return IEnhancedQName.of(namespace, localname);
   }
 
+  /**
+   * Create a QName item with the given namespace and local name.
+   *
+   * @param namespace
+   *          the namespace URI
+   * @param localname
+   *          the local name
+   * @return the QName item
+   */
   @NonNull
   public static IQNameItem qname(@NonNull String namespace, @NonNull String localname) {
     return IQNameItem.valueOf(eqname(namespace, localname));

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDataTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnDataTest.java
@@ -102,9 +102,8 @@ class FnDataTest
     assertEquals(3, result.size());
 
     // Verify actual values and order
-    java.util.List<IAnyAtomicItem> items = result.getValue();
-    assertEquals(1, ((IIntegerItem) items.get(0)).asInteger().intValue());
-    assertEquals(2, ((IIntegerItem) items.get(1)).asInteger().intValue());
-    assertEquals(3, ((IIntegerItem) items.get(2)).asInteger().intValue());
+    assertEquals(1, ((IIntegerItem) result.get(0)).asInteger().intValue());
+    assertEquals(2, ((IIntegerItem) result.get(1)).asInteger().intValue());
+    assertEquals(3, ((IIntegerItem) result.get(2)).asInteger().intValue());
   }
 }

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/item/node/AbstractRecursionPreventingNodeItemVisitorTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/item/node/AbstractRecursionPreventingNodeItemVisitorTest.java
@@ -5,12 +5,12 @@
 
 package gov.nist.secauto.metaschema.core.metapath.item.node;
 
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
 import gov.nist.secauto.metaschema.core.model.IModule;
 import gov.nist.secauto.metaschema.core.model.ISource;
-import gov.nist.secauto.metaschema.core.testsupport.builder.IModuleBuilder;
 import gov.nist.secauto.metaschema.core.testsupport.MockedModelTestSupport;
-
-import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import gov.nist.secauto.metaschema.core.testsupport.builder.IModuleBuilder;
 
 import org.junit.jupiter.api.Test;
 

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/item/node/RecursionCollectingNodeItemVisitorTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/metapath/item/node/RecursionCollectingNodeItemVisitorTest.java
@@ -10,8 +10,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import gov.nist.secauto.metaschema.core.model.IModule;
 import gov.nist.secauto.metaschema.core.model.ISource;
-import gov.nist.secauto.metaschema.core.testsupport.builder.IModuleBuilder;
 import gov.nist.secauto.metaschema.core.testsupport.MockedModelTestSupport;
+import gov.nist.secauto.metaschema.core.testsupport.builder.IModuleBuilder;
 
 import org.junit.jupiter.api.Test;
 

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/util/MermaidErDiagramGeneratorTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/util/MermaidErDiagramGeneratorTest.java
@@ -10,8 +10,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import gov.nist.secauto.metaschema.core.model.IModule;
 import gov.nist.secauto.metaschema.core.model.ISource;
 import gov.nist.secauto.metaschema.core.model.util.MermaidErDiagramGenerator;
-import gov.nist.secauto.metaschema.core.testsupport.builder.IModuleBuilder;
 import gov.nist.secauto.metaschema.core.testsupport.MockedModelTestSupport;
+import gov.nist.secauto.metaschema.core.testsupport.builder.IModuleBuilder;
 
 import org.junit.jupiter.api.Test;
 

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/DefaultBindingContext.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/DefaultBindingContext.java
@@ -271,8 +271,7 @@ public class DefaultBindingContext implements IBindingContext {
   @Override
   @SuppressWarnings({
       "PMD.EmptyFinalizer",
-      "checkstyle:NoFinalizer",
-      "deprecation" })
+      "checkstyle:NoFinalizer" })
   protected final void finalize() {
     // Do nothing
   }

--- a/pom.xml
+++ b/pom.xml
@@ -623,6 +623,12 @@
 					<artifactId>maven-javadoc-plugin</artifactId>
 					<configuration>
 						<excludePackageNames>*.xmlbeans:*.xmlbeans.*:*.antlr</excludePackageNames>
+						<encoding>UTF-8</encoding>
+						<docencoding>UTF-8</docencoding>
+						<charset>UTF-8</charset>
+						<additionalJOptions>
+							<additionalJOption>-J-Dfile.encoding=UTF-8</additionalJOption>
+						</additionalJOptions>
 						<failOnWarnings>false</failOnWarnings>
 						<failOnError>false</failOnError>
 					</configuration>


### PR DESCRIPTION
## Summary

- Added missing Javadoc comments to public/protected members across 99 files
- Improved package-level documentation in all 43 package-info.java files
- Created 14 new package-info.java files for previously undocumented packages
- Fixed Javadoc encoding issue on Windows with JDK 17 (added `-J-Dfile.encoding=UTF-8`)
- Fixed Checkstyle warnings (import order, variable declaration distance)

## Changes

### Javadoc Documentation (99 files)
- Added Javadocs to methods, constructors, and inner classes
- Fixed invalid @see references pointing to packages instead of classes
- Comprehensive coverage of model, metapath, datatype, and util packages

### Package Documentation (43 files)
- Enhanced existing package-info.java files with detailed descriptions
- Listed key interfaces/classes for each package
- Added cross-references and XPath 3.1 specification links
- Created new package-info.java for: mdm, metapath/impl, cst/items, cst/logic, function/impl, item/atomic/impl, item/function, type, model/impl, qname, and more

### Build Fixes
- Fixed Javadoc encoding on Windows: JDK 17 defaults to Windows-1252, causing "unmappable character" errors with UTF-8 source files
- Added `additionalJOption` `-J-Dfile.encoding=UTF-8` to maven-javadoc-plugin

### Checkstyle Fixes
- Fixed import order in test files
- Made local variables final to address VariableDeclarationUsageDistance warnings

## Test plan

- [x] `mvn clean install -PCI -Prelease -DskipTests` passes
- [x] `mvn -pl core checkstyle:check` passes with 0 violations
- [x] `mvn -pl core javadoc:javadoc` generates without encoding errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Extensive Javadoc and package-level documentation added across many core modules to improve discoverability and usage guidance.

* **New Features**
  * Added richer model APIs (new defaults, constants, enums), new diagram edge types, enhanced exception context capture, and utility unwrap helpers.

* **API Changes**
  * Removed a deprecated sequence accessor; added several default interface methods and small enum/constructor additions; tightened nullability on a function resolver method.

* **Chores**
  * Maven Javadoc configured for consistent UTF‑8 encoding.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->