### PR TITLE
Prepare for release: PMD fixes and code cleanup

### DIFF
--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/ICommandExecutor.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/ICommandExecutor.java
@@ -17,6 +17,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * implementations. Concrete subclasses must implement the {@link #execute()}
  * method to define specific command behavior.
  */
+@FunctionalInterface
 public interface ICommandExecutor {
   /**
    * Execute the command operation.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/ICustomJavaDataType.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/ICustomJavaDataType.java
@@ -14,6 +14,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * @param <TYPE>
  *          the type of the custom Java class
  */
+@FunctionalInterface
 public interface ICustomJavaDataType<TYPE extends ICustomJavaDataType<TYPE>> {
   /**
    * Provides a copy of the data value associated with the Datatype instance.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/flexmark/FlexmarkFactory.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/flexmark/FlexmarkFactory.java
@@ -21,7 +21,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * Provides factory methods for Flexmark processing to support HTML-to-markdown
  * and markdown-to-HTML conversion.
  */
-@SuppressWarnings("PMD.DataClass")
 public final class FlexmarkFactory {
   @NonNull
   private static final FlexmarkFactory SINGLETON = new FlexmarkFactory();

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/flexmark/impl/FixedEmphasisDelimiterProcessor.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/flexmark/impl/FixedEmphasisDelimiterProcessor.java
@@ -38,7 +38,6 @@ public class FixedEmphasisDelimiterProcessor
     this.multipleUse = strongWrapsEmphasis ? 1 : 2;
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn") // for readability
   @Override
   public int getDelimiterUse(DelimiterRun opener, DelimiterRun closer) {
     // "multiple of 3" rule for internal delimiter runs

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/flexmark/impl/IMarkupVisitor.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/flexmark/impl/IMarkupVisitor.java
@@ -19,6 +19,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  *          the Java type of exception that can be thrown when a writing error
  *          occurs
  */
+@FunctionalInterface
 @SuppressFBWarnings("THROWS_METHOD_THROWS_CLAUSE_THROWABLE")
 public interface IMarkupVisitor<T, E extends Throwable> {
   /**

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/flexmark/impl/SuppressPTagExtension.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/markup/flexmark/impl/SuppressPTagExtension.java
@@ -50,8 +50,8 @@ public class SuppressPTagExtension
   static class PTagNodeRenderer implements NodeRenderer {
 
     @Override
-    public @Nullable
-    Set<NodeRenderingHandler<?>> getNodeRenderingHandlers() {
+    @Nullable
+    public Set<NodeRenderingHandler<?>> getNodeRenderingHandlers() {
       return Collections.singleton(
           new NodeRenderingHandler<>(Paragraph.class, this::render));
     }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/object/AmbiguousDate.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/object/AmbiguousDate.java
@@ -43,7 +43,6 @@ public class AmbiguousDate
     return Objects.hash(getValue(), hasTimeZone());
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @Override
   public boolean equals(Object obj) {
     if (this == obj) {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/object/AmbiguousDateTime.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/object/AmbiguousDateTime.java
@@ -44,7 +44,6 @@ public class AmbiguousDateTime
     return Objects.hash(getValue(), hasTimeZone());
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @Override
   public boolean equals(Object obj) {
     if (this == obj) {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/object/AmbiguousTime.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/datatype/object/AmbiguousTime.java
@@ -43,7 +43,6 @@ public class AmbiguousTime
     return Objects.hash(getValue(), hasTimeZone());
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @Override
   public boolean equals(Object obj) {
     if (this == obj) {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/IErrorCode.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/IErrorCode.java
@@ -25,7 +25,6 @@ public interface IErrorCode {
    *          the error code value
    * @return a new error code instance
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   static IErrorCode of(@NonNull String prefix, int code) {
     return new ErrorCodeImpl(prefix, code);

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/For.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/For.java
@@ -22,7 +22,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * <a href="https://www.w3.org/TR/xpath-31/#id-for-expressions">For
  * expression</a> supporting variable-based iteration.
  */
-@SuppressWarnings("PMD.ShortClassName")
 public class For
     extends AbstractExpression {
   @NonNull

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/Let.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/Let.java
@@ -20,7 +20,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * <a href="https://www.w3.org/TR/xpath-31/#id-let-expressions">Let
  * expression</a> supporting variable value binding.
  */
-@SuppressWarnings("PMD.ShortClassName")
 public class Let
     extends AbstractExpression {
   @NonNull

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/items/Quantified.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/items/Quantified.java
@@ -155,12 +155,12 @@ public class Quantified
         subDynamicContext.bindVariableValue(var, ISequence.of(item));
       }
       boolean result = FnBoolean.fnBooleanAsPrimitive(getSatisfies().accept(subDynamicContext, focus));
-      if (Quantifier.EVERY.equals(quantifier) && !result) {
+      if (quantifier == Quantifier.EVERY && !result) {
         // fail on first false
         retval = false;
         break;
       }
-      if (Quantifier.SOME.equals(quantifier)) {
+      if (quantifier == Quantifier.SOME) {
         if (result) {
           // pass on first true
           retval = true;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/items/Quantified.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/items/Quantified.java
@@ -270,7 +270,6 @@ public class Quantified
       this.size = size;
     }
 
-    @SuppressWarnings("PMD.OnlyOneReturn") // readability
     @Override
     public Iterator<List<T>> iterator() {
       if (size == 0) {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/logic/If.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/logic/If.java
@@ -23,7 +23,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * <a href="https://www.w3.org/TR/xpath-31/#doc-xpath31-IfExpr">If
  * expression</a> supporting conditional evaluation.
  */
-@SuppressWarnings("PMD.ShortClassName")
 public class If
     extends AbstractExpression {
   private final IExpression testExpression;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/logic/Or.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/logic/Or.java
@@ -31,7 +31,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * This implementation will short-circuit and return {@code true} when the first
  * expression evaluates to {@code true}, otherwise it will return {@code false}.
  */
-@SuppressWarnings("PMD.ShortClassName")
 public class Or
     extends AbstractNAryExpression
     implements IBooleanLogicExpression {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/math/AbstractBasicArithmeticExpression.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/math/AbstractBasicArithmeticExpression.java
@@ -101,7 +101,6 @@ public abstract class AbstractBasicArithmeticExpression
    *          timezone
    * @return the result of the operation
    */
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @NonNull
   protected IAnyAtomicItem operation(
       @NonNull IAnyAtomicItem left,

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/path/Axis.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/path/Axis.java
@@ -18,7 +18,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * An implementation of <a href="https://www.w3.org/TR/xpath-31/#axes">Metapath
  * axes</a>.
  */
-@SuppressWarnings("PMD.ShortClassName")
 public enum Axis {
   /**
    * The {@code self::} axis, referring to the current context node.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/path/IWildcardMatcher.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/path/IWildcardMatcher.java
@@ -18,6 +18,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * <a href="https://www.w3.org/TR/xpath-31/#node-tests">wildcard node test</a>
  * syntax.
  */
+@FunctionalInterface
 public interface IWildcardMatcher extends Predicate<IDefinitionNodeItem<?, ?>> {
   /**
    * Construct a wildcard matcher that matches the provided local name in any

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/path/Step.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/path/Step.java
@@ -27,7 +27,6 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * with the evaluation of a series of predicate expressions that filter the
  * result of the evaluation.
  */
-@SuppressWarnings("PMD.ShortClassName")
 public class Step
     extends AbstractExpression {
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/type/Cast.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/type/Cast.java
@@ -18,7 +18,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * A compact syntax tree node that supports the Metapath
  * <a href="https://www.w3.org/TR/xpath-31/#id-cast">"cast as" operator</a>.
  */
-@SuppressWarnings("PMD.ShortClassName")
 public class Cast
     extends AbstractCastingExpression {
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/type/Castable.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/type/Castable.java
@@ -20,7 +20,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * A compact syntax tree node that supports the Metapath
  * <a href="https://www.w3.org/TR/xpath-31/#id-cast">"cast as" operator</a>.
  */
-@SuppressWarnings("PMD.ShortClassName")
 public class Castable
     extends AbstractCastingExpression {
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/type/Treat.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/cst/type/Treat.java
@@ -23,7 +23,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * A compact syntax tree node that supports the Metapath
  * <a href="https://www.w3.org/TR/xpath-31/#id-cast">"cast as" operator</a>.
  */
-@SuppressWarnings("PMD.ShortClassName")
 public class Treat
     extends AbstractExpression {
   @NonNull

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/format/MetapathFormatter.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/format/MetapathFormatter.java
@@ -25,8 +25,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public class MetapathFormatter implements IPathFormatter {
 
   @Override
-  public @NonNull
-  String formatMetaschema(IModuleNodeItem metaschema) {
+  @NonNull
+  public String formatMetaschema(IModuleNodeItem metaschema) {
     // this will result in a slash being generated using the join in the format
     // method
     return "";

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/CalledContext.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/CalledContext.java
@@ -90,7 +90,6 @@ public final class CalledContext {
     return prime * result + Objects.hash(contextItem, arguments);
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @Override
   public boolean equals(Object obj) {
     if (this == obj) {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/FunctionUtils.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/FunctionUtils.java
@@ -32,7 +32,6 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  */
 // FIXME: Remove these methods in favor of direct calls to methods on the item
 // types
-@SuppressWarnings("PMD.CouplingBetweenObjects")
 public final class FunctionUtils {
   private FunctionUtils() {
     // disable

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/IArgument.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/IArgument.java
@@ -32,7 +32,6 @@ public interface IArgument {
    *          the argument's sequence type
    * @return a new argument instance
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   static IArgument of(@NonNull IEnhancedQName name, @NonNull ISequenceType sequenceType) {
     return new ArgumentImpl(name, sequenceType);

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArraySubarray.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/ArraySubarray.java
@@ -124,7 +124,6 @@ public final class ArraySubarray {
    * @throws IndexOutOfBoundsArrayMetapathException
    *           if the start position is not in the range of 1 to array:size
    */
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @NonNull
   public static <T extends ICollectionValue> IArrayItem<T> subarray(
       @NonNull IArrayItem<T> array,
@@ -151,7 +150,6 @@ public final class ArraySubarray {
    * @throws IndexOutOfBoundsArrayMetapathException
    *           if the start position is not in the range of 1 to array:size
    */
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @NonNull
   public static <T extends ICollectionValue> IArrayItem<T> subarray(
       @NonNull IArrayItem<T> array,

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnInsertBefore.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnInsertBefore.java
@@ -85,7 +85,6 @@ public final class FnInsertBefore {
    *          the sequence of Metapath items to be inserted into the target
    * @return the sequence of Metapath items with insertions
    */
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @NonNull
   public static <T extends IItem> List<T> fnInsertBefore(
       @NonNull List<T> target,

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnMinMax.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnMinMax.java
@@ -171,7 +171,6 @@ public final class FnMinMax {
         });
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn") // readability
   private static Stream<? extends IAnyAtomicItem> normalize(
       @NonNull List<? extends IAnyAtomicItem> items) {
     if (items.isEmpty()) {
@@ -202,7 +201,6 @@ public final class FnMinMax {
     return ISequence.ofCollection((List<IAnyAtomicItem>) items).countTypes(PRIMITIVE_ITEM_TYPES);
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @NonNull
   private static Stream<? extends IAnyAtomicItem> createNormalizedStream(
       @NonNull List<? extends IAnyAtomicItem> items,

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnRemove.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnRemove.java
@@ -75,7 +75,6 @@ public final class FnRemove {
    *          the position of the item in the sequence to be removed
    * @return {@code sequence} the new sequence with the item removed
    */
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @NonNull
   public static <T extends IItem> List<T> fnRemove(
       @NonNull List<T> target,

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnReverse.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnReverse.java
@@ -68,7 +68,6 @@ public final class FnReverse {
    * @return {@code sequence} the new sequence with items in reverse order.
    *
    */
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @NonNull
   public static <T extends IItem> List<T> fnReverse(@NonNull List<T> target) {
     if (target.size() <= 1) {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnStringJoin.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnStringJoin.java
@@ -73,7 +73,7 @@ public final class FnStringJoin {
     // disable construction
   }
 
-  @SuppressWarnings({ "unused", "PMD.OnlyOneReturn" })
+  @SuppressWarnings("unused")
   @NonNull
   private static ISequence<IStringItem> execute(
       @NonNull IFunction function,

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstring.java
@@ -80,7 +80,7 @@ public final class FnSubstring {
     // disable construction
   }
 
-  @SuppressWarnings({ "unused", "PMD.OnlyOneReturn" })
+  @SuppressWarnings("unused")
   @NonNull
   private static ISequence<IStringItem> executeTwoArg(
       @NonNull IFunction function,
@@ -105,7 +105,7 @@ public final class FnSubstring {
             sourceString.asString().length() - Math.max(startIndex, 1) + 1)));
   }
 
-  @SuppressWarnings({ "unused", "PMD.OnlyOneReturn" })
+  @SuppressWarnings("unused")
   @NonNull
   private static ISequence<IStringItem> executeThreeArg(
       @NonNull IFunction function,

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstringAfter.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstringAfter.java
@@ -56,7 +56,7 @@ public final class FnSubstringAfter {
     // disable construction
   }
 
-  @SuppressWarnings({ "unused", "PMD.OnlyOneReturn" })
+  @SuppressWarnings("unused")
   @NonNull
   private static ISequence<IStringItem> executeTwoArg(
       @NonNull IFunction function,

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstringBefore.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSubstringBefore.java
@@ -56,7 +56,7 @@ public final class FnSubstringBefore {
     // disable construction
   }
 
-  @SuppressWarnings({ "unused", "PMD.OnlyOneReturn" })
+  @SuppressWarnings("unused")
   @NonNull
   private static ISequence<IStringItem> executeTwoArg(
       @NonNull IFunction function,

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSum.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnSum.java
@@ -117,7 +117,6 @@ public final class FnSum {
    * @return the average
    */
   @SuppressWarnings({
-      "PMD.OnlyOneReturn", // readability
       "PMD.CyclomaticComplexity", // ok
       "unchecked" // safe cast for wildcard type
   })

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTokenize.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/FnTokenize.java
@@ -146,7 +146,6 @@ public final class FnTokenize {
     return execute(input, pattern, flags);
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @NonNull
   private static ISequence<IStringItem> execute(
       @Nullable IStringItem input,
@@ -191,7 +190,7 @@ public final class FnTokenize {
    *          matching options
    * @return the stream of tokens
    */
-  @SuppressWarnings({ "PMD.OnlyOneReturn", "PMD.CyclomaticComplexity" })
+  @SuppressWarnings("PMD.CyclomaticComplexity")
   @NonNull
   public static List<String> fnTokenize(@NonNull String input, @NonNull String pattern, @NonNull String flags) {
     if (input.isEmpty()) {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapMerge.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/function/library/MapMerge.java
@@ -171,7 +171,7 @@ public final class MapMerge {
    *          settings that affect the merge behavior
    * @return a map containing the merged entries
    */
-  @SuppressWarnings({ "null", "PMD.OnlyOneReturn" })
+  @SuppressWarnings("null")
   @NonNull
   public static IMapItem<?> merge(@NonNull Collection<? extends Map<IMapKey, ? extends ICollectionValue>> maps,
       @NonNull Map<IMapKey, ? extends ICollectionValue> options) {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/impl/AbstractSequence.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/impl/AbstractSequence.java
@@ -179,7 +179,6 @@ public abstract class AbstractSequence<ITEM extends IItem>
     return new UnsupportedOperationException("sequences are immutable");
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @Override
   public boolean equals(Object other) {
     // must either be the same instance or a sequence that has the same list
@@ -208,7 +207,6 @@ public abstract class AbstractSequence<ITEM extends IItem>
     return asList().hashCode();
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @Override
   public boolean deepEquals(ICollectionValue other, DynamicContext dynamicContext) {
     if (!(other instanceof ISequence)) {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/ISequence.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/ISequence.java
@@ -38,7 +38,6 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * @param <ITEM>
  *          the Java type of the items in a sequence
  */
-@SuppressWarnings("PMD.ShortMethodName")
 public interface ISequence<ITEM extends IItem> extends List<ITEM>, ICollectionValue {
   /**
    * Get an empty sequence.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/ItemUtils.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/ItemUtils.java
@@ -102,11 +102,11 @@ public final class ItemUtils {
       @NonNull ISequence<?> items) {
     return ISequence.of(ObjectUtils.notNull(items.stream()
         // ensures a non-null INodeItem instance
-        .map(item -> ItemUtils.checkItemIsNodeItem(dynamicContext, item))
+        .map(item -> checkItemIsNodeItem(dynamicContext, item))
         .map(item -> Axis.ANCESTOR_OR_SELF.execute(ObjectUtils.notNull(item))
             .findFirst().stream()
             .filter(IDocumentBasedNodeItem.class::isInstance)
-            .map(firstItem -> ItemUtils.checkItemIsDocumentNodeItem(dynamicContext, firstItem))
+            .map(firstItem -> checkItemIsDocumentNodeItem(dynamicContext, firstItem))
             .findFirst().orElseThrow(() -> new InvalidTreatTypeDynamicMetapathException(
                 dynamicContext.getExecutionStack(),
                 String.format("The node '%s' is not the descendant of a document node.",

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/AbstractDateItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/AbstractDateItem.java
@@ -41,7 +41,6 @@ public abstract class AbstractDateItem<TYPE>
     return 31 * result * getClass().hashCode();
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @Override
   public boolean equals(Object obj) {
     if (this == obj) {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/AbstractDateTimeItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/AbstractDateTimeItem.java
@@ -41,7 +41,6 @@ public abstract class AbstractDateTimeItem<TYPE>
     return 31 * result * getClass().hashCode();
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @Override
   public boolean equals(Object obj) {
     if (this == obj) {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/AbstractIPAddressItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/AbstractIPAddressItem.java
@@ -45,7 +45,6 @@ public abstract class AbstractIPAddressItem<TYPE extends IPAddress>
     return asIpAddress().hashCode();
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @Override
   public boolean equals(Object obj) {
     return this == obj

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/AbstractIntegerItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/AbstractIntegerItem.java
@@ -50,7 +50,6 @@ public abstract class AbstractIntegerItem
     return asInteger().hashCode();
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @Override
   public boolean equals(Object obj) {
     return this == obj

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/AbstractMarkupItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/AbstractMarkupItem.java
@@ -50,7 +50,6 @@ public abstract class AbstractMarkupItem<TYPE extends IMarkupString<TYPE>>
     return "'" + asString() + "'";
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @Override
   public boolean equals(Object obj) {
     return this == obj

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/AbstractStringItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/AbstractStringItem.java
@@ -75,7 +75,6 @@ public abstract class AbstractStringItem
     return asString().hashCode();
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @Override
   public boolean equals(Object obj) {
     return this == obj

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/AbstractTimeItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/AbstractTimeItem.java
@@ -39,7 +39,6 @@ public abstract class AbstractTimeItem<TYPE>
     return asOffsetTime().withOffsetSameInstant(ZoneOffset.UTC).hashCode();
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @Override
   public boolean equals(Object obj) {
     if (this == obj) {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/AbstractUriItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/AbstractUriItem.java
@@ -63,7 +63,6 @@ public abstract class AbstractUriItem
     return "'" + asString() + "'";
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @Override
   public boolean equals(Object obj) {
     return this == obj

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/Base64BinaryItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/Base64BinaryItemImpl.java
@@ -49,7 +49,6 @@ public class Base64BinaryItemImpl
     return asByteBuffer().hashCode();
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @Override
   public boolean equals(Object obj) {
     return this == obj

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/BooleanItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/BooleanItemImpl.java
@@ -83,7 +83,6 @@ public class BooleanItemImpl
     return Boolean.hashCode(booleanValue);
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @Override
   public boolean equals(Object obj) {
     return this == obj

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/DayTimeDurationItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/DayTimeDurationItemImpl.java
@@ -66,7 +66,6 @@ public class DayTimeDurationItemImpl
     return asDuration().hashCode();
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @Override
   public boolean equals(Object obj) {
     return this == obj

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/DecimalItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/DecimalItemImpl.java
@@ -76,7 +76,6 @@ public class DecimalItemImpl
     return Objects.hash(asDecimal());
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @Override
   public boolean equals(Object obj) {
     return this == obj

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/HexBinaryItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/HexBinaryItem.java
@@ -49,7 +49,6 @@ public class HexBinaryItem
     return asByteBuffer().hashCode();
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @Override
   public boolean equals(Object obj) {
     return this == obj

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/QNameItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/QNameItemImpl.java
@@ -76,7 +76,6 @@ public class QNameItemImpl
     return value.hashCode();
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @Override
   public boolean equals(Object obj) {
     return this == obj

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/UuidItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/UuidItemImpl.java
@@ -57,7 +57,6 @@ public class UuidItemImpl
     return asString().hashCode();
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @Override
   public boolean equals(Object obj) {
     return this == obj

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/YearMonthDurationItemImpl.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/atomic/impl/YearMonthDurationItemImpl.java
@@ -50,7 +50,6 @@ public class YearMonthDurationItemImpl
     return Objects.hash(asPeriod());
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn") // readability
   @Override
   public boolean equals(Object obj) {
     return this == obj

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/IArrayItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/IArrayItem.java
@@ -40,7 +40,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * @param <ITEM>
  *          the Metapath item type of array members
  */
-@SuppressWarnings({ "PMD.ShortMethodName", "PMD.ExcessivePublicCount" })
+@SuppressWarnings("PMD.ExcessivePublicCount")
 public interface IArrayItem<ITEM extends ICollectionValue> extends IFunction, List<ITEM> {
   /**
    * Get the type information for this item.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/ICalendarMapKey.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/ICalendarMapKey.java
@@ -10,6 +10,7 @@ import gov.nist.secauto.metaschema.core.metapath.item.atomic.ICalendarTemporalIt
 /**
  * An {@link IMapItem} key based on an {@link ICalendarTemporalItem}.
  */
+@FunctionalInterface
 public interface ICalendarMapKey extends ITemporalMapKey {
   @Override
   ICalendarTemporalItem getKey();

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/IKeySpecifier.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/IKeySpecifier.java
@@ -17,6 +17,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 /**
  * A common interface for all key specifier implementations.
  */
+@FunctionalInterface
 public interface IKeySpecifier {
 
   /**

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/IMapItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/IMapItem.java
@@ -167,7 +167,6 @@ public interface IMapItem<VALUE extends ICollectionValue>
    *          the value Java type
    * @return an empty {@code IMapItem}
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   static <V extends ICollectionValue> IMapItem<V> of() {
     return AbstractMapItem.empty();
@@ -188,7 +187,6 @@ public interface IMapItem<VALUE extends ICollectionValue>
    * @throws NullPointerException
    *           if the key or the value is {@code null}
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   static <K extends IAnyAtomicItem, V extends ICollectionValue> IMapItem<V> of(@NonNull K k1, @NonNull V v1) {
     return new MapItemN<>(entry(k1, v1));
@@ -215,7 +213,6 @@ public interface IMapItem<VALUE extends ICollectionValue>
    * @throws NullPointerException
    *           if any key or value is {@code null}
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   static <K extends IAnyAtomicItem, V extends ICollectionValue> IMapItem<V> of(
       @NonNull K k1, @NonNull V v1,
@@ -250,7 +247,6 @@ public interface IMapItem<VALUE extends ICollectionValue>
    * @throws NullPointerException
    *           if any key or value is {@code null}
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   static <K extends IAnyAtomicItem, V extends ICollectionValue>
       IMapItem<V> of(
@@ -292,7 +288,6 @@ public interface IMapItem<VALUE extends ICollectionValue>
    * @throws NullPointerException
    *           if any key or value is {@code null}
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   static <K extends IAnyAtomicItem, V extends ICollectionValue>
       IMapItem<V> of(
@@ -340,7 +335,6 @@ public interface IMapItem<VALUE extends ICollectionValue>
    * @throws NullPointerException
    *           if any key or value is {@code null}
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   static <K extends IAnyAtomicItem, V extends ICollectionValue>
       IMapItem<V> of(
@@ -394,10 +388,7 @@ public interface IMapItem<VALUE extends ICollectionValue>
    * @throws NullPointerException
    *           if any key or value is {@code null}
    */
-  @SuppressWarnings({
-      "PMD.ExcessiveParameterList",
-      "PMD.ShortMethodName"
-  })
+  @SuppressWarnings("PMD.ExcessiveParameterList")
   @NonNull
   static <K extends IAnyAtomicItem, V extends ICollectionValue>
       IMapItem<V> of(
@@ -458,10 +449,7 @@ public interface IMapItem<VALUE extends ICollectionValue>
    * @throws NullPointerException
    *           if any key or value is {@code null}
    */
-  @SuppressWarnings({
-      "PMD.ExcessiveParameterList",
-      "PMD.ShortMethodName"
-  })
+  @SuppressWarnings("PMD.ExcessiveParameterList")
   @NonNull
   static <K extends IAnyAtomicItem, V extends ICollectionValue> IMapItem<V> of(
       @NonNull K k1, @NonNull V v1,
@@ -527,10 +515,7 @@ public interface IMapItem<VALUE extends ICollectionValue>
    * @throws NullPointerException
    *           if any key or value is {@code null}
    */
-  @SuppressWarnings({
-      "PMD.ExcessiveParameterList",
-      "PMD.ShortMethodName"
-  })
+  @SuppressWarnings("PMD.ExcessiveParameterList")
   @NonNull
   static <K extends IAnyAtomicItem, V extends ICollectionValue>
       IMapItem<V> of(
@@ -602,10 +587,7 @@ public interface IMapItem<VALUE extends ICollectionValue>
    * @throws NullPointerException
    *           if any key or value is {@code null}
    */
-  @SuppressWarnings({
-      "PMD.ExcessiveParameterList",
-      "PMD.ShortMethodName"
-  })
+  @SuppressWarnings("PMD.ExcessiveParameterList")
   @NonNull
   static <K extends IAnyAtomicItem, V extends ICollectionValue>
       IMapItem<V> of(
@@ -675,10 +657,7 @@ public interface IMapItem<VALUE extends ICollectionValue>
    * @throws NullPointerException
    *           if any key or value is {@code null}
    */
-  @SuppressWarnings({
-      "PMD.ExcessiveParameterList",
-      "PMD.ShortMethodName"
-  })
+  @SuppressWarnings("PMD.ExcessiveParameterList")
   @NonNull
   static <K extends IAnyAtomicItem, V extends ICollectionValue> IMapItem<V> of(
       @NonNull K k1, @NonNull V v1,

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/IOpaqueMapKey.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/IOpaqueMapKey.java
@@ -9,6 +9,7 @@ package gov.nist.secauto.metaschema.core.metapath.item.function;
  * Represents a map key with no special handling based on the key value's data
  * type. In this way the key value is essentially "opaque".
  */
+@FunctionalInterface
 public interface IOpaqueMapKey extends IMapKey {
   @Override
   @SuppressWarnings("PMD.CompareObjectsWithEquals")

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/ITemporalMapKey.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/ITemporalMapKey.java
@@ -10,6 +10,7 @@ import gov.nist.secauto.metaschema.core.metapath.item.atomic.ITemporalItem;
 /**
  * An {@link IMapItem} key based on an {@link ITemporalItem} value.
  */
+@FunctionalInterface
 public interface ITemporalMapKey extends IMapKey {
 
   @Override

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/ITemporalMapKey.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/ITemporalMapKey.java
@@ -17,7 +17,6 @@ public interface ITemporalMapKey extends IMapKey {
   ITemporalItem getKey();
 
   @Override
-  @SuppressWarnings("PMD.OnlyOneReturn")
   default boolean isSameKey(IMapKey other) {
     if (!(other instanceof ITemporalMapKey)) {
       return false;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/impl/AbstractArrayItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/impl/AbstractArrayItem.java
@@ -100,7 +100,6 @@ public abstract class AbstractArrayItem<ITEM extends ICollectionValue>
         || other instanceof IArrayItem && getValue().equals(((IArrayItem<?>) other).getValue());
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @Override
   public boolean deepEquals(ICollectionValue other, DynamicContext dynamicContext) {
     if (!(other instanceof IArrayItem)) {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/impl/AbstractMapItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/function/impl/AbstractMapItem.java
@@ -107,7 +107,6 @@ public abstract class AbstractMapItem<VALUE extends ICollectionValue>
         || other instanceof IMapItem && getValue().equals(((IMapItem<?>) other).getValue());
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @Override
   public boolean deepEquals(ICollectionValue other, DynamicContext dynamicContext) {
     if (!(other instanceof IMapItem)) {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/IFieldNodeItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/IFieldNodeItem.java
@@ -69,8 +69,8 @@ public interface IFieldNodeItem
   }
 
   @Override
-  default @NonNull
-  String format(@NonNull IPathFormatter formatter) {
+  @NonNull
+  default String format(@NonNull IPathFormatter formatter) {
     return formatter.formatField(this);
   }
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/IFlagNodeItem.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/IFlagNodeItem.java
@@ -105,8 +105,8 @@ public interface IFlagNodeItem
    */
   @SuppressWarnings("null")
   @Override
-  default @NonNull
-  Stream<? extends IFlagNodeItem> flags() {
+  @NonNull
+  default Stream<? extends IFlagNodeItem> flags() {
     // a flag does not have flags
     return Stream.empty();
   }
@@ -117,8 +117,8 @@ public interface IFlagNodeItem
    */
   @SuppressWarnings("null")
   @Override
-  default @NonNull
-  Collection<? extends List<? extends IModelNodeItem<?, ?>>> getModelItems() {
+  @NonNull
+  default Collection<? extends List<? extends IModelNodeItem<?, ?>>> getModelItems() {
     // a flag does not have model items
     return Collections.emptyList();
   }
@@ -146,8 +146,8 @@ public interface IFlagNodeItem
   }
 
   @Override
-  default @NonNull
-  String format(@NonNull IPathFormatter formatter) {
+  @NonNull
+  default String format(@NonNull IPathFormatter formatter) {
     return formatter.formatFlag(this);
   }
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/INodeItemVisitable.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/INodeItemVisitable.java
@@ -6,6 +6,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 /**
  * Marks a node item as visitable by a {@link INodeItemVisitor}.
  */
+@FunctionalInterface
 public interface INodeItemVisitable {
   /**
    * A visitor callback.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/NodeComparators.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/NodeComparators.java
@@ -42,7 +42,7 @@ public final class NodeComparators {
       @NonNull INodeItem item1,
       @NonNull INodeItem item2,
       @NonNull DynamicContext dynamicContext) {
-    return item1.getNodeType().equals(item2.getNodeType())
+    return item1.getNodeType() == item2.getNodeType()
         && compareFlags(item1.getFlags(), item2.getFlags(), dynamicContext)
         && compareModelItems(item1.getModelItems(), item2.getModelItems(), dynamicContext);
   }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/NodeComparators.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/item/node/NodeComparators.java
@@ -82,7 +82,6 @@ public final class NodeComparators {
     return retval;
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   private static boolean compareFlags(
       @NonNull Collection<? extends IFlagNodeItem> flags1,
       @NonNull Collection<? extends IFlagNodeItem> flags2,
@@ -111,7 +110,6 @@ public final class NodeComparators {
     return true;
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   private static boolean compareModelItems(
       @NonNull Collection<? extends List<? extends IModelNodeItem<?, ?>>> items1,
       @NonNull Collection<? extends List<? extends IModelNodeItem<?, ?>>> items2,
@@ -164,7 +162,6 @@ public final class NodeComparators {
         && compareAtomics(item1.toAtomicItem(), item2.toAtomicItem(), dynamicContext);
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   private static boolean compareAsField(
       @NonNull IModelNodeItem<?, ?> item1,
       @NonNull IModelNodeItem<?, ?> item2,

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/type/DataTypeItemType.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/type/DataTypeItemType.java
@@ -69,7 +69,6 @@ public class DataTypeItemType<T extends IAnyAtomicItem>
     return Objects.hash(adapter, getItemClass());
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @Override
   public boolean equals(Object obj) {
     if (this == obj) {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/type/IArrayTest.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/type/IArrayTest.java
@@ -14,6 +14,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 /**
  * Declares the expected type information for an {@link IArrayItem}.
  */
+@FunctionalInterface
 public interface IArrayTest extends IItemType {
   @SuppressWarnings({ "rawtypes" })
   @Override

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/type/IAtomicOrUnionType.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/type/IAtomicOrUnionType.java
@@ -36,7 +36,6 @@ public interface IAtomicOrUnionType<I extends IAnyAtomicItem> extends IItemType 
    *          the qualified name of the type
    * @return the type information
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   static <I extends IAnyAtomicItem> IAtomicOrUnionType<I> of(
       Class<I> itemClass,

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/type/ISequenceType.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/type/ISequenceType.java
@@ -37,7 +37,6 @@ public interface ISequenceType {
    *          the expected occurrence of the sequence
    * @return the new sequence type
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   static ISequenceType of(
       @NonNull IItemType type,

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/type/ISequenceType.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/type/ISequenceType.java
@@ -42,7 +42,7 @@ public interface ISequenceType {
   static ISequenceType of(
       @NonNull IItemType type,
       @NonNull Occurrence occurrence) {
-    return Occurrence.ZERO.equals(occurrence)
+    return occurrence == Occurrence.ZERO
         ? empty()
         : new SequenceTypeImpl(type, occurrence);
   }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/type/impl/NonAdapterAtomicItemType.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/metapath/type/impl/NonAdapterAtomicItemType.java
@@ -66,7 +66,6 @@ public class NonAdapterAtomicItemType<T extends IAnyAtomicItem>
     return Objects.hash(getItemClass(), qname);
   }
 
-  @SuppressWarnings("PMD.OnlyOneReturn")
   @Override
   public boolean equals(Object obj) {
     if (this == obj) {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/AbstractContainerModelSupport.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/AbstractContainerModelSupport.java
@@ -42,7 +42,6 @@ public abstract class AbstractContainerModelSupport<
   /**
    * Construct an empty, mutable container.
    */
-  @SuppressWarnings("PMD.UseConcurrentHashMap")
   public AbstractContainerModelSupport() {
     this(
         new LinkedHashMap<>(),

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IAttributable.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IAttributable.java
@@ -18,6 +18,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * A marker interface for implementations that supports the mapping of a
  * namespace valued key to a set of values.
  */
+@FunctionalInterface
 public interface IAttributable {
   /**
    * The default key namespace for a property.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IAttributable.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IAttributable.java
@@ -109,7 +109,6 @@ public interface IAttributable {
    */
   // FIXME: use IEnhancedQName instead of name and namespace, or replace key
   // altogether with an integer value
-  @SuppressWarnings("PMD.ShortClassName")
   final class Key {
     @NonNull
     private final String name;
@@ -150,7 +149,6 @@ public interface IAttributable {
       return Objects.hash(name, namespace);
     }
 
-    @SuppressWarnings("PMD.OnlyOneReturn")
     @Override
     public boolean equals(Object obj) {
       if (this == obj) {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IBoundObject.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IBoundObject.java
@@ -11,6 +11,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * A common interface found bound objects that have a complex model consisting
  * of flags, fields, or assemblies.
  */
+@FunctionalInterface
 public interface IBoundObject {
   /**
    * Get additional Metaschema-related information for the object (i.e., resource

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IContainer.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IContainer.java
@@ -11,6 +11,7 @@ package gov.nist.secauto.metaschema.core.model;
  * This interface is implemented by model definitions that may contain flags,
  * fields, or assemblies as part of their structure.
  */
+@FunctionalInterface
 public interface IContainer {
   /**
    * Identifies if the container allows child instances or not.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IGroupable.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IGroupable.java
@@ -86,7 +86,7 @@ public interface IGroupable extends IInstance {
    */
   @Nullable
   default IEnhancedQName getEffectiveXmlGroupAsQName() {
-    return XmlGroupAsBehavior.GROUPED.equals(getXmlGroupAsBehavior())
+    return getXmlGroupAsBehavior() == XmlGroupAsBehavior.GROUPED
         ? IEnhancedQName.of(
             getContainingDefinition().getQName().getNamespace(),
             ObjectUtils.requireNonNull(getGroupAsName()))

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IJsonInstance.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IJsonInstance.java
@@ -13,6 +13,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * This interface provides access to the name used when the instance appears in
  * JSON or YAML serialization.
  */
+@FunctionalInterface
 public interface IJsonInstance {
   /**
    * Get the name used for the instance in JSON/YAML serialization.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IJsonNamed.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IJsonNamed.java
@@ -13,6 +13,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * This interface provides access to the name used when serializing or
  * deserializing the element in JSON or YAML format.
  */
+@FunctionalInterface
 public interface IJsonNamed {
 
   /**

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IMetapathQueryable.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IMetapathQueryable.java
@@ -15,6 +15,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * This interface provides access to the node item representation required for
  * Metapath evaluation.
  */
+@FunctionalInterface
 public interface IMetapathQueryable {
   /**
    * Get the Metapath node item for this Metaschema module construct, which can be

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IModelElementVisitable.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IModelElementVisitable.java
@@ -13,6 +13,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * This interface supports traversal of model elements using implementations of
  * {@link IModelElementVisitor}.
  */
+@FunctionalInterface
 public interface IModelElementVisitable {
   /**
    * A visitor callback.

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IModuleExtended.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IModuleExtended.java
@@ -67,8 +67,8 @@ public interface IModuleExtended<
    * @return a predicate implementing the filter
    */
   static <DEF extends IDefinition> Predicate<DEF> allNonLocalDefinitions() {
-    return definition -> IDefinition.ModuleScope.PUBLIC.equals(definition.getModuleScope())
-        || ModelType.ASSEMBLY.equals(definition.getModelType())
+    return definition -> definition.getModuleScope() == IDefinition.ModuleScope.PUBLIC
+        || definition.getModelType() == ModelType.ASSEMBLY
             && ((IAssemblyDefinition) definition).isRoot();
   }
 
@@ -80,7 +80,7 @@ public interface IModuleExtended<
    * @return a predicate implementing the filter
    */
   static <DEF extends IDefinition> Predicate<DEF> allRootAssemblyDefinitions() {
-    return definition -> ModelType.ASSEMBLY.equals(definition.getModelType())
+    return definition -> definition.getModelType() == ModelType.ASSEMBLY
         && ((IAssemblyDefinition) definition).isRoot();
   }
 

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/INamedModelInstanceAbsolute.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/INamedModelInstanceAbsolute.java
@@ -39,7 +39,7 @@ public interface INamedModelInstanceAbsolute extends INamedModelInstance, IModel
   @Override
   @Nullable
   default IFlagInstance getEffectiveJsonKey() {
-    return JsonGroupAsBehavior.KEYED.equals(getJsonGroupAsBehavior())
+    return getJsonGroupAsBehavior() == JsonGroupAsBehavior.KEYED
         ? getJsonKey()
         : null;
   }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/INamedModelInstanceGrouped.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/INamedModelInstanceGrouped.java
@@ -51,7 +51,7 @@ public interface INamedModelInstanceGrouped extends INamedModelInstance {
   @Override
   @Nullable
   default IFlagInstance getEffectiveJsonKey() {
-    return JsonGroupAsBehavior.KEYED.equals(getParentContainer().getJsonGroupAsBehavior())
+    return getParentContainer().getJsonGroupAsBehavior() == JsonGroupAsBehavior.KEYED
         ? ObjectUtils.requireNonNull(getJsonKey())
         : null;
   }

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/IUriResolver.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/IUriResolver.java
@@ -12,6 +12,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 /**
  * Provides URI resolution capabilities for Metaschema resources.
  */
+@FunctionalInterface
 public interface IUriResolver {
   /**
    * Resolve the provided URI, producing a resolved URI, which may point to a

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/AssemblyConstraintSet.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/AssemblyConstraintSet.java
@@ -18,7 +18,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * Represents a container of rules constraining the effective model of a
  * Metaschema assembly data instance.
  */
-@SuppressWarnings("PMD.CouplingBetweenObjects")
 public class AssemblyConstraintSet
     extends ValueConstraintSet
     implements IModelConstrained {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/DefaultConstraintValidator.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/DefaultConstraintValidator.java
@@ -950,8 +950,8 @@ public class DefaultConstraintValidator
       if (newExtensible.ordinal() > extensible.ordinal()) {
         // record the most restrictive value
         extensible = allowedValues.getExtensible();
-      } else if (IAllowedValuesConstraint.Extensible.NONE.equals(newExtensible)
-          && IAllowedValuesConstraint.Extensible.NONE.equals(extensible)) {
+      } else if (newExtensible == IAllowedValuesConstraint.Extensible.NONE
+          && extensible == IAllowedValuesConstraint.Extensible.NONE) {
         // this is an error, where there are two none constraints that conflict
         // TODO: find a different exception type to use
         throw new ConstraintValidationException(
@@ -963,7 +963,7 @@ public class DefaultConstraintValidator
                     constraints.stream()
                         .map(Pair::getLeft)
                         .filter(
-                            constraint -> IAllowedValuesConstraint.Extensible.NONE.equals(constraint.getExtensible())))
+                            constraint -> constraint.getExtensible() == IAllowedValuesConstraint.Extensible.NONE))
                     .map(IConstraint::getConstraintIdentity)
                     .collect(Collectors.joining(", ", "{", "}")),
                 item.getMetapath())));
@@ -994,7 +994,7 @@ public class DefaultConstraintValidator
           if (matchingValue != null) {
             match = true;
             handlePass(allowedValues, node, item, dynamicContext);
-          } else if (IAllowedValuesConstraint.Extensible.NONE.equals(allowedValues.getExtensible())) {
+          } else if (allowedValues.getExtensible() == IAllowedValuesConstraint.Extensible.NONE) {
             // hard failure, since no other values can satisfy this constraint
             failedConstraints = CollectionUtil.singletonList(allowedValues);
             match = false;

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/IAllowedValue.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/IAllowedValue.java
@@ -31,7 +31,6 @@ public interface IAllowedValue {
    *          the version this value was deprecated in
    * @return the new allowed value
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   static IAllowedValue of(
       @NonNull String value,

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/IKeyField.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/IKeyField.java
@@ -34,7 +34,6 @@ public interface IKeyField {
    *          optional remarks describing the intent of the constraint
    * @return the new key field
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   static IKeyField of(
       @NonNull IMetapathExpression target,

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/ILet.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/ILet.java
@@ -17,7 +17,6 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 /**
  * Represents a variable assignment for use in Metaschema module constraints.
  */
-@SuppressWarnings("PMD.ShortClassName")
 public interface ILet {
   /**
    * Create a new Let expression by compiling the provided Metapath expression
@@ -37,7 +36,6 @@ public interface ILet {
    *          remarks about the let statement
    * @return the original let statement with the same name or {@code null}
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   @Deprecated(since = "2.2.0", forRemoval = true)
   static ILet of(
@@ -65,7 +63,6 @@ public interface ILet {
    *          remarks about the let statement
    * @return the original let statement with the same name or {@code null}
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   static ILet of(
       @NonNull IEnhancedQName name,

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/LoggingConstraintValidationHandler.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/LoggingConstraintValidationHandler.java
@@ -104,7 +104,7 @@ public class LoggingConstraintValidationHandler
       @NonNull INodeItem node,
       @NonNull CharSequence message,
       @Nullable Throwable cause) {
-    if (!Level.NONE.equals(level)) {
+    if (level != Level.NONE) {
       LogBuilder builder = getLogBuilder(level);
       if (cause != null) {
         builder.withThrowable(cause);

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/ValidationFeature.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/constraint/ValidationFeature.java
@@ -16,7 +16,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * @param <V>
  *          the Java type of the configuration value
  */
-@SuppressWarnings("PMD.DataClass") // not a data class
 public final class ValidationFeature<V>
     extends AbstractConfigurationFeature<V> {
   /**

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/impl/DefaultContainerModelAssemblySupport.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/impl/DefaultContainerModelAssemblySupport.java
@@ -71,7 +71,6 @@ public class DefaultContainerModelAssemblySupport<
   /**
    * Construct an empty, mutable container.
    */
-  @SuppressWarnings("PMD.UseConcurrentHashMap")
   public DefaultContainerModelAssemblySupport() {
     this(
         new LinkedList<>(),

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/util/JsonUtil.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/util/JsonUtil.java
@@ -125,7 +125,7 @@ public final class JsonUtil {
       @NonNull URI resource,
       @NonNull JsonToken token) throws IOException {
     JsonToken currentToken = null;
-    while (parser.hasCurrentToken() && !token.equals(currentToken = parser.currentToken())) {
+    while (parser.hasCurrentToken() && (currentToken = parser.currentToken()) != token) {
       currentToken = parser.nextToken();
       if (LOGGER.isWarnEnabled()) {
         LOGGER.warn("skipping over: {}",
@@ -157,7 +157,7 @@ public final class JsonUtil {
 
     JsonToken currentToken = parser.currentToken();
     // skip the field name
-    if (JsonToken.FIELD_NAME.equals(currentToken)) {
+    if (currentToken == JsonToken.FIELD_NAME) {
       currentToken = parser.nextToken();
     }
 
@@ -238,7 +238,7 @@ public final class JsonUtil {
       @NonNull JsonToken... expectedTokens) {
     JsonToken current = parser.currentToken();
     assert Arrays.stream(expectedTokens)
-        .anyMatch(expected -> expected.equals(current)) : generateExpectedMessage(
+        .anyMatch(expected -> expected == current) : generateExpectedMessage(
             parser,
             resource,
             expectedTokens,
@@ -275,7 +275,7 @@ public final class JsonUtil {
       @NonNull JsonToken expectedToken)
       throws IOException {
     JsonToken token = parser.currentToken();
-    assert expectedToken.equals(token) : generateExpectedMessage(
+    assert token == expectedToken : generateExpectedMessage(
         parser,
         resource,
         expectedToken,
@@ -304,7 +304,7 @@ public final class JsonUtil {
       @NonNull JsonToken expectedToken)
       throws IOException {
     JsonToken token = parser.nextToken();
-    assert expectedToken.equals(token) : generateExpectedMessage(
+    assert token == expectedToken : generateExpectedMessage(
         parser,
         resource,
         expectedToken,

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/util/XmlEventUtil.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/util/XmlEventUtil.java
@@ -301,7 +301,6 @@ public final class XmlEventUtil { // NOPMD this is a set of utility methods
    * @throws XMLStreamException
    *           if an error occurred while reading the event stream
    */
-  @SuppressWarnings("PMD.OnlyOneReturn")
   public static XMLEvent skipElement(@NonNull XMLEventReader2 reader) throws XMLStreamException {
     XMLEvent xmlEvent = reader.peek();
     if (!xmlEvent.isStartElement()) {

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/model/validation/XmlSchemaContentValidator.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/model/validation/XmlSchemaContentValidator.java
@@ -159,7 +159,7 @@ public class XmlSchemaContentValidator
 
     @Override
     public Kind getKind() {
-      return Level.WARNING.equals(getSeverity()) ? Kind.PASS : Kind.FAIL;
+      return getSeverity() == Level.WARNING ? Kind.PASS : Kind.FAIL;
     }
 
     @Override

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/qname/IEnhancedQName.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/qname/IEnhancedQName.java
@@ -68,7 +68,6 @@ public interface IEnhancedQName extends Comparable<IEnhancedQName> {
    *          the index value to lookup
    * @return an optional containing the qualified name, if it exists
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   static Optional<IEnhancedQName> of(int index) {
     return EQNameFactory.instance().get(index);
@@ -81,7 +80,6 @@ public interface IEnhancedQName extends Comparable<IEnhancedQName> {
    *          the qualified name to get
    * @return the qualified name
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   static IEnhancedQName of(@NonNull QName qname) {
     return of(
@@ -96,7 +94,6 @@ public interface IEnhancedQName extends Comparable<IEnhancedQName> {
    *          the qualified name local part
    * @return the qualified name
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   static IEnhancedQName of(@NonNull String localName) {
     return of("", localName);
@@ -111,7 +108,6 @@ public interface IEnhancedQName extends Comparable<IEnhancedQName> {
    *          the qualified name local part
    * @return the qualified name
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   static IEnhancedQName of(@NonNull URI namespace, @NonNull String localName) {
     return of(ObjectUtils.notNull(namespace.toASCIIString()), localName);
@@ -126,7 +122,6 @@ public interface IEnhancedQName extends Comparable<IEnhancedQName> {
    *          the qualified name local part
    * @return the qualified name
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   static IEnhancedQName of(@NonNull String namespace, @NonNull String localName) {
     return EQNameFactory.instance().newQName(namespace, localName);

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/qname/NamespaceCache.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/qname/NamespaceCache.java
@@ -57,7 +57,6 @@ public final class NamespaceCache {
    *          the namespace
    * @return the index value
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   public int indexOf(@NonNull String namespace) {
     return nsToIndex.computeIfAbsent(namespace, key -> {
       int nextIndex = indexCounter.getAndIncrement();

--- a/core/src/main/java/gov/nist/secauto/metaschema/core/qname/QNameCache.java
+++ b/core/src/main/java/gov/nist/secauto/metaschema/core/qname/QNameCache.java
@@ -90,7 +90,6 @@ public final class QNameCache {
    * @return the new cached qualified name or the existing cached name if it
    *         already exists in the cache
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   public IEnhancedQName cachedQNameFor(@NonNull String namespace, @NonNull String name) {
     int namespacePosition = namespaceCache.indexOf(namespace);
@@ -193,7 +192,6 @@ public final class QNameCache {
       return Objects.hashCode(qnameIndexPosition);
     }
 
-    @SuppressWarnings("PMD.OnlyOneReturn")
     @Override
     public boolean equals(Object obj) {
       if (this == obj) {

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/model/constraint/CardinalityConstraintTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/model/constraint/CardinalityConstraintTest.java
@@ -1,0 +1,467 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.model.constraint;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import gov.nist.secauto.metaschema.core.mdm.IDMAssemblyNodeItem;
+import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
+import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
+import gov.nist.secauto.metaschema.core.metapath.StaticContext;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
+import gov.nist.secauto.metaschema.core.model.IAssemblyDefinition;
+import gov.nist.secauto.metaschema.core.model.IFieldInstance;
+import gov.nist.secauto.metaschema.core.model.ISource;
+import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
+import gov.nist.secauto.metaschema.core.testsupport.MockedModelTestSupport;
+import gov.nist.secauto.metaschema.core.util.ObjectUtils;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Tests for cardinality constraint validation using real DM node items.
+ */
+@SuppressWarnings("PMD.TooManyStaticImports")
+class CardinalityConstraintTest {
+  @NonNull
+  private static final String NS = ObjectUtils.notNull(URI.create("http://example.com/ns").toASCIIString());
+  @NonNull
+  private static final IEnhancedQName ASSEMBLY_QNAME = IEnhancedQName.of(NS, "assembly");
+  @NonNull
+  private static final IEnhancedQName ITEM_QNAME = IEnhancedQName.of(NS, "item");
+
+  /**
+   * Helper class to hold assembly definition and field instance together.
+   */
+  private static class AssemblyWithField {
+    @NonNull
+    final IAssemblyDefinition assemblyDef;
+    @NonNull
+    final IFieldInstance fieldInstance;
+
+    AssemblyWithField(@NonNull IAssemblyDefinition assemblyDef, @NonNull IFieldInstance fieldInstance) {
+      this.assemblyDef = assemblyDef;
+      this.fieldInstance = fieldInstance;
+    }
+  }
+
+  /**
+   * Create an assembly definition with a child field instance named "item".
+   *
+   * @param mocking
+   *          the mock support
+   * @param source
+   *          the module source
+   * @return the assembly with its field instance
+   */
+  @NonNull
+  private static AssemblyWithField createAssemblyWithItemField(
+      @NonNull MockedModelTestSupport mocking,
+      @NonNull ISource source) {
+    IAssemblyDefinition assemblyDef = mocking.assembly()
+        .qname(ASSEMBLY_QNAME)
+        .source(source)
+        .toDefinition();
+    // Create a field instance named "item" on the assembly
+    IFieldInstance fieldInstance = mocking.field()
+        .qname(ITEM_QNAME)
+        .source(source)
+        .toInstance(assemblyDef);
+    return new AssemblyWithField(assemblyDef, fieldInstance);
+  }
+
+  /**
+   * Test that cardinality constraint passes when minOccurs is met.
+   *
+   * @throws ConstraintValidationException
+   *           if an unexpected error occurred while validating a constraint
+   */
+  @Test
+  void testCardinalityMinOccursPass() throws ConstraintValidationException {
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource("https://example.com/module");
+
+    AssemblyWithField awf = createAssemblyWithItemField(mocking, source);
+
+    // Create assembly node and add 3 child items
+    StaticContext staticContext = StaticContext.builder()
+        .defaultModelNamespace(NS)
+        .build();
+    IDMAssemblyNodeItem assembly = IDMAssemblyNodeItem.newInstance(awf.assemblyDef, staticContext);
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("value1"));
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("value2"));
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("value3"));
+
+    // Constraint requires minOccurs=2, we have 3 items - should pass
+    ICardinalityConstraint constraint = ICardinalityConstraint.builder()
+        .source(source)
+        .target(IMetapathExpression.compile("item", staticContext))
+        .minOccurs(2)
+        .build();
+    awf.assemblyDef.addConstraint(constraint);
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(assembly, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertTrue(handler.isPassing(), "should pass with 3 items when minOccurs=2");
+  }
+
+  /**
+   * Test that cardinality constraint fails when minOccurs is not met.
+   *
+   * @throws ConstraintValidationException
+   *           if an unexpected error occurred while validating a constraint
+   */
+  @Test
+  void testCardinalityMinOccursFail() throws ConstraintValidationException {
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource("https://example.com/module");
+
+    AssemblyWithField awf = createAssemblyWithItemField(mocking, source);
+
+    // Create assembly node and add 1 child item
+    StaticContext staticContext = StaticContext.builder()
+        .defaultModelNamespace(NS)
+        .build();
+    IDMAssemblyNodeItem assembly = IDMAssemblyNodeItem.newInstance(awf.assemblyDef, staticContext);
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("value1"));
+
+    // Constraint requires minOccurs=2, we have 1 item - should fail
+    ICardinalityConstraint constraint = ICardinalityConstraint.builder()
+        .source(source)
+        .target(IMetapathExpression.compile("item", staticContext))
+        .minOccurs(2)
+        .build();
+    awf.assemblyDef.addConstraint(constraint);
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(assembly, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertAll(
+        () -> assertFalse(handler.isPassing(), "should fail with 1 item when minOccurs=2"),
+        () -> assertThat("should have 1 finding", handler.getFindings(), hasSize(1)),
+        () -> assertThat("finding should be for assembly node",
+            handler.getFindings().get(0),
+            hasProperty("node", is(assembly))));
+  }
+
+  /**
+   * Test that cardinality constraint passes when maxOccurs is met.
+   *
+   * @throws ConstraintValidationException
+   *           if an unexpected error occurred while validating a constraint
+   */
+  @Test
+  void testCardinalityMaxOccursPass() throws ConstraintValidationException {
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource("https://example.com/module");
+
+    AssemblyWithField awf = createAssemblyWithItemField(mocking, source);
+
+    // Create assembly node and add 2 child items
+    StaticContext staticContext = StaticContext.builder()
+        .defaultModelNamespace(NS)
+        .build();
+    IDMAssemblyNodeItem assembly = IDMAssemblyNodeItem.newInstance(awf.assemblyDef, staticContext);
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("value1"));
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("value2"));
+
+    // Constraint requires maxOccurs=3, we have 2 items - should pass
+    ICardinalityConstraint constraint = ICardinalityConstraint.builder()
+        .source(source)
+        .target(IMetapathExpression.compile("item", staticContext))
+        .maxOccurs(3)
+        .build();
+    awf.assemblyDef.addConstraint(constraint);
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(assembly, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertTrue(handler.isPassing(), "should pass with 2 items when maxOccurs=3");
+  }
+
+  /**
+   * Test that cardinality constraint fails when maxOccurs is exceeded.
+   *
+   * @throws ConstraintValidationException
+   *           if an unexpected error occurred while validating a constraint
+   */
+  @Test
+  void testCardinalityMaxOccursFail() throws ConstraintValidationException {
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource("https://example.com/module");
+
+    AssemblyWithField awf = createAssemblyWithItemField(mocking, source);
+
+    // Create assembly node and add 4 child items
+    StaticContext staticContext = StaticContext.builder()
+        .defaultModelNamespace(NS)
+        .build();
+    IDMAssemblyNodeItem assembly = IDMAssemblyNodeItem.newInstance(awf.assemblyDef, staticContext);
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("value1"));
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("value2"));
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("value3"));
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("value4"));
+
+    // Constraint requires maxOccurs=3, we have 4 items - should fail
+    ICardinalityConstraint constraint = ICardinalityConstraint.builder()
+        .source(source)
+        .target(IMetapathExpression.compile("item", staticContext))
+        .maxOccurs(3)
+        .build();
+    awf.assemblyDef.addConstraint(constraint);
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(assembly, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertAll(
+        () -> assertFalse(handler.isPassing(), "should fail with 4 items when maxOccurs=3"),
+        () -> assertThat("should have 1 finding", handler.getFindings(), hasSize(1)),
+        () -> assertThat("finding should be for assembly node",
+            handler.getFindings().get(0),
+            hasProperty("node", is(assembly))));
+  }
+
+  /**
+   * Test that cardinality constraint with both minOccurs and maxOccurs passes
+   * when within range.
+   *
+   * @throws ConstraintValidationException
+   *           if an unexpected error occurred while validating a constraint
+   */
+  @Test
+  void testCardinalityBothMinMaxPass() throws ConstraintValidationException {
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource("https://example.com/module");
+
+    AssemblyWithField awf = createAssemblyWithItemField(mocking, source);
+
+    // Create assembly node and add 3 child items
+    StaticContext staticContext = StaticContext.builder()
+        .defaultModelNamespace(NS)
+        .build();
+    IDMAssemblyNodeItem assembly = IDMAssemblyNodeItem.newInstance(awf.assemblyDef, staticContext);
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("value1"));
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("value2"));
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("value3"));
+
+    // Constraint requires minOccurs=2, maxOccurs=5, we have 3 items - should pass
+    ICardinalityConstraint constraint = ICardinalityConstraint.builder()
+        .source(source)
+        .target(IMetapathExpression.compile("item", staticContext))
+        .minOccurs(2)
+        .maxOccurs(5)
+        .build();
+    awf.assemblyDef.addConstraint(constraint);
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(assembly, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertTrue(handler.isPassing(), "should pass with 3 items when minOccurs=2 and maxOccurs=5");
+  }
+
+  /**
+   * Test that cardinality constraint with both minOccurs and maxOccurs fails when
+   * below minimum.
+   *
+   * @throws ConstraintValidationException
+   *           if an unexpected error occurred while validating a constraint
+   */
+  @Test
+  void testCardinalityBothMinMaxFailMin() throws ConstraintValidationException {
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource("https://example.com/module");
+
+    AssemblyWithField awf = createAssemblyWithItemField(mocking, source);
+
+    // Create assembly node and add 1 child item
+    StaticContext staticContext = StaticContext.builder()
+        .defaultModelNamespace(NS)
+        .build();
+    IDMAssemblyNodeItem assembly = IDMAssemblyNodeItem.newInstance(awf.assemblyDef, staticContext);
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("value1"));
+
+    // Constraint requires minOccurs=2, maxOccurs=5, we have 1 item - should fail on
+    // minimum
+    ICardinalityConstraint constraint = ICardinalityConstraint.builder()
+        .source(source)
+        .target(IMetapathExpression.compile("item", staticContext))
+        .minOccurs(2)
+        .maxOccurs(5)
+        .build();
+    awf.assemblyDef.addConstraint(constraint);
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(assembly, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertAll(
+        () -> assertFalse(handler.isPassing(), "should fail with 1 item when minOccurs=2 and maxOccurs=5"),
+        () -> assertThat("should have 1 finding", handler.getFindings(), hasSize(1)),
+        () -> assertThat("finding should be for assembly node",
+            handler.getFindings().get(0),
+            hasProperty("node", is(assembly))));
+  }
+
+  /**
+   * Test that cardinality constraint with both minOccurs and maxOccurs fails when
+   * above maximum.
+   *
+   * @throws ConstraintValidationException
+   *           if an unexpected error occurred while validating a constraint
+   */
+  @Test
+  void testCardinalityBothMinMaxFailMax() throws ConstraintValidationException {
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource("https://example.com/module");
+
+    AssemblyWithField awf = createAssemblyWithItemField(mocking, source);
+
+    // Create assembly node and add 6 child items
+    StaticContext staticContext = StaticContext.builder()
+        .defaultModelNamespace(NS)
+        .build();
+    IDMAssemblyNodeItem assembly = IDMAssemblyNodeItem.newInstance(awf.assemblyDef, staticContext);
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("value1"));
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("value2"));
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("value3"));
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("value4"));
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("value5"));
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("value6"));
+
+    // Constraint requires minOccurs=2, maxOccurs=5, we have 6 items - should fail
+    // on maximum
+    ICardinalityConstraint constraint = ICardinalityConstraint.builder()
+        .source(source)
+        .target(IMetapathExpression.compile("item", staticContext))
+        .minOccurs(2)
+        .maxOccurs(5)
+        .build();
+    awf.assemblyDef.addConstraint(constraint);
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(assembly, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertAll(
+        () -> assertFalse(handler.isPassing(), "should fail with 6 items when minOccurs=2 and maxOccurs=5"),
+        () -> assertThat("should have 1 finding", handler.getFindings(), hasSize(1)),
+        () -> assertThat("finding should be for assembly node",
+            handler.getFindings().get(0),
+            hasProperty("node", is(assembly))));
+  }
+
+  /**
+   * Test that cardinality constraint passes when there are zero matching targets
+   * and minOccurs is 0.
+   *
+   * @throws ConstraintValidationException
+   *           if an unexpected error occurred while validating a constraint
+   */
+  @Test
+  void testCardinalityZeroTargetsPass() throws ConstraintValidationException {
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource("https://example.com/module");
+
+    AssemblyWithField awf = createAssemblyWithItemField(mocking, source);
+
+    // Create assembly node with no child items
+    StaticContext staticContext = StaticContext.builder()
+        .defaultModelNamespace(NS)
+        .build();
+    IDMAssemblyNodeItem assembly = IDMAssemblyNodeItem.newInstance(awf.assemblyDef, staticContext);
+    // Don't add any items
+
+    // Constraint requires minOccurs=0, maxOccurs=3, we have 0 items - should pass
+    ICardinalityConstraint constraint = ICardinalityConstraint.builder()
+        .source(source)
+        .target(IMetapathExpression.compile("item", staticContext))
+        .minOccurs(0)
+        .maxOccurs(3)
+        .build();
+    awf.assemblyDef.addConstraint(constraint);
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(assembly, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertTrue(handler.isPassing(), "should pass with 0 items when minOccurs=0 and maxOccurs=3");
+  }
+
+  /**
+   * Test that cardinality constraint fails when there are zero matching targets
+   * but minOccurs requires items.
+   *
+   * @throws ConstraintValidationException
+   *           if an unexpected error occurred while validating a constraint
+   */
+  @Test
+  void testCardinalityZeroTargetsFail() throws ConstraintValidationException {
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource("https://example.com/module");
+
+    AssemblyWithField awf = createAssemblyWithItemField(mocking, source);
+
+    // Create assembly node with no child items
+    StaticContext staticContext = StaticContext.builder()
+        .defaultModelNamespace(NS)
+        .build();
+    IDMAssemblyNodeItem assembly = IDMAssemblyNodeItem.newInstance(awf.assemblyDef, staticContext);
+    // Don't add any items
+
+    // Constraint requires minOccurs=1, we have 0 items - should fail
+    ICardinalityConstraint constraint = ICardinalityConstraint.builder()
+        .source(source)
+        .target(IMetapathExpression.compile("item", staticContext))
+        .minOccurs(1)
+        .build();
+    awf.assemblyDef.addConstraint(constraint);
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(assembly, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertAll(
+        () -> assertFalse(handler.isPassing(), "should fail with 0 items when minOccurs=1"),
+        () -> assertThat("should have 1 finding", handler.getFindings(), hasSize(1)),
+        () -> assertThat("finding should be for assembly node",
+            handler.getFindings().get(0),
+            hasProperty("node", is(assembly))));
+  }
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/model/constraint/ExpectConstraintTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/model/constraint/ExpectConstraintTest.java
@@ -1,0 +1,513 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.model.constraint;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import gov.nist.secauto.metaschema.core.datatype.markup.MarkupLine;
+import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
+import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
+import gov.nist.secauto.metaschema.core.metapath.StaticContext;
+import gov.nist.secauto.metaschema.core.mdm.IDMFieldNodeItem;
+import gov.nist.secauto.metaschema.core.metapath.format.IPathFormatter;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
+import gov.nist.secauto.metaschema.core.metapath.item.node.IFieldNodeItem;
+import gov.nist.secauto.metaschema.core.metapath.item.node.IFlagNodeItem;
+import gov.nist.secauto.metaschema.core.model.IFieldDefinition;
+import gov.nist.secauto.metaschema.core.model.IFlagDefinition;
+import gov.nist.secauto.metaschema.core.model.IFlagInstance;
+import gov.nist.secauto.metaschema.core.model.ISource;
+import gov.nist.secauto.metaschema.core.model.constraint.IConstraint.Level;
+import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
+import gov.nist.secauto.metaschema.core.testsupport.MockedModelTestSupport;
+import gov.nist.secauto.metaschema.core.testsupport.mocking.MockNodeItemFactory;
+import gov.nist.secauto.metaschema.core.util.CollectionUtil;
+import gov.nist.secauto.metaschema.core.util.ObjectUtils;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Comprehensive tests for expect constraint validation.
+ */
+@SuppressWarnings("PMD.TooManyStaticImports")
+class ExpectConstraintTest {
+  @NonNull
+  private static final String NS = ObjectUtils.notNull(URI.create("http://example.com/ns").toASCIIString());
+
+  @NonNull
+  private static IEnhancedQName qname(@NonNull String name) {
+    return IEnhancedQName.of(NS, name);
+  }
+
+  /**
+   * Mock constraint methods on a flag definition to prevent null pointer
+   * exceptions during validation.
+   *
+   * @param flag
+   *          the flag node item whose definition to mock
+   */
+  @SuppressWarnings("null")
+  private static void mockFlagDefinitionConstraints(@NonNull IFlagNodeItem flag) {
+    IFlagDefinition definition = flag.getDefinition();
+    doReturn(CollectionUtil.emptyMap()).when(definition).getLetExpressions();
+    doReturn(CollectionUtil.emptyList()).when(definition).getAllowedValuesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(definition).getExpectConstraints();
+    doReturn(CollectionUtil.emptyList()).when(definition).getMatchesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(definition).getIndexHasKeyConstraints();
+  }
+
+  /**
+   * Test expect constraint that passes when test expression evaluates to true.
+   *
+   * @throws ConstraintValidationException
+   *           if an error occurred during validation
+   */
+  @SuppressWarnings("null")
+  @Test
+  void testExpectConstraintPasses() throws ConstraintValidationException {
+    MockNodeItemFactory itemFactory = new MockNodeItemFactory();
+
+    IFlagNodeItem flag = itemFactory.flag(qname("value"), IStringItem.valueOf("test-value"));
+
+    IFlagDefinition flagDefinition = mock(IFlagDefinition.class);
+
+    ISource source = mock(ISource.class);
+
+    // Create expect constraint with test that evaluates to true
+    IExpectConstraint expectConstraint = IExpectConstraint.builder()
+        .source(source)
+        .test(IMetapathExpression.compile("string-length(.) > 0"))
+        .build();
+
+    doReturn(flagDefinition).when(flag).getDefinition();
+    doReturn("flag/path").when(flag).toPath(any(IPathFormatter.class));
+
+    doReturn(CollectionUtil.emptyMap()).when(flagDefinition).getLetExpressions();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getAllowedValuesConstraints();
+    doReturn(CollectionUtil.singletonList(expectConstraint)).when(flagDefinition).getExpectConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getMatchesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getIndexHasKeyConstraints();
+
+    StaticContext staticContext = StaticContext.instance();
+    doReturn(staticContext).when(source).getStaticContext();
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(flag, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertTrue(handler.isPassing(), "constraint should pass when test expression evaluates to true");
+  }
+
+  /**
+   * Test expect constraint that fails when test expression evaluates to false.
+   *
+   * @throws ConstraintValidationException
+   *           if an error occurred during validation
+   */
+  @SuppressWarnings("null")
+  @Test
+  void testExpectConstraintFails() throws ConstraintValidationException {
+    MockNodeItemFactory itemFactory = new MockNodeItemFactory();
+
+    IFlagNodeItem flag = itemFactory.flag(qname("value"), IStringItem.valueOf("test"));
+
+    IFlagDefinition flagDefinition = mock(IFlagDefinition.class);
+
+    ISource source = mock(ISource.class);
+
+    // Create expect constraint with test that evaluates to false
+    IExpectConstraint expectConstraint = IExpectConstraint.builder()
+        .source(source)
+        .test(IMetapathExpression.compile("string-length(.) > 10"))
+        .build();
+
+    doReturn(flagDefinition).when(flag).getDefinition();
+    doReturn("flag/path").when(flag).toPath(any(IPathFormatter.class));
+
+    doReturn(CollectionUtil.emptyMap()).when(flagDefinition).getLetExpressions();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getAllowedValuesConstraints();
+    doReturn(CollectionUtil.singletonList(expectConstraint)).when(flagDefinition).getExpectConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getMatchesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getIndexHasKeyConstraints();
+
+    StaticContext staticContext = StaticContext.instance();
+    doReturn(staticContext).when(source).getStaticContext();
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(flag, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertAll(
+        () -> assertFalse(handler.isPassing(), "constraint should fail when test expression evaluates to false"),
+        () -> assertThat("should have 1 finding", handler.getFindings(), hasSize(1)),
+        () -> assertThat("finding should be for the flag node", handler.getFindings(),
+            hasItem(hasProperty("node", is(flag)))));
+  }
+
+  /**
+   * Test expect constraint with custom message.
+   *
+   * @throws ConstraintValidationException
+   *           if an error occurred during validation
+   */
+  @SuppressWarnings("null")
+  @Test
+  void testExpectConstraintWithCustomMessage() throws ConstraintValidationException {
+    MockNodeItemFactory itemFactory = new MockNodeItemFactory();
+
+    IFlagNodeItem flag = itemFactory.flag(qname("value"), IStringItem.valueOf("short"));
+
+    IFlagDefinition flagDefinition = mock(IFlagDefinition.class);
+
+    ISource source = mock(ISource.class);
+
+    String customMessage = "Value must be at least 10 characters long";
+
+    // Create expect constraint with custom message
+    IExpectConstraint expectConstraint = IExpectConstraint.builder()
+        .source(source)
+        .test(IMetapathExpression.compile("string-length(.) >= 10"))
+        .message(customMessage)
+        .build();
+
+    doReturn(flagDefinition).when(flag).getDefinition();
+    doReturn("flag/path").when(flag).toPath(any(IPathFormatter.class));
+
+    doReturn(CollectionUtil.emptyMap()).when(flagDefinition).getLetExpressions();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getAllowedValuesConstraints();
+    doReturn(CollectionUtil.singletonList(expectConstraint)).when(flagDefinition).getExpectConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getMatchesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getIndexHasKeyConstraints();
+
+    StaticContext staticContext = StaticContext.instance();
+    doReturn(staticContext).when(source).getStaticContext();
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(flag, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertAll(
+        () -> assertFalse(handler.isPassing(), "constraint should fail"),
+        () -> assertThat("should have 1 finding", handler.getFindings(), hasSize(1)),
+        () -> assertThat("finding should contain custom message", handler.getFindings(),
+            hasItem(hasProperty("message", is(customMessage)))));
+  }
+
+  /**
+   * Test expect constraint targeting specific Metapath using DM data model.
+   *
+   * @throws ConstraintValidationException
+   *           if an error occurred during validation
+   */
+  @Test
+  void testExpectConstraintWithTargetMetapath() throws ConstraintValidationException {
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource("https://example.com/module");
+
+    // Create field definition with a "status" flag
+    IFieldDefinition fieldDef = mocking.field()
+        .qname(qname("item"))
+        .source(source)
+        .toDefinition();
+
+    // Create flag instance on the field definition
+    IFlagInstance statusFlagInstance = mocking.flag()
+        .qname(IEnhancedQName.of("status"))
+        .source(source)
+        .toInstance(fieldDef);
+
+    // Create a StaticContext for Metapath compilation
+    StaticContext staticContext = StaticContext.builder()
+        .defaultModelNamespace(NS)
+        .build();
+
+    // Create field node with "status" flag set to "active"
+    IDMFieldNodeItem field = IDMFieldNodeItem.newInstance(fieldDef, IStringItem.valueOf("value"), staticContext);
+    field.newFlag(statusFlagInstance, IStringItem.valueOf("active"));
+
+    // Create expect constraint targeting the @status flag, expecting 'inactive'
+    IExpectConstraint expectConstraint = IExpectConstraint.builder()
+        .source(source)
+        .target(IMetapathExpression.compile("@status", staticContext))
+        .test(IMetapathExpression.compile(". = 'inactive'", staticContext))
+        .build();
+    fieldDef.addConstraint(expectConstraint);
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(field, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertAll(
+        () -> assertFalse(handler.isPassing(), "constraint should fail when target test fails"),
+        () -> assertThat("should have 1 finding", handler.getFindings(), hasSize(1)));
+  }
+
+  /**
+   * Test expect constraint with WARNING severity level.
+   *
+   * @throws ConstraintValidationException
+   *           if an error occurred during validation
+   */
+  @SuppressWarnings("null")
+  @Test
+  void testExpectConstraintWithWarningSeverity() throws ConstraintValidationException {
+    MockNodeItemFactory itemFactory = new MockNodeItemFactory();
+
+    IFlagNodeItem flag = itemFactory.flag(qname("value"), IStringItem.valueOf("test"));
+
+    IFlagDefinition flagDefinition = mock(IFlagDefinition.class);
+
+    ISource source = mock(ISource.class);
+
+    // Create expect constraint with WARNING level
+    IExpectConstraint expectConstraint = IExpectConstraint.builder()
+        .source(source)
+        .level(Level.WARNING)
+        .test(IMetapathExpression.compile("string-length(.) > 10"))
+        .build();
+
+    doReturn(flagDefinition).when(flag).getDefinition();
+    doReturn("flag/path").when(flag).toPath(any(IPathFormatter.class));
+
+    doReturn(CollectionUtil.emptyMap()).when(flagDefinition).getLetExpressions();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getAllowedValuesConstraints();
+    doReturn(CollectionUtil.singletonList(expectConstraint)).when(flagDefinition).getExpectConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getMatchesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getIndexHasKeyConstraints();
+
+    StaticContext staticContext = StaticContext.instance();
+    doReturn(staticContext).when(source).getStaticContext();
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(flag, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertAll(
+        () -> assertTrue(handler.isPassing(), "validation should pass with WARNING level violation"),
+        () -> assertThat("should have 1 finding", handler.getFindings(), hasSize(1)),
+        () -> assertThat("finding should have WARNING severity", handler.getFindings(),
+            hasItem(hasProperty("severity", is(Level.WARNING)))));
+  }
+
+  /**
+   * Test expect constraint with ERROR severity level.
+   *
+   * @throws ConstraintValidationException
+   *           if an error occurred during validation
+   */
+  @SuppressWarnings("null")
+  @Test
+  void testExpectConstraintWithErrorSeverity() throws ConstraintValidationException {
+    MockNodeItemFactory itemFactory = new MockNodeItemFactory();
+
+    IFlagNodeItem flag = itemFactory.flag(qname("value"), IStringItem.valueOf("test"));
+
+    IFlagDefinition flagDefinition = mock(IFlagDefinition.class);
+
+    ISource source = mock(ISource.class);
+
+    // Create expect constraint with ERROR level (default)
+    IExpectConstraint expectConstraint = IExpectConstraint.builder()
+        .source(source)
+        .level(Level.ERROR)
+        .test(IMetapathExpression.compile("string-length(.) > 10"))
+        .build();
+
+    doReturn(flagDefinition).when(flag).getDefinition();
+    doReturn("flag/path").when(flag).toPath(any(IPathFormatter.class));
+
+    doReturn(CollectionUtil.emptyMap()).when(flagDefinition).getLetExpressions();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getAllowedValuesConstraints();
+    doReturn(CollectionUtil.singletonList(expectConstraint)).when(flagDefinition).getExpectConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getMatchesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getIndexHasKeyConstraints();
+
+    StaticContext staticContext = StaticContext.instance();
+    doReturn(staticContext).when(source).getStaticContext();
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(flag, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertAll(
+        () -> assertFalse(handler.isPassing(), "validation should fail with ERROR level violation"),
+        () -> assertThat("should have 1 finding", handler.getFindings(), hasSize(1)),
+        () -> assertThat("finding should have ERROR severity", handler.getFindings(),
+            hasItem(hasProperty("severity", is(Level.ERROR)))));
+  }
+
+  /**
+   * Test expect constraint with CRITICAL severity level.
+   *
+   * @throws ConstraintValidationException
+   *           if an error occurred during validation
+   */
+  @SuppressWarnings("null")
+  @Test
+  void testExpectConstraintWithCriticalSeverity() throws ConstraintValidationException {
+    MockNodeItemFactory itemFactory = new MockNodeItemFactory();
+
+    IFlagNodeItem flag = itemFactory.flag(qname("value"), IStringItem.valueOf("test"));
+
+    IFlagDefinition flagDefinition = mock(IFlagDefinition.class);
+
+    ISource source = mock(ISource.class);
+
+    // Create expect constraint with CRITICAL level
+    IExpectConstraint expectConstraint = IExpectConstraint.builder()
+        .source(source)
+        .level(Level.CRITICAL)
+        .test(IMetapathExpression.compile("string-length(.) > 10"))
+        .build();
+
+    doReturn(flagDefinition).when(flag).getDefinition();
+    doReturn("flag/path").when(flag).toPath(any(IPathFormatter.class));
+
+    doReturn(CollectionUtil.emptyMap()).when(flagDefinition).getLetExpressions();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getAllowedValuesConstraints();
+    doReturn(CollectionUtil.singletonList(expectConstraint)).when(flagDefinition).getExpectConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getMatchesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getIndexHasKeyConstraints();
+
+    StaticContext staticContext = StaticContext.instance();
+    doReturn(staticContext).when(source).getStaticContext();
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(flag, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertAll(
+        () -> assertFalse(handler.isPassing(), "validation should fail with CRITICAL level violation"),
+        () -> assertThat("should have 1 finding", handler.getFindings(), hasSize(1)),
+        () -> assertThat("finding should have CRITICAL severity", handler.getFindings(),
+            hasItem(hasProperty("severity", is(Level.CRITICAL)))));
+  }
+
+  /**
+   * Test expect constraint with complex test expression.
+   *
+   * @throws ConstraintValidationException
+   *           if an error occurred during validation
+   */
+  @SuppressWarnings("null")
+  @Test
+  void testExpectConstraintWithComplexExpression() throws ConstraintValidationException {
+    MockNodeItemFactory itemFactory = new MockNodeItemFactory();
+
+    IFlagNodeItem flag = itemFactory.flag(qname("email"), IStringItem.valueOf("user@example.com"));
+
+    IFlagDefinition flagDefinition = mock(IFlagDefinition.class);
+
+    ISource source = mock(ISource.class);
+
+    // Create expect constraint with complex test expression
+    IExpectConstraint expectConstraint = IExpectConstraint.builder()
+        .source(source)
+        .test(IMetapathExpression.compile("contains(., '@') and string-length(.) > 5"))
+        .build();
+
+    doReturn(flagDefinition).when(flag).getDefinition();
+    doReturn("flag/path").when(flag).toPath(any(IPathFormatter.class));
+
+    doReturn(CollectionUtil.emptyMap()).when(flagDefinition).getLetExpressions();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getAllowedValuesConstraints();
+    doReturn(CollectionUtil.singletonList(expectConstraint)).when(flagDefinition).getExpectConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getMatchesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getIndexHasKeyConstraints();
+
+    StaticContext staticContext = StaticContext.instance();
+    doReturn(staticContext).when(source).getStaticContext();
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(flag, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertTrue(handler.isPassing(), "constraint should pass when complex expression evaluates to true");
+  }
+
+  /**
+   * Test expect constraint with formal name and description.
+   *
+   * @throws ConstraintValidationException
+   *           if an error occurred during validation
+   */
+  @SuppressWarnings("null")
+  @Test
+  void testExpectConstraintWithMetadata() throws ConstraintValidationException {
+    MockNodeItemFactory itemFactory = new MockNodeItemFactory();
+
+    IFlagNodeItem flag = itemFactory.flag(qname("value"), IStringItem.valueOf("test"));
+
+    IFlagDefinition flagDefinition = mock(IFlagDefinition.class);
+
+    ISource source = mock(ISource.class);
+
+    // Create expect constraint with metadata
+    IExpectConstraint expectConstraint = IExpectConstraint.builder()
+        .source(source)
+        .identifier("expect-001")
+        .formalName("Minimum Length Constraint")
+        .description(MarkupLine.fromMarkdown("Ensures value has minimum length of 10 characters"))
+        .test(IMetapathExpression.compile("string-length(.) >= 10"))
+        .message("Value is too short")
+        .build();
+
+    doReturn(flagDefinition).when(flag).getDefinition();
+    doReturn("flag/path").when(flag).toPath(any(IPathFormatter.class));
+
+    doReturn(CollectionUtil.emptyMap()).when(flagDefinition).getLetExpressions();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getAllowedValuesConstraints();
+    doReturn(CollectionUtil.singletonList(expectConstraint)).when(flagDefinition).getExpectConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getMatchesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getIndexHasKeyConstraints();
+
+    StaticContext staticContext = StaticContext.instance();
+    doReturn(staticContext).when(source).getStaticContext();
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(flag, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertAll(
+        () -> assertFalse(handler.isPassing(), "constraint should fail"),
+        () -> assertThat("should have 1 finding", handler.getFindings(), hasSize(1)),
+        () -> assertThat("constraint should have id", expectConstraint.getId(), is("expect-001")),
+        () -> assertThat("constraint should have formal name", expectConstraint.getFormalName(),
+            is("Minimum Length Constraint")));
+  }
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/model/constraint/IndexUniqueConstraintTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/model/constraint/IndexUniqueConstraintTest.java
@@ -1,0 +1,500 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.model.constraint;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import gov.nist.secauto.metaschema.core.mdm.IDMAssemblyNodeItem;
+import gov.nist.secauto.metaschema.core.mdm.IDMFieldNodeItem;
+import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
+import gov.nist.secauto.metaschema.core.metapath.IMetapathExpression;
+import gov.nist.secauto.metaschema.core.metapath.StaticContext;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
+import gov.nist.secauto.metaschema.core.model.IAssemblyDefinition;
+import gov.nist.secauto.metaschema.core.model.IFieldInstance;
+import gov.nist.secauto.metaschema.core.model.IFlagInstance;
+import gov.nist.secauto.metaschema.core.model.ISource;
+import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
+import gov.nist.secauto.metaschema.core.testsupport.MockedModelTestSupport;
+import gov.nist.secauto.metaschema.core.util.ObjectUtils;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Tests for Index and Unique constraint validation using real DM node items.
+ */
+@SuppressWarnings("PMD.TooManyStaticImports")
+class IndexUniqueConstraintTest {
+  @NonNull
+  private static final String NS = ObjectUtils.notNull(URI.create("http://example.com/ns").toASCIIString());
+  @NonNull
+  private static final IEnhancedQName PARENT_QNAME = IEnhancedQName.of(NS, "parent");
+  @NonNull
+  private static final IEnhancedQName CHILD_QNAME = IEnhancedQName.of(NS, "child");
+  @NonNull
+  private static final IEnhancedQName KEY1_QNAME = IEnhancedQName.of("key1");
+  @NonNull
+  private static final IEnhancedQName KEY2_QNAME = IEnhancedQName.of("key2");
+
+  /**
+   * Helper class to hold assembly definition and field instance together.
+   */
+  private static class AssemblyWithField {
+    @NonNull
+    final IAssemblyDefinition assemblyDef;
+    @NonNull
+    final IFieldInstance fieldInstance;
+
+    AssemblyWithField(@NonNull IAssemblyDefinition assemblyDef, @NonNull IFieldInstance fieldInstance) {
+      this.assemblyDef = assemblyDef;
+      this.fieldInstance = fieldInstance;
+    }
+  }
+
+  /**
+   * Helper class to hold assembly definition and field instance with flags.
+   */
+  private static class AssemblyWithFieldAndFlags {
+    @NonNull
+    final IAssemblyDefinition assemblyDef;
+    @NonNull
+    final IFieldInstance fieldInstance;
+    @NonNull
+    final IFlagInstance key1FlagInstance;
+    @NonNull
+    final IFlagInstance key2FlagInstance;
+
+    AssemblyWithFieldAndFlags(
+        @NonNull IAssemblyDefinition assemblyDef,
+        @NonNull IFieldInstance fieldInstance,
+        @NonNull IFlagInstance key1FlagInstance,
+        @NonNull IFlagInstance key2FlagInstance) {
+      this.assemblyDef = assemblyDef;
+      this.fieldInstance = fieldInstance;
+      this.key1FlagInstance = key1FlagInstance;
+      this.key2FlagInstance = key2FlagInstance;
+    }
+  }
+
+  /**
+   * Create an assembly definition with a child field instance named "child".
+   *
+   * @param mocking
+   *          the mock support
+   * @param source
+   *          the module source
+   * @return the assembly with its field instance
+   */
+  @NonNull
+  private static AssemblyWithField createAssemblyWithChildField(
+      @NonNull MockedModelTestSupport mocking,
+      @NonNull ISource source) {
+    IAssemblyDefinition assemblyDef = mocking.assembly()
+        .qname(PARENT_QNAME)
+        .source(source)
+        .toDefinition();
+    IFieldInstance fieldInstance = mocking.field()
+        .qname(CHILD_QNAME)
+        .source(source)
+        .toInstance(assemblyDef);
+    return new AssemblyWithField(assemblyDef, fieldInstance);
+  }
+
+  /**
+   * Create an assembly with a child field that has two flag instances (key1,
+   * key2).
+   *
+   * @param mocking
+   *          the mock support
+   * @param source
+   *          the module source
+   * @return the assembly with its field and flag instances
+   */
+  @NonNull
+  private static AssemblyWithFieldAndFlags createAssemblyWithChildFieldAndFlags(
+      @NonNull MockedModelTestSupport mocking,
+      @NonNull ISource source) {
+    IAssemblyDefinition assemblyDef = mocking.assembly()
+        .qname(PARENT_QNAME)
+        .source(source)
+        .toDefinition();
+
+    // Create field definition first to add flags to it
+    var fieldDef = mocking.field()
+        .qname(CHILD_QNAME)
+        .source(source)
+        .toDefinition();
+
+    // Add flag instances to the field definition
+    IFlagInstance key1FlagInstance = mocking.flag()
+        .qname(KEY1_QNAME)
+        .source(source)
+        .toInstance(fieldDef);
+
+    IFlagInstance key2FlagInstance = mocking.flag()
+        .qname(KEY2_QNAME)
+        .source(source)
+        .toInstance(fieldDef);
+
+    // Create field instance linking to parent and definition
+    IFieldInstance fieldInstance = mocking.field()
+        .qname(CHILD_QNAME)
+        .source(source)
+        .toInstance(assemblyDef, fieldDef);
+
+    return new AssemblyWithFieldAndFlags(assemblyDef, fieldInstance, key1FlagInstance, key2FlagInstance);
+  }
+
+  /**
+   * Test index constraint with unique entries (should pass).
+   *
+   * @throws ConstraintValidationException
+   *           if an unexpected error occurred while validating a constraint
+   */
+  @Test
+  void testIndexConstraintSuccess() throws ConstraintValidationException {
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource("https://example.com/module");
+
+    AssemblyWithField awf = createAssemblyWithChildField(mocking, source);
+
+    // Create assembly node and add 3 child items with unique values
+    StaticContext staticContext = StaticContext.builder()
+        .defaultModelNamespace(NS)
+        .build();
+    IDMAssemblyNodeItem assembly = IDMAssemblyNodeItem.newInstance(awf.assemblyDef, staticContext);
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("id1"));
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("id2"));
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("id3"));
+
+    // Index constraint with key field "." (the field value)
+    IIndexConstraint indexConstraint = IIndexConstraint.builder("test-index")
+        .source(source)
+        .target(IMetapathExpression.compile("child", staticContext))
+        .keyField(IKeyField.of(
+            IMetapathExpression.compile(".", staticContext),
+            null,
+            null))
+        .build();
+    awf.assemblyDef.addConstraint(indexConstraint);
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(assembly, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertTrue(handler.isPassing(), "should pass with unique index entries");
+  }
+
+  /**
+   * Test index constraint with duplicate index names (should fail).
+   *
+   * @throws ConstraintValidationException
+   *           if an unexpected error occurred while validating a constraint
+   */
+  @Test
+  void testIndexConstraintDuplicateName() throws ConstraintValidationException {
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource("https://example.com/module");
+
+    AssemblyWithField awf = createAssemblyWithChildField(mocking, source);
+
+    StaticContext staticContext = StaticContext.builder()
+        .defaultModelNamespace(NS)
+        .build();
+    IDMAssemblyNodeItem assembly = IDMAssemblyNodeItem.newInstance(awf.assemblyDef, staticContext);
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("id1"));
+
+    // Create two index constraints with the same name
+    IIndexConstraint indexConstraint1 = IIndexConstraint.builder("test-index")
+        .source(source)
+        .target(IMetapathExpression.compile("child", staticContext))
+        .keyField(IKeyField.of(
+            IMetapathExpression.compile(".", staticContext),
+            null,
+            null))
+        .build();
+
+    IIndexConstraint indexConstraint2 = IIndexConstraint.builder("test-index")
+        .source(source)
+        .target(IMetapathExpression.compile("child", staticContext))
+        .keyField(IKeyField.of(
+            IMetapathExpression.compile(".", staticContext),
+            null,
+            null))
+        .build();
+
+    awf.assemblyDef.addConstraint(indexConstraint1);
+    awf.assemblyDef.addConstraint(indexConstraint2);
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(assembly, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertAll(
+        () -> assertFalse(handler.isPassing(), "should fail with duplicate index name"),
+        () -> assertThat("should have findings", handler.getFindings(), hasSize(1)));
+  }
+
+  /**
+   * Test index constraint with duplicate keys (should fail).
+   *
+   * @throws ConstraintValidationException
+   *           if an unexpected error occurred while validating a constraint
+   */
+  @Test
+  void testIndexConstraintDuplicateKeys() throws ConstraintValidationException {
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource("https://example.com/module");
+
+    AssemblyWithField awf = createAssemblyWithChildField(mocking, source);
+
+    StaticContext staticContext = StaticContext.builder()
+        .defaultModelNamespace(NS)
+        .build();
+    IDMAssemblyNodeItem assembly = IDMAssemblyNodeItem.newInstance(awf.assemblyDef, staticContext);
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("duplicate"));
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("duplicate"));
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("unique"));
+
+    IIndexConstraint indexConstraint = IIndexConstraint.builder("test-index")
+        .source(source)
+        .target(IMetapathExpression.compile("child", staticContext))
+        .keyField(IKeyField.of(
+            IMetapathExpression.compile(".", staticContext),
+            null,
+            null))
+        .build();
+    awf.assemblyDef.addConstraint(indexConstraint);
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(assembly, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertAll(
+        () -> assertFalse(handler.isPassing(), "should fail with duplicate keys"),
+        () -> assertThat("should have findings", handler.getFindings(), hasSize(1)));
+  }
+
+  /**
+   * Test unique constraint with all unique values (should pass).
+   *
+   * @throws ConstraintValidationException
+   *           if an unexpected error occurred while validating a constraint
+   */
+  @Test
+  void testUniqueConstraintAllUnique() throws ConstraintValidationException {
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource("https://example.com/module");
+
+    AssemblyWithField awf = createAssemblyWithChildField(mocking, source);
+
+    StaticContext staticContext = StaticContext.builder()
+        .defaultModelNamespace(NS)
+        .build();
+    IDMAssemblyNodeItem assembly = IDMAssemblyNodeItem.newInstance(awf.assemblyDef, staticContext);
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("value1"));
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("value2"));
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("value3"));
+
+    IUniqueConstraint uniqueConstraint = IUniqueConstraint.builder()
+        .source(source)
+        .target(IMetapathExpression.compile("child", staticContext))
+        .keyField(IKeyField.of(
+            IMetapathExpression.compile(".", staticContext),
+            null,
+            null))
+        .build();
+    awf.assemblyDef.addConstraint(uniqueConstraint);
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(assembly, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertTrue(handler.isPassing(), "should pass with all unique values");
+  }
+
+  /**
+   * Test unique constraint with duplicate values (should fail).
+   *
+   * @throws ConstraintValidationException
+   *           if an unexpected error occurred while validating a constraint
+   */
+  @Test
+  void testUniqueConstraintDuplicateValues() throws ConstraintValidationException {
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource("https://example.com/module");
+
+    AssemblyWithField awf = createAssemblyWithChildField(mocking, source);
+
+    StaticContext staticContext = StaticContext.builder()
+        .defaultModelNamespace(NS)
+        .build();
+    IDMAssemblyNodeItem assembly = IDMAssemblyNodeItem.newInstance(awf.assemblyDef, staticContext);
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("duplicate"));
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("duplicate"));
+    assembly.newField(awf.fieldInstance, IStringItem.valueOf("unique"));
+
+    IUniqueConstraint uniqueConstraint = IUniqueConstraint.builder()
+        .source(source)
+        .target(IMetapathExpression.compile("child", staticContext))
+        .keyField(IKeyField.of(
+            IMetapathExpression.compile(".", staticContext),
+            null,
+            null))
+        .build();
+    awf.assemblyDef.addConstraint(uniqueConstraint);
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(assembly, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertAll(
+        () -> assertFalse(handler.isPassing(), "should fail with duplicate values"),
+        () -> assertThat("should have findings", handler.getFindings(), hasSize(1)));
+  }
+
+  /**
+   * Test unique constraint with compound keys - all unique (should pass).
+   *
+   * @throws ConstraintValidationException
+   *           if an unexpected error occurred while validating a constraint
+   */
+  @Test
+  void testUniqueConstraintCompoundKeys() throws ConstraintValidationException {
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource("https://example.com/module");
+
+    AssemblyWithFieldAndFlags awff = createAssemblyWithChildFieldAndFlags(mocking, source);
+
+    StaticContext staticContext = StaticContext.builder()
+        .defaultModelNamespace(NS)
+        .build();
+    IDMAssemblyNodeItem assembly = IDMAssemblyNodeItem.newInstance(awff.assemblyDef, staticContext);
+
+    // Add child fields with unique compound keys
+    // child1: key1=a, key2=1
+    IDMFieldNodeItem child1 = assembly.newField(awff.fieldInstance, IStringItem.valueOf("data1"));
+    child1.newFlag(awff.key1FlagInstance, IStringItem.valueOf("a"));
+    child1.newFlag(awff.key2FlagInstance, IStringItem.valueOf("1"));
+
+    // child2: key1=a, key2=2 (different from child1)
+    IDMFieldNodeItem child2 = assembly.newField(awff.fieldInstance, IStringItem.valueOf("data2"));
+    child2.newFlag(awff.key1FlagInstance, IStringItem.valueOf("a"));
+    child2.newFlag(awff.key2FlagInstance, IStringItem.valueOf("2"));
+
+    // child3: key1=b, key2=1 (different from child1 and child2)
+    IDMFieldNodeItem child3 = assembly.newField(awff.fieldInstance, IStringItem.valueOf("data3"));
+    child3.newFlag(awff.key1FlagInstance, IStringItem.valueOf("b"));
+    child3.newFlag(awff.key2FlagInstance, IStringItem.valueOf("1"));
+
+    // Compound key constraint with two key fields
+    IUniqueConstraint uniqueConstraint = IUniqueConstraint.builder()
+        .source(source)
+        .target(IMetapathExpression.compile("child", staticContext))
+        .keyField(IKeyField.of(
+            IMetapathExpression.compile("@key1", staticContext),
+            null,
+            null))
+        .keyField(IKeyField.of(
+            IMetapathExpression.compile("@key2", staticContext),
+            null,
+            null))
+        .build();
+    awff.assemblyDef.addConstraint(uniqueConstraint);
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(assembly, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertTrue(handler.isPassing(), "should pass with unique compound keys");
+  }
+
+  /**
+   * Test unique constraint with duplicate compound keys (should fail).
+   *
+   * @throws ConstraintValidationException
+   *           if an unexpected error occurred while validating a constraint
+   */
+  @Test
+  void testUniqueConstraintCompoundKeysDuplicate() throws ConstraintValidationException {
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource("https://example.com/module");
+
+    AssemblyWithFieldAndFlags awff = createAssemblyWithChildFieldAndFlags(mocking, source);
+
+    StaticContext staticContext = StaticContext.builder()
+        .defaultModelNamespace(NS)
+        .build();
+    IDMAssemblyNodeItem assembly = IDMAssemblyNodeItem.newInstance(awff.assemblyDef, staticContext);
+
+    // Add child fields with duplicate compound keys
+    // child1: key1=a, key2=1
+    IDMFieldNodeItem child1 = assembly.newField(awff.fieldInstance, IStringItem.valueOf("data1"));
+    child1.newFlag(awff.key1FlagInstance, IStringItem.valueOf("a"));
+    child1.newFlag(awff.key2FlagInstance, IStringItem.valueOf("1"));
+
+    // child2: key1=a, key2=1 (duplicate compound key)
+    IDMFieldNodeItem child2 = assembly.newField(awff.fieldInstance, IStringItem.valueOf("data2"));
+    child2.newFlag(awff.key1FlagInstance, IStringItem.valueOf("a"));
+    child2.newFlag(awff.key2FlagInstance, IStringItem.valueOf("1"));
+
+    // child3: key1=b, key2=1 (unique)
+    IDMFieldNodeItem child3 = assembly.newField(awff.fieldInstance, IStringItem.valueOf("data3"));
+    child3.newFlag(awff.key1FlagInstance, IStringItem.valueOf("b"));
+    child3.newFlag(awff.key2FlagInstance, IStringItem.valueOf("1"));
+
+    // Compound key constraint with two key fields
+    IUniqueConstraint uniqueConstraint = IUniqueConstraint.builder()
+        .source(source)
+        .target(IMetapathExpression.compile("child", staticContext))
+        .keyField(IKeyField.of(
+            IMetapathExpression.compile("@key1", staticContext),
+            null,
+            null))
+        .keyField(IKeyField.of(
+            IMetapathExpression.compile("@key2", staticContext),
+            null,
+            null))
+        .build();
+    awff.assemblyDef.addConstraint(uniqueConstraint);
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(assembly, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertAll(
+        () -> assertFalse(handler.isPassing(), "should fail with duplicate compound keys"),
+        () -> assertThat("should have findings", handler.getFindings(), hasSize(1)),
+        () -> assertThat("finding should be for assembly", handler.getFindings().get(0),
+            hasProperty("node", is(assembly))));
+  }
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/model/constraint/MatchesConstraintTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/model/constraint/MatchesConstraintTest.java
@@ -1,0 +1,632 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.model.constraint;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import gov.nist.secauto.metaschema.core.datatype.adapter.MetaschemaDataTypeProvider;
+import gov.nist.secauto.metaschema.core.metapath.DynamicContext;
+import gov.nist.secauto.metaschema.core.metapath.StaticContext;
+import gov.nist.secauto.metaschema.core.metapath.format.IPathFormatter;
+import gov.nist.secauto.metaschema.core.metapath.item.atomic.IStringItem;
+import gov.nist.secauto.metaschema.core.metapath.item.node.IFlagNodeItem;
+import gov.nist.secauto.metaschema.core.model.IFlagDefinition;
+import gov.nist.secauto.metaschema.core.model.ISource;
+import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
+import gov.nist.secauto.metaschema.core.testsupport.mocking.MockNodeItemFactory;
+import gov.nist.secauto.metaschema.core.util.CollectionUtil;
+import gov.nist.secauto.metaschema.core.util.ObjectUtils;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Tests for {@link IMatchesConstraint} validation.
+ */
+@SuppressWarnings("PMD.TooManyStaticImports")
+class MatchesConstraintTest {
+  @NonNull
+  private static final String NS = ObjectUtils.notNull(URI.create("http://example.com/ns").toASCIIString());
+
+  @NonNull
+  private static IEnhancedQName qname(@NonNull String name) {
+    return IEnhancedQName.of(NS, name);
+  }
+
+  /**
+   * Tests that a value matching the regex pattern passes validation.
+   *
+   * @throws ConstraintValidationException
+   *           if validation fails unexpectedly
+   */
+  @SuppressWarnings("null")
+  @Test
+  void testMatchesRegexSuccess() throws ConstraintValidationException {
+    MockNodeItemFactory itemFactory = new MockNodeItemFactory();
+
+    IFlagNodeItem flag = itemFactory.flag(qname("email"), IStringItem.valueOf("test@example.com"));
+
+    IFlagDefinition flagDefinition = mock(IFlagDefinition.class);
+    ISource source = mock(ISource.class);
+
+    IMatchesConstraint matchesConstraint = IMatchesConstraint.builder()
+        .source(source)
+        .regex("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$")
+        .build();
+
+    doReturn(flagDefinition).when(flag).getDefinition();
+    doReturn("flag/path").when(flag).toPath(any(IPathFormatter.class));
+
+    doReturn(CollectionUtil.emptyMap()).when(flagDefinition).getLetExpressions();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getAllowedValuesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getExpectConstraints();
+    doReturn(CollectionUtil.singletonList(matchesConstraint)).when(flagDefinition).getMatchesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getIndexHasKeyConstraints();
+
+    StaticContext staticContext = StaticContext.instance();
+    doReturn(staticContext).when(source).getStaticContext();
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(flag, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertTrue(handler.isPassing(), "expected validation to pass");
+  }
+
+  /**
+   * Tests that a value not matching the regex pattern fails validation.
+   *
+   * @throws ConstraintValidationException
+   *           if validation fails unexpectedly
+   */
+  @SuppressWarnings("null")
+  @Test
+  void testMatchesRegexFailure() throws ConstraintValidationException {
+    MockNodeItemFactory itemFactory = new MockNodeItemFactory();
+
+    IFlagNodeItem flag = itemFactory.flag(qname("email"), IStringItem.valueOf("invalid-email"));
+
+    IFlagDefinition flagDefinition = mock(IFlagDefinition.class);
+    ISource source = mock(ISource.class);
+
+    IMatchesConstraint matchesConstraint = IMatchesConstraint.builder()
+        .source(source)
+        .regex("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$")
+        .build();
+
+    doReturn(flagDefinition).when(flag).getDefinition();
+    doReturn("flag/path").when(flag).toPath(any(IPathFormatter.class));
+
+    doReturn(CollectionUtil.emptyMap()).when(flagDefinition).getLetExpressions();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getAllowedValuesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getExpectConstraints();
+    doReturn(CollectionUtil.singletonList(matchesConstraint)).when(flagDefinition).getMatchesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getIndexHasKeyConstraints();
+
+    StaticContext staticContext = StaticContext.instance();
+    doReturn(staticContext).when(source).getStaticContext();
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(flag, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertAll(
+        () -> assertFalse(handler.isPassing(), "expected validation to fail"),
+        () -> assertThat("expected one finding", handler.getFindings(), hasSize(1)),
+        () -> assertThat("finding is for the flag node", handler.getFindings(),
+            hasItem(hasProperty("node", is(flag)))));
+  }
+
+  /**
+   * Tests that a value conforming to a datatype passes validation.
+   *
+   * @throws ConstraintValidationException
+   *           if validation fails unexpectedly
+   */
+  @SuppressWarnings("null")
+  @Test
+  void testMatchesDatatypeSuccess() throws ConstraintValidationException {
+    MockNodeItemFactory itemFactory = new MockNodeItemFactory();
+
+    IFlagNodeItem flag = itemFactory.flag(qname("uuid"),
+        IStringItem.valueOf("f81d4fae-7dec-11d0-a765-00a0c91e6bf6"));
+
+    IFlagDefinition flagDefinition = mock(IFlagDefinition.class);
+    ISource source = mock(ISource.class);
+
+    IMatchesConstraint matchesConstraint = IMatchesConstraint.builder()
+        .source(source)
+        .datatype(MetaschemaDataTypeProvider.UUID)
+        .build();
+
+    doReturn(flagDefinition).when(flag).getDefinition();
+    doReturn("flag/path").when(flag).toPath(any(IPathFormatter.class));
+
+    doReturn(CollectionUtil.emptyMap()).when(flagDefinition).getLetExpressions();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getAllowedValuesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getExpectConstraints();
+    doReturn(CollectionUtil.singletonList(matchesConstraint)).when(flagDefinition).getMatchesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getIndexHasKeyConstraints();
+
+    StaticContext staticContext = StaticContext.instance();
+    doReturn(staticContext).when(source).getStaticContext();
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(flag, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertTrue(handler.isPassing(), "expected validation to pass");
+  }
+
+  /**
+   * Tests that a value not conforming to a datatype fails validation.
+   *
+   * @throws ConstraintValidationException
+   *           if validation fails unexpectedly
+   */
+  @SuppressWarnings("null")
+  @Test
+  void testMatchesDatatypeFailure() throws ConstraintValidationException {
+    MockNodeItemFactory itemFactory = new MockNodeItemFactory();
+
+    IFlagNodeItem flag = itemFactory.flag(qname("uuid"), IStringItem.valueOf("not-a-uuid"));
+
+    IFlagDefinition flagDefinition = mock(IFlagDefinition.class);
+    ISource source = mock(ISource.class);
+
+    IMatchesConstraint matchesConstraint = IMatchesConstraint.builder()
+        .source(source)
+        .datatype(MetaschemaDataTypeProvider.UUID)
+        .build();
+
+    doReturn(flagDefinition).when(flag).getDefinition();
+    doReturn("flag/path").when(flag).toPath(any(IPathFormatter.class));
+
+    doReturn(CollectionUtil.emptyMap()).when(flagDefinition).getLetExpressions();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getAllowedValuesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getExpectConstraints();
+    doReturn(CollectionUtil.singletonList(matchesConstraint)).when(flagDefinition).getMatchesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getIndexHasKeyConstraints();
+
+    StaticContext staticContext = StaticContext.instance();
+    doReturn(staticContext).when(source).getStaticContext();
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(flag, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertAll(
+        () -> assertFalse(handler.isPassing(), "expected validation to fail"),
+        () -> assertThat("expected one finding", handler.getFindings(), hasSize(1)),
+        () -> assertThat("finding is for the flag node", handler.getFindings(),
+            hasItem(hasProperty("node", is(flag)))));
+  }
+
+  /**
+   * Tests that a value matching both regex and datatype passes validation.
+   *
+   * @throws ConstraintValidationException
+   *           if validation fails unexpectedly
+   */
+  @SuppressWarnings("null")
+  @Test
+  void testMatchesRegexAndDatatypeSuccess() throws ConstraintValidationException {
+    MockNodeItemFactory itemFactory = new MockNodeItemFactory();
+
+    IFlagNodeItem flag = itemFactory.flag(qname("uuid"),
+        IStringItem.valueOf("f81d4fae-7dec-11d0-a765-00a0c91e6bf6"));
+
+    IFlagDefinition flagDefinition = mock(IFlagDefinition.class);
+    ISource source = mock(ISource.class);
+
+    IMatchesConstraint matchesConstraint = IMatchesConstraint.builder()
+        .source(source)
+        .regex("^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$")
+        .datatype(MetaschemaDataTypeProvider.UUID)
+        .build();
+
+    doReturn(flagDefinition).when(flag).getDefinition();
+    doReturn("flag/path").when(flag).toPath(any(IPathFormatter.class));
+
+    doReturn(CollectionUtil.emptyMap()).when(flagDefinition).getLetExpressions();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getAllowedValuesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getExpectConstraints();
+    doReturn(CollectionUtil.singletonList(matchesConstraint)).when(flagDefinition).getMatchesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getIndexHasKeyConstraints();
+
+    StaticContext staticContext = StaticContext.instance();
+    doReturn(staticContext).when(source).getStaticContext();
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(flag, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertTrue(handler.isPassing(), "expected validation to pass");
+  }
+
+  /**
+   * Tests that a value matching regex but not datatype fails validation.
+   *
+   * @throws ConstraintValidationException
+   *           if validation fails unexpectedly
+   */
+  @SuppressWarnings("null")
+  @Test
+  void testMatchesRegexButNotDatatype() throws ConstraintValidationException {
+    MockNodeItemFactory itemFactory = new MockNodeItemFactory();
+
+    // This value matches a simple UUID-like pattern but is not a valid UUID (has
+    // invalid characters)
+    IFlagNodeItem flag = itemFactory.flag(qname("uuid"),
+        IStringItem.valueOf("not-a-valid-uuid-value-here"));
+
+    IFlagDefinition flagDefinition = mock(IFlagDefinition.class);
+    ISource source = mock(ISource.class);
+
+    IMatchesConstraint matchesConstraint = IMatchesConstraint.builder()
+        .source(source)
+        .regex("^[a-z-]+$")
+        .datatype(MetaschemaDataTypeProvider.UUID)
+        .build();
+
+    doReturn(flagDefinition).when(flag).getDefinition();
+    doReturn("flag/path").when(flag).toPath(any(IPathFormatter.class));
+
+    doReturn(CollectionUtil.emptyMap()).when(flagDefinition).getLetExpressions();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getAllowedValuesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getExpectConstraints();
+    doReturn(CollectionUtil.singletonList(matchesConstraint)).when(flagDefinition).getMatchesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getIndexHasKeyConstraints();
+
+    StaticContext staticContext = StaticContext.instance();
+    doReturn(staticContext).when(source).getStaticContext();
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(flag, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    // The validation should fail because the datatype check fails
+    assertAll(
+        () -> assertFalse(handler.isPassing(), "expected validation to fail"),
+        () -> assertThat("expected one finding", handler.getFindings(), hasSize(1)),
+        () -> assertThat("finding is for the flag node", handler.getFindings(),
+            hasItem(hasProperty("node", is(flag)))));
+  }
+
+  /**
+   * Tests complex regex patterns with special characters.
+   *
+   * @throws ConstraintValidationException
+   *           if validation fails unexpectedly
+   */
+  @SuppressWarnings("null")
+  @Test
+  void testComplexRegexPattern() throws ConstraintValidationException {
+    MockNodeItemFactory itemFactory = new MockNodeItemFactory();
+
+    // Test a complex pattern for version strings
+    IFlagNodeItem flag = itemFactory.flag(qname("version"), IStringItem.valueOf("1.2.3-beta.1"));
+
+    IFlagDefinition flagDefinition = mock(IFlagDefinition.class);
+    ISource source = mock(ISource.class);
+
+    IMatchesConstraint matchesConstraint = IMatchesConstraint.builder()
+        .source(source)
+        .regex("^\\d+\\.\\d+\\.\\d+(-(alpha|beta|rc)\\.\\d+)?$")
+        .build();
+
+    doReturn(flagDefinition).when(flag).getDefinition();
+    doReturn("flag/path").when(flag).toPath(any(IPathFormatter.class));
+
+    doReturn(CollectionUtil.emptyMap()).when(flagDefinition).getLetExpressions();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getAllowedValuesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getExpectConstraints();
+    doReturn(CollectionUtil.singletonList(matchesConstraint)).when(flagDefinition).getMatchesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getIndexHasKeyConstraints();
+
+    StaticContext staticContext = StaticContext.instance();
+    doReturn(staticContext).when(source).getStaticContext();
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(flag, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertTrue(handler.isPassing(), "expected validation to pass");
+  }
+
+  /**
+   * Tests edge case with empty string.
+   *
+   * @throws ConstraintValidationException
+   *           if validation fails unexpectedly
+   */
+  @SuppressWarnings("null")
+  @Test
+  void testEmptyStringFailsPattern() throws ConstraintValidationException {
+    MockNodeItemFactory itemFactory = new MockNodeItemFactory();
+
+    IFlagNodeItem flag = itemFactory.flag(qname("value"), IStringItem.valueOf(""));
+
+    IFlagDefinition flagDefinition = mock(IFlagDefinition.class);
+    ISource source = mock(ISource.class);
+
+    // Pattern requires at least one character
+    IMatchesConstraint matchesConstraint = IMatchesConstraint.builder()
+        .source(source)
+        .regex("^.+$")
+        .build();
+
+    doReturn(flagDefinition).when(flag).getDefinition();
+    doReturn("flag/path").when(flag).toPath(any(IPathFormatter.class));
+
+    doReturn(CollectionUtil.emptyMap()).when(flagDefinition).getLetExpressions();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getAllowedValuesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getExpectConstraints();
+    doReturn(CollectionUtil.singletonList(matchesConstraint)).when(flagDefinition).getMatchesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getIndexHasKeyConstraints();
+
+    StaticContext staticContext = StaticContext.instance();
+    doReturn(staticContext).when(source).getStaticContext();
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(flag, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertAll(
+        () -> assertFalse(handler.isPassing(), "expected validation to fail"),
+        () -> assertThat("expected one finding", handler.getFindings(), hasSize(1)),
+        () -> assertThat("finding is for the flag node", handler.getFindings(),
+            hasItem(hasProperty("node", is(flag)))));
+  }
+
+  /**
+   * Tests edge case with empty string that matches pattern.
+   *
+   * @throws ConstraintValidationException
+   *           if validation fails unexpectedly
+   */
+  @SuppressWarnings("null")
+  @Test
+  void testEmptyStringMatchesPattern() throws ConstraintValidationException {
+    MockNodeItemFactory itemFactory = new MockNodeItemFactory();
+
+    IFlagNodeItem flag = itemFactory.flag(qname("value"), IStringItem.valueOf(""));
+
+    IFlagDefinition flagDefinition = mock(IFlagDefinition.class);
+    ISource source = mock(ISource.class);
+
+    // Pattern allows empty string
+    IMatchesConstraint matchesConstraint = IMatchesConstraint.builder()
+        .source(source)
+        .regex("^.*$")
+        .build();
+
+    doReturn(flagDefinition).when(flag).getDefinition();
+    doReturn("flag/path").when(flag).toPath(any(IPathFormatter.class));
+
+    doReturn(CollectionUtil.emptyMap()).when(flagDefinition).getLetExpressions();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getAllowedValuesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getExpectConstraints();
+    doReturn(CollectionUtil.singletonList(matchesConstraint)).when(flagDefinition).getMatchesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getIndexHasKeyConstraints();
+
+    StaticContext staticContext = StaticContext.instance();
+    doReturn(staticContext).when(source).getStaticContext();
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(flag, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertTrue(handler.isPassing(), "expected validation to pass");
+  }
+
+  /**
+   * Tests pattern with special regex characters.
+   *
+   * @throws ConstraintValidationException
+   *           if validation fails unexpectedly
+   */
+  @SuppressWarnings("null")
+  @Test
+  void testSpecialCharactersInValue() throws ConstraintValidationException {
+    MockNodeItemFactory itemFactory = new MockNodeItemFactory();
+
+    IFlagNodeItem flag = itemFactory.flag(qname("path"), IStringItem.valueOf("/usr/local/bin"));
+
+    IFlagDefinition flagDefinition = mock(IFlagDefinition.class);
+    ISource source = mock(ISource.class);
+
+    // Pattern for Unix-style paths
+    IMatchesConstraint matchesConstraint = IMatchesConstraint.builder()
+        .source(source)
+        .regex("^(/[a-z]+)+$")
+        .build();
+
+    doReturn(flagDefinition).when(flag).getDefinition();
+    doReturn("flag/path").when(flag).toPath(any(IPathFormatter.class));
+
+    doReturn(CollectionUtil.emptyMap()).when(flagDefinition).getLetExpressions();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getAllowedValuesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getExpectConstraints();
+    doReturn(CollectionUtil.singletonList(matchesConstraint)).when(flagDefinition).getMatchesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getIndexHasKeyConstraints();
+
+    StaticContext staticContext = StaticContext.instance();
+    doReturn(staticContext).when(source).getStaticContext();
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(flag, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertTrue(handler.isPassing(), "expected validation to pass");
+  }
+
+  /**
+   * Tests URI datatype validation with valid URI.
+   *
+   * @throws ConstraintValidationException
+   *           if validation fails unexpectedly
+   */
+  @SuppressWarnings("null")
+  @Test
+  void testUriDatatypeSuccess() throws ConstraintValidationException {
+    MockNodeItemFactory itemFactory = new MockNodeItemFactory();
+
+    IFlagNodeItem flag = itemFactory.flag(qname("url"),
+        IStringItem.valueOf("https://example.com/path"));
+
+    IFlagDefinition flagDefinition = mock(IFlagDefinition.class);
+    ISource source = mock(ISource.class);
+
+    IMatchesConstraint matchesConstraint = IMatchesConstraint.builder()
+        .source(source)
+        .datatype(MetaschemaDataTypeProvider.URI)
+        .build();
+
+    doReturn(flagDefinition).when(flag).getDefinition();
+    doReturn("flag/path").when(flag).toPath(any(IPathFormatter.class));
+
+    doReturn(CollectionUtil.emptyMap()).when(flagDefinition).getLetExpressions();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getAllowedValuesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getExpectConstraints();
+    doReturn(CollectionUtil.singletonList(matchesConstraint)).when(flagDefinition).getMatchesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getIndexHasKeyConstraints();
+
+    StaticContext staticContext = StaticContext.instance();
+    doReturn(staticContext).when(source).getStaticContext();
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(flag, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertTrue(handler.isPassing(), "expected validation to pass");
+  }
+
+  /**
+   * Tests case-sensitive regex pattern matching.
+   *
+   * @throws ConstraintValidationException
+   *           if validation fails unexpectedly
+   */
+  @SuppressWarnings("null")
+  @Test
+  void testCaseSensitiveRegex() throws ConstraintValidationException {
+    MockNodeItemFactory itemFactory = new MockNodeItemFactory();
+
+    IFlagNodeItem flag = itemFactory.flag(qname("code"), IStringItem.valueOf("ABC123"));
+
+    IFlagDefinition flagDefinition = mock(IFlagDefinition.class);
+    ISource source = mock(ISource.class);
+
+    // Pattern requires uppercase letters followed by digits
+    IMatchesConstraint matchesConstraint = IMatchesConstraint.builder()
+        .source(source)
+        .regex("^[A-Z]+\\d+$")
+        .build();
+
+    doReturn(flagDefinition).when(flag).getDefinition();
+    doReturn("flag/path").when(flag).toPath(any(IPathFormatter.class));
+
+    doReturn(CollectionUtil.emptyMap()).when(flagDefinition).getLetExpressions();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getAllowedValuesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getExpectConstraints();
+    doReturn(CollectionUtil.singletonList(matchesConstraint)).when(flagDefinition).getMatchesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getIndexHasKeyConstraints();
+
+    StaticContext staticContext = StaticContext.instance();
+    doReturn(staticContext).when(source).getStaticContext();
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(flag, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertTrue(handler.isPassing(), "expected validation to pass");
+  }
+
+  /**
+   * Tests case-sensitive regex pattern failing with wrong case.
+   *
+   * @throws ConstraintValidationException
+   *           if validation fails unexpectedly
+   */
+  @SuppressWarnings("null")
+  @Test
+  void testCaseSensitiveRegexFailure() throws ConstraintValidationException {
+    MockNodeItemFactory itemFactory = new MockNodeItemFactory();
+
+    IFlagNodeItem flag = itemFactory.flag(qname("code"), IStringItem.valueOf("abc123"));
+
+    IFlagDefinition flagDefinition = mock(IFlagDefinition.class);
+    ISource source = mock(ISource.class);
+
+    // Pattern requires uppercase letters followed by digits
+    IMatchesConstraint matchesConstraint = IMatchesConstraint.builder()
+        .source(source)
+        .regex("^[A-Z]+\\d+$")
+        .build();
+
+    doReturn(flagDefinition).when(flag).getDefinition();
+    doReturn("flag/path").when(flag).toPath(any(IPathFormatter.class));
+
+    doReturn(CollectionUtil.emptyMap()).when(flagDefinition).getLetExpressions();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getAllowedValuesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getExpectConstraints();
+    doReturn(CollectionUtil.singletonList(matchesConstraint)).when(flagDefinition).getMatchesConstraints();
+    doReturn(CollectionUtil.emptyList()).when(flagDefinition).getIndexHasKeyConstraints();
+
+    StaticContext staticContext = StaticContext.instance();
+    doReturn(staticContext).when(source).getStaticContext();
+
+    FindingCollectingConstraintValidationHandler handler = new FindingCollectingConstraintValidationHandler();
+    DefaultConstraintValidator validator = new DefaultConstraintValidator(handler);
+    DynamicContext dynamicContext = new DynamicContext(staticContext);
+    validator.validate(flag, dynamicContext);
+    validator.finalizeValidation(dynamicContext);
+
+    assertAll(
+        () -> assertFalse(handler.isPassing(), "expected validation to fail"),
+        () -> assertThat("expected one finding", handler.getFindings(), hasSize(1)),
+        () -> assertThat("finding is for the flag node", handler.getFindings(),
+            hasItem(hasProperty("node", is(flag)))));
+  }
+}

--- a/core/src/test/java/gov/nist/secauto/metaschema/core/model/validation/SchemaContentValidatorTest.java
+++ b/core/src/test/java/gov/nist/secauto/metaschema/core/model/validation/SchemaContentValidatorTest.java
@@ -1,0 +1,322 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.core.model.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import gov.nist.secauto.metaschema.core.model.constraint.IConstraint.Level;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import javax.xml.transform.stream.StreamSource;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Comprehensive tests for schema content validators including XML and JSON
+ * validation.
+ */
+class SchemaContentValidatorTest {
+
+  @NonNull
+  private static final String VALID_XML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+      + "<root xmlns=\"http://example.com/test\">\n"
+      + "    <name>John Doe</name>\n"
+      + "    <age>30</age>\n"
+      + "    <email>john@example.com</email>\n"
+      + "</root>";
+
+  @NonNull
+  private static final String INVALID_XML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+      + "<root xmlns=\"http://example.com/test\">\n"
+      + "    <name>Jane Doe</name>\n"
+      + "    <age>-5</age>\n"
+      + "</root>";
+
+  @NonNull
+  private static final String VALID_JSON = "{\n"
+      + "  \"name\": \"John Doe\",\n"
+      + "  \"age\": 30,\n"
+      + "  \"email\": \"john@example.com\"\n"
+      + "}";
+
+  @NonNull
+  private static final String INVALID_JSON = "{\n"
+      + "  \"name\": \"Jane Doe\",\n"
+      + "  \"age\": -5,\n"
+      + "  \"extraField\": \"should not be here\"\n"
+      + "}";
+
+  @NonNull
+  private static final URI TEST_URI = URI.create("file:///test-document");
+
+  /**
+   * Test XML validation with valid content - should pass with no findings.
+   */
+  @Test
+  void testXmlValidationWithValidContent() throws IOException {
+    // Load the XSD schema from classpath
+    XmlSchemaContentValidator validator = createXmlValidator();
+
+    // Validate valid XML content
+    InputStream is = new ByteArrayInputStream(VALID_XML.getBytes(StandardCharsets.UTF_8));
+    IValidationResult result = validator.validate(is, TEST_URI);
+
+    assertNotNull(result, "Validation result should not be null");
+    assertTrue(result.isPassing(), "Validation should pass for valid content");
+    assertEquals(Level.INFORMATIONAL, result.getHighestSeverity(),
+        "Highest severity should be INFORMATIONAL for valid content");
+    assertTrue(result.getFindings().isEmpty(), "No findings should be present for valid content");
+  }
+
+  /**
+   * Test XML validation with invalid content - should return findings.
+   */
+  @Test
+  void testXmlValidationWithInvalidContent() throws IOException {
+    // Load the XSD schema from classpath
+    XmlSchemaContentValidator validator = createXmlValidator();
+
+    // Validate invalid XML content (negative age violates xs:positiveInteger)
+    InputStream is = new ByteArrayInputStream(INVALID_XML.getBytes(StandardCharsets.UTF_8));
+    IValidationResult result = validator.validate(is, TEST_URI);
+
+    assertNotNull(result, "Validation result should not be null");
+    assertFalse(result.isPassing(), "Validation should fail for invalid content");
+    assertFalse(result.getFindings().isEmpty(), "Findings should be present for invalid content");
+    assertTrue(result.getHighestSeverity().ordinal() >= Level.ERROR.ordinal(),
+        "Highest severity should be ERROR or higher for invalid content");
+  }
+
+  /**
+   * Test XML validation findings have proper metadata.
+   */
+  @Test
+  void testXmlValidationFindingMetadata() throws IOException {
+    XmlSchemaContentValidator validator = createXmlValidator();
+
+    InputStream is = new ByteArrayInputStream(INVALID_XML.getBytes(StandardCharsets.UTF_8));
+    IValidationResult result = validator.validate(is, TEST_URI);
+
+    assertFalse(result.getFindings().isEmpty(), "Should have at least one finding");
+
+    IValidationFinding finding = result.getFindings().get(0);
+    assertNotNull(finding.getMessage(), "Finding should have a message");
+    assertNotNull(finding.getCause(), "Finding should have a cause exception");
+    assertEquals(IValidationFinding.Kind.FAIL, finding.getKind(), "Finding kind should be FAIL");
+    assertNotNull(finding.getDocumentUri(), "Finding should have a document URI");
+  }
+
+  /**
+   * Test JSON validation with valid content - should pass with no findings.
+   */
+  @Test
+  void testJsonValidationWithValidContent() throws IOException {
+    // Load the JSON schema from classpath
+    JsonSchemaContentValidator validator = createJsonValidator();
+
+    // Validate valid JSON content
+    InputStream is = new ByteArrayInputStream(VALID_JSON.getBytes(StandardCharsets.UTF_8));
+    IValidationResult result = validator.validate(is, TEST_URI);
+
+    assertNotNull(result, "Validation result should not be null");
+    assertTrue(result.isPassing(), "Validation should pass for valid content");
+    assertEquals(Level.INFORMATIONAL, result.getHighestSeverity(),
+        "Highest severity should be INFORMATIONAL for valid content");
+    assertTrue(result.getFindings().isEmpty(), "No findings should be present for valid content");
+  }
+
+  /**
+   * Test JSON validation with invalid content - should return findings.
+   */
+  @Test
+  void testJsonValidationWithInvalidContent() throws IOException {
+    JsonSchemaContentValidator validator = createJsonValidator();
+
+    // Validate invalid JSON content (negative age, extra field)
+    InputStream is = new ByteArrayInputStream(INVALID_JSON.getBytes(StandardCharsets.UTF_8));
+    IValidationResult result = validator.validate(is, TEST_URI);
+
+    assertNotNull(result, "Validation result should not be null");
+    assertFalse(result.isPassing(), "Validation should fail for invalid content");
+    assertFalse(result.getFindings().isEmpty(), "Findings should be present for invalid content");
+    assertTrue(result.getHighestSeverity().ordinal() >= Level.ERROR.ordinal(),
+        "Highest severity should be ERROR or higher for invalid content");
+  }
+
+  /**
+   * Test JSON validation findings have proper metadata.
+   */
+  @Test
+  void testJsonValidationFindingMetadata() throws IOException {
+    JsonSchemaContentValidator validator = createJsonValidator();
+
+    InputStream is = new ByteArrayInputStream(INVALID_JSON.getBytes(StandardCharsets.UTF_8));
+    IValidationResult result = validator.validate(is, TEST_URI);
+
+    assertFalse(result.getFindings().isEmpty(), "Should have at least one finding");
+
+    IValidationFinding finding = result.getFindings().get(0);
+    assertNotNull(finding.getMessage(), "Finding should have a message");
+    assertNotNull(finding.getCause(), "Finding should have a cause exception");
+    assertEquals(IValidationFinding.Kind.FAIL, finding.getKind(), "Finding kind should be FAIL");
+    assertEquals(Level.CRITICAL, finding.getSeverity(), "JSON validation failures should be CRITICAL");
+    assertEquals("JSON-pointer", finding.getPathKind(), "Path kind should be JSON-pointer");
+    assertNotNull(finding.getDocumentUri(), "Finding should have a document URI");
+  }
+
+  /**
+   * Test aggregating multiple validation results.
+   */
+  @Test
+  void testAggregateValidationResult() throws IOException {
+    XmlSchemaContentValidator xmlValidator = createXmlValidator();
+    JsonSchemaContentValidator jsonValidator = createJsonValidator();
+
+    // Validate invalid XML
+    InputStream xmlIs = new ByteArrayInputStream(INVALID_XML.getBytes(StandardCharsets.UTF_8));
+    IValidationResult xmlResult = xmlValidator.validate(xmlIs, TEST_URI);
+
+    // Validate invalid JSON
+    InputStream jsonIs = new ByteArrayInputStream(INVALID_JSON.getBytes(StandardCharsets.UTF_8));
+    IValidationResult jsonResult = jsonValidator.validate(jsonIs, TEST_URI);
+
+    // Aggregate both results
+    IValidationResult aggregated = AggregateValidationResult.aggregate(xmlResult, jsonResult);
+
+    assertNotNull(aggregated, "Aggregated result should not be null");
+    assertFalse(aggregated.isPassing(), "Aggregated result should fail when any result fails");
+    assertFalse(aggregated.getFindings().isEmpty(), "Aggregated result should have findings");
+
+    int expectedFindingsCount = xmlResult.getFindings().size() + jsonResult.getFindings().size();
+    assertEquals(expectedFindingsCount, aggregated.getFindings().size(),
+        "Aggregated result should contain all findings from both results");
+  }
+
+  /**
+   * Test aggregating results with different severity levels.
+   */
+  @Test
+  void testAggregateValidationResultHighestSeverity() throws IOException {
+    XmlSchemaContentValidator xmlValidator = createXmlValidator();
+
+    // Validate valid XML (INFORMATIONAL)
+    InputStream validIs = new ByteArrayInputStream(VALID_XML.getBytes(StandardCharsets.UTF_8));
+    IValidationResult validResult = xmlValidator.validate(validIs, TEST_URI);
+
+    // Validate invalid XML (CRITICAL)
+    InputStream invalidIs = new ByteArrayInputStream(INVALID_XML.getBytes(StandardCharsets.UTF_8));
+    IValidationResult invalidResult = xmlValidator.validate(invalidIs, TEST_URI);
+
+    // Aggregate both results - highest severity should be from invalid result
+    IValidationResult aggregated = AggregateValidationResult.aggregate(validResult, invalidResult);
+
+    assertNotNull(aggregated, "Aggregated result should not be null");
+    assertTrue(aggregated.getHighestSeverity().ordinal() >= Level.ERROR.ordinal(),
+        "Aggregated highest severity should be ERROR or higher");
+  }
+
+  /**
+   * Test aggregating all passing results.
+   */
+  @Test
+  void testAggregateAllPassingResults() throws IOException {
+    XmlSchemaContentValidator xmlValidator = createXmlValidator();
+    JsonSchemaContentValidator jsonValidator = createJsonValidator();
+
+    // Validate valid XML
+    InputStream xmlIs = new ByteArrayInputStream(VALID_XML.getBytes(StandardCharsets.UTF_8));
+    IValidationResult xmlResult = xmlValidator.validate(xmlIs, TEST_URI);
+
+    // Validate valid JSON
+    InputStream jsonIs = new ByteArrayInputStream(VALID_JSON.getBytes(StandardCharsets.UTF_8));
+    IValidationResult jsonResult = jsonValidator.validate(jsonIs, TEST_URI);
+
+    // Aggregate both passing results
+    IValidationResult aggregated = AggregateValidationResult.aggregate(xmlResult, jsonResult);
+
+    assertNotNull(aggregated, "Aggregated result should not be null");
+    assertTrue(aggregated.isPassing(), "Aggregated result should pass when all results pass");
+    assertTrue(aggregated.getFindings().isEmpty(), "Aggregated result should have no findings");
+    assertEquals(Level.INFORMATIONAL, aggregated.getHighestSeverity(),
+        "Aggregated highest severity should be INFORMATIONAL when all pass");
+  }
+
+  /**
+   * Test the PASSING_RESULT constant.
+   */
+  @Test
+  void testPassingResultConstant() {
+    IValidationResult result = IValidationResult.PASSING_RESULT;
+
+    assertNotNull(result, "PASSING_RESULT should not be null");
+    assertTrue(result.isPassing(), "PASSING_RESULT should be passing");
+    assertEquals(Level.INFORMATIONAL, result.getHighestSeverity(),
+        "PASSING_RESULT highest severity should be INFORMATIONAL");
+    assertTrue(result.getFindings().isEmpty(), "PASSING_RESULT should have no findings");
+  }
+
+  /**
+   * Test validation result severity levels.
+   */
+  @Test
+  void testValidationResultSeverityLevels() {
+    // Test that severity levels are properly ordered
+    assertTrue(Level.INFORMATIONAL.ordinal() < Level.WARNING.ordinal(),
+        "INFORMATIONAL should be less severe than WARNING");
+    assertTrue(Level.WARNING.ordinal() < Level.ERROR.ordinal(),
+        "WARNING should be less severe than ERROR");
+    assertTrue(Level.ERROR.ordinal() < Level.CRITICAL.ordinal(),
+        "ERROR should be less severe than CRITICAL");
+
+    // Test isPassing based on severity
+    IValidationResult passingResult = IValidationResult.PASSING_RESULT;
+    assertTrue(passingResult.isPassing(), "INFORMATIONAL severity should pass");
+  }
+
+  /**
+   * Create an XML validator with the test schema.
+   *
+   * @return the XML validator
+   * @throws IOException
+   *           if the schema cannot be loaded
+   */
+  @NonNull
+  private static XmlSchemaContentValidator createXmlValidator() throws IOException {
+    InputStream schemaIs = SchemaContentValidatorTest.class
+        .getResourceAsStream("/schema-validation/simple-test.xsd");
+    assertNotNull(schemaIs, "Schema resource should be found on classpath");
+
+    StreamSource schemaSource = new StreamSource(schemaIs);
+    return new XmlSchemaContentValidator(List.of(schemaSource));
+  }
+
+  /**
+   * Create a JSON validator with the test schema.
+   *
+   * @return the JSON validator
+   * @throws IOException
+   *           if the schema cannot be loaded
+   */
+  @NonNull
+  private static JsonSchemaContentValidator createJsonValidator() throws IOException {
+    InputStream schemaIs = SchemaContentValidatorTest.class
+        .getResourceAsStream("/schema-validation/simple-test-schema.json");
+    assertNotNull(schemaIs, "Schema resource should be found on classpath");
+
+    return new JsonSchemaContentValidator(schemaIs);
+  }
+}

--- a/core/src/test/resources/schema-validation/README.md
+++ b/core/src/test/resources/schema-validation/README.md
@@ -1,0 +1,44 @@
+# Schema Validation Test Resources
+
+This directory contains test schemas and instances for validating the schema content validator implementations.
+
+## Files
+
+### XML Schema Files
+- `simple-test.xsd` - A simple XML Schema for testing XML validation
+  - Defines a `root` element with `name` (string), `age` (positiveInteger), and optional `email` fields
+  - Used by `SchemaContentValidatorTest` to test `XmlSchemaContentValidator`
+
+### JSON Schema Files
+- `simple-test-schema.json` - A JSON Schema (draft-07) for testing JSON validation
+  - Defines an object with `name` (string), `age` (positive integer), and optional `email` fields
+  - Enforces `additionalProperties: false` to detect extra fields
+  - Used by `SchemaContentValidatorTest` to test `JsonSchemaContentValidator`
+
+### XML Test Instances
+- `valid-instance.xml` - Valid XML document that conforms to `simple-test.xsd`
+  - Contains valid data: name="John Doe", age=30, email="john@example.com"
+
+- `invalid-instance.xml` - Invalid XML document that violates `simple-test.xsd`
+  - Contains invalid data: age=-5 (violates positiveInteger constraint)
+
+### JSON Test Instances
+- `valid-instance.json` - Valid JSON document that conforms to `simple-test-schema.json`
+  - Contains valid data matching the schema requirements
+
+- `invalid-instance.json` - Invalid JSON document that violates `simple-test-schema.json`
+  - Contains multiple violations: age=-5 (violates minimum constraint), extraField (violates additionalProperties)
+
+## Usage
+
+These test resources are loaded by the test classes in the `gov.nist.secauto.metaschema.core.model.validation` package:
+
+- `SchemaContentValidatorTest` - Main comprehensive test suite
+- `ValidationFindingTest` - Tests for individual validation finding classes
+
+The tests verify:
+1. Valid content passes validation with no findings
+2. Invalid content fails validation with appropriate findings
+3. Finding metadata (severity, messages, locations) is properly populated
+4. Validation result aggregation works correctly
+5. Severity levels are properly handled

--- a/core/src/test/resources/schema-validation/invalid-instance.json
+++ b/core/src/test/resources/schema-validation/invalid-instance.json
@@ -1,0 +1,5 @@
+{
+  "name": "Jane Doe",
+  "age": -5,
+  "extraField": "should not be here"
+}

--- a/core/src/test/resources/schema-validation/invalid-instance.xml
+++ b/core/src/test/resources/schema-validation/invalid-instance.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root xmlns="http://example.com/test">
+    <name>Jane Doe</name>
+    <age>-5</age>
+</root>

--- a/core/src/test/resources/schema-validation/simple-test-schema.json
+++ b/core/src/test/resources/schema-validation/simple-test-schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "age": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "email": {
+      "type": "string",
+      "format": "email"
+    }
+  },
+  "required": ["name", "age"],
+  "additionalProperties": false
+}

--- a/core/src/test/resources/schema-validation/simple-test.xsd
+++ b/core/src/test/resources/schema-validation/simple-test.xsd
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns="http://example.com/test"
+    targetNamespace="http://example.com/test"
+    elementFormDefault="qualified">
+
+    <xs:element name="root">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="name" type="xs:string"/>
+                <xs:element name="age" type="xs:positiveInteger"/>
+                <xs:element name="email" type="xs:string" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/core/src/test/resources/schema-validation/valid-instance.json
+++ b/core/src/test/resources/schema-validation/valid-instance.json
@@ -1,0 +1,5 @@
+{
+  "name": "John Doe",
+  "age": 30,
+  "email": "john@example.com"
+}

--- a/core/src/test/resources/schema-validation/valid-instance.xml
+++ b/core/src/test/resources/schema-validation/valid-instance.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root xmlns="http://example.com/test">
+    <name>John Doe</name>
+    <age>30</age>
+    <email>john@example.com</email>
+</root>

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/IModuleBindingGenerator.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/IModuleBindingGenerator.java
@@ -11,6 +11,7 @@ import gov.nist.secauto.metaschema.databind.model.IBoundModule;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+@FunctionalInterface
 public interface IModuleBindingGenerator {
   @NonNull
   Class<? extends IBoundModule> generate(@NonNull IModule module) throws MetaschemaException;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/config/DefaultBindingConfiguration.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/config/DefaultBindingConfiguration.java
@@ -105,9 +105,9 @@ public class DefaultBindingConfiguration implements IBindingConfiguration {
     return retval;
   }
 
+  @NonNull
   @Override
-  public @NonNull
-  String getClassName(@NonNull IModule module) {
+  public String getClassName(@NonNull IModule module) {
     // TODO: make this configurable
     return ClassUtils.toClassName(module.getShortName() + "Module");
   }

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/AbstractModelInstanceTypeInfo.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/AbstractModelInstanceTypeInfo.java
@@ -51,9 +51,9 @@ abstract class AbstractModelInstanceTypeInfo<INSTANCE extends IModelInstanceAbso
     return baseName;
   }
 
+  @NonNull
   @Override
-  public @NonNull
-  TypeName getJavaFieldType() {
+  public TypeName getJavaFieldType() {
     TypeName item = getJavaItemType();
 
     @NonNull

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/AbstractNamedModelInstanceTypeInfo.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/AbstractNamedModelInstanceTypeInfo.java
@@ -42,9 +42,9 @@ abstract class AbstractNamedModelInstanceTypeInfo<INSTANCE extends INamedModelIn
     super(instance, parentDefinition);
   }
 
+  @NonNull
   @Override
-  public @NonNull
-  String getBaseName() {
+  public String getBaseName() {
     INSTANCE modelInstance = getInstance();
     String retval;
     if (modelInstance.getMaxOccurs() == -1 || modelInstance.getMaxOccurs() > 1) {

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/IGroupedAssemblyInstanceTypeInfo.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/IGroupedAssemblyInstanceTypeInfo.java
@@ -5,6 +5,7 @@
 
 package gov.nist.secauto.metaschema.databind.codegen.typeinfo;
 
+@FunctionalInterface
 public interface IGroupedAssemblyInstanceTypeInfo extends IGroupedNamedModelInstanceTypeInfo {
   // no additional methods
 }

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/IGroupedFieldInstanceTypeInfo.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/IGroupedFieldInstanceTypeInfo.java
@@ -5,6 +5,7 @@
 
 package gov.nist.secauto.metaschema.databind.codegen.typeinfo;
 
+@FunctionalInterface
 public interface IGroupedFieldInstanceTypeInfo extends IGroupedNamedModelInstanceTypeInfo {
   // no additional methods
 }

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/IGroupedNamedModelInstanceTypeInfo.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/IGroupedNamedModelInstanceTypeInfo.java
@@ -14,6 +14,7 @@ import java.util.Set;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+@FunctionalInterface
 public interface IGroupedNamedModelInstanceTypeInfo {
   @NonNull
   Set<IModelDefinition> generateMemberAnnotation(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/IProblemHandler.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/IProblemHandler.java
@@ -18,6 +18,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * Implementations support handling common parsing issues.
  */
 // TODO: consider what methods can be defined here
+@FunctionalInterface
 public interface IProblemHandler {
   /**
    * A callback used to handle bound properties for which no data was found when

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/xml/IXmlProblemHandler.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/xml/IXmlProblemHandler.java
@@ -20,6 +20,7 @@ import javax.xml.stream.events.StartElement;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+@FunctionalInterface
 public interface IXmlProblemHandler extends IProblemHandler {
   /**
    * Callback used to handle an attribute that is unknown to the model being

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/IFeatureJavaField.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/IFeatureJavaField.java
@@ -10,6 +10,7 @@ import java.lang.reflect.Type;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+@FunctionalInterface
 public interface IFeatureJavaField extends IValuedMutable {
 
   /**

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/IValuedMutable.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/IValuedMutable.java
@@ -12,6 +12,7 @@ import java.lang.reflect.Type;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+@FunctionalInterface
 public interface IValuedMutable extends IValued {
   /**
    * Set the provided value on the provided object. The provided object must be of

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/annotations/NullJavaTypeAdapter.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/annotations/NullJavaTypeAdapter.java
@@ -74,15 +74,15 @@ public final class NullJavaTypeAdapter
       throw new UnsupportedOperationException(NOT_VALID);
     }
 
+    @NonNull
     @Override
-    public @NonNull
-    IAnyAtomicItem toAtomicItem() {
+    public IAnyAtomicItem toAtomicItem() {
       throw new UnsupportedOperationException(NOT_VALID);
     }
 
+    @NonNull
     @Override
-    public @NonNull
-    String asString() {
+    public String asString() {
       throw new UnsupportedOperationException(NOT_VALID);
     }
 

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractValidateContentCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractValidateContentCommand.java
@@ -67,7 +67,7 @@ public abstract class AbstractValidateContentCommand
           .hasArgs()
           .argName("URL")
           .desc("additional constraint definitions")
-          .build());
+          .get());
   @NonNull
   private static final Option SARIF_OUTPUT_FILE_OPTION = ObjectUtils.notNull(
       Option.builder("o")
@@ -75,25 +75,25 @@ public abstract class AbstractValidateContentCommand
           .argName("FILE")
           .desc("write SARIF results to the provided FILE")
           .numberOfArgs(1)
-          .build());
+          .get());
   @NonNull
   private static final Option SARIF_INCLUDE_PASS_OPTION = ObjectUtils.notNull(
       Option.builder()
           .longOpt("sarif-include-pass")
           .desc("include pass results in SARIF")
-          .build());
+          .get());
   @NonNull
   private static final Option NO_SCHEMA_VALIDATION_OPTION = ObjectUtils.notNull(
       Option.builder()
           .longOpt("disable-schema-validation")
           .desc("do not perform schema validation")
-          .build());
+          .get());
   @NonNull
   private static final Option NO_CONSTRAINT_VALIDATION_OPTION = ObjectUtils.notNull(
       Option.builder()
           .longOpt("disable-constraint-validation")
           .desc("do not perform constraint validation")
-          .build());
+          .get());
 
   @Override
   public String getName() {

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/GenerateSchemaCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/GenerateSchemaCommand.java
@@ -57,7 +57,7 @@ class GenerateSchemaCommand
       Option.builder()
           .longOpt("inline-types")
           .desc("definitions declared inline will be generated as inline types")
-          .build());
+          .get());
 
   @Override
   public String getName() {

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/MetaschemaCommands.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/MetaschemaCommands.java
@@ -81,7 +81,7 @@ public final class MetaschemaCommands {
           .required()
           .desc("metaschema resource")
           .numberOfArgs(1)
-          .build());
+          .get());
   /**
    * Used by commands to declare an optional Metaschema module for processing.
    *
@@ -94,7 +94,7 @@ public final class MetaschemaCommands {
           .argName("FILE_OR_URL")
           .desc("metaschema resource")
           .numberOfArgs(1)
-          .build());
+          .get());
   /**
    * Used by commands to protect existing files from being overwritten, unless
    * this option is provided.
@@ -104,7 +104,7 @@ public final class MetaschemaCommands {
       Option.builder()
           .longOpt("overwrite")
           .desc("overwrite the destination if it exists")
-          .build());
+          .get());
   /**
    * Used by commands to identify the target format for a content conversion
    * operation.
@@ -121,7 +121,7 @@ public final class MetaschemaCommands {
               .map(Enum::name)
               .collect(CustomCollectors.joiningWithOxfordComma("or")))
           .numberOfArgs(1)
-          .build());
+          .get());
   /**
    * Used by commands to identify the source format for a content-related
    * operation.
@@ -138,7 +138,7 @@ public final class MetaschemaCommands {
               .map(Enum::name)
               .collect(CustomCollectors.joiningWithOxfordComma("or")))
           .numberOfArgs(1)
-          .build());
+          .get());
   /**
    * Used by commands that produce schemas to identify the schema format to
    * produce.
@@ -156,7 +156,7 @@ public final class MetaschemaCommands {
               .map(Enum::name)
               .collect(CustomCollectors.joiningWithOxfordComma("or")))
           .numberOfArgs(1)
-          .build());
+          .get());
 
   /**
    * Get the provided source path or URI string as an absolute {@link URI} for the

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/metapath/EvaluateMetapathCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/metapath/EvaluateMetapathCommand.java
@@ -72,14 +72,14 @@ class EvaluateMetapathCommand
           .hasArg()
           .argName("EXPRESSION")
           .desc("Metapath expression to execute")
-          .build());
+          .get());
   @NonNull
   private static final Option CONTENT_OPTION = ObjectUtils.notNull(
       Option.builder("i")
           .hasArg()
           .argName("FILE_OR_URL")
           .desc("Metaschema content instance resource")
-          .build());
+          .get());
 
   @Override
   public String getName() {

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>dev.metaschema</groupId>
 		<artifactId>oss-parent</artifactId>
-		<version>9-SNAPSHOT</version>
+		<version>9</version>
 	</parent>
 
 	<groupId>dev.metaschema.java</groupId>
@@ -741,6 +741,12 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-pmd-plugin</artifactId>
+					<configuration>
+						<!-- Use custom ruleset that excludes TypeParameterNamingConventions -->
+						<rulesets>
+							<ruleset>src/main/config/pmd/ruleset.xml</ruleset>
+						</rulesets>
+					</configuration>
 					<executions>
 						<execution>
 							<id>pmd-verify</id>

--- a/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/IInlineStrategy.java
+++ b/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/IInlineStrategy.java
@@ -10,6 +10,7 @@ import gov.nist.secauto.metaschema.core.model.IDefinition;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+@FunctionalInterface
 public interface IInlineStrategy {
   @NonNull
   IInlineStrategy NONE_INLINE = new IInlineStrategy() {

--- a/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/ISchemaGenerator.java
+++ b/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/ISchemaGenerator.java
@@ -19,6 +19,7 @@ import java.nio.file.StandardOpenOption;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+@FunctionalInterface
 public interface ISchemaGenerator {
   /**
    * Generate and write a schema for the provided {@code metaschema} to the

--- a/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/ICardinalityBehavior.java
+++ b/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/ICardinalityBehavior.java
@@ -21,6 +21,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * The {@link #behaviorFor(IModelInstanceAbsolute)} method can be used to get
  * the appropriate behavior for a Metaschema definition model instance.
  */
+@FunctionalInterface
 public interface ICardinalityBehavior {
   /**
    * Used to get the appropriate behavior for a Metaschema definition model

--- a/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/IJsonSchema.java
+++ b/schemagen/src/main/java/gov/nist/secauto/metaschema/schemagen/json/impl/IJsonSchema.java
@@ -13,6 +13,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * Represents a JSON schema for a given Metaschema-based model object, which may
  * be part of a larger JSON schema.
  */
+@FunctionalInterface
 public interface IJsonSchema {
 
   /**

--- a/src/main/config/pmd/ruleset.xml
+++ b/src/main/config/pmd/ruleset.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="Metaschema Java Custom Ruleset"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+
+    <description>
+        Custom PMD ruleset for metaschema-java that extends the oss-maven ruleset
+        while excluding rules that don't fit the project's conventions.
+    </description>
+
+    <!-- Include the parent oss-maven ruleset -->
+    <rule ref="pmd/category/java/custom.xml">
+        <!-- Exclude TypeParameterNamingConventions since this project uses descriptive
+             type parameter names like TYPE, RESULT, CONTEXT instead of single letters -->
+        <exclude name="TypeParameterNamingConventions"/>
+    </rule>
+
+</ruleset>

--- a/src/main/config/pmd/ruleset.xml
+++ b/src/main/config/pmd/ruleset.xml
@@ -14,6 +14,12 @@
         <!-- Exclude TypeParameterNamingConventions since this project uses descriptive
              type parameter names like TYPE, RESULT, CONTEXT instead of single letters -->
         <exclude name="TypeParameterNamingConventions"/>
+        <!-- Exclude OnlyOneReturn - multiple returns improve readability for guard clauses -->
+        <exclude name="OnlyOneReturn"/>
+        <!-- Exclude ShortMethodName - factory methods like of(), as() are idiomatic Java -->
+        <exclude name="ShortMethodName"/>
+        <!-- Exclude ShortClassName - short class names like If, Or, For are acceptable for DSL-style APIs -->
+        <exclude name="ShortClassName"/>
     </rule>
 
 </ruleset>


### PR DESCRIPTION
## Summary

- Remove unnecessary `@SuppressWarnings` annotations for disabled PMD rules (ShortClassName, ShortMethodName, OnlyOneReturn, GodClass)
- Fix PMD Priority 1-2 violations across cli-processor, databind, and schemagen modules
- Replace deprecated `Option.Builder.build()` with `get()` in metaschema-cli
- Add comprehensive test coverage for constraint validation and schema content validation
- Update PMD ruleset configuration

## Test plan

- [x] All existing tests pass
- [x] Build completes successfully with `mvn install -PCI -Prelease`
- [x] PMD checks pass across all modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Chores**
  * Updated internal code quality configuration and removed compilation warnings.
  * Refactored internal code consistency across the application.

* **Tests**
  * Expanded test coverage for constraint validation, schema content validation, and related functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->