### PR TITLE
Fix YAML/JSON module loading: add missing typeAdapter and discriminatorValue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ package-lock.json
 # Claude
 CLAUDE.local.md
 .claude/settings.local.json
+
+# Git worktrees
+.worktrees/

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/AbstractGroupedNamedModelInstanceTypeInfo.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/AbstractGroupedNamedModelInstanceTypeInfo.java
@@ -60,12 +60,19 @@ public abstract class AbstractGroupedNamedModelInstanceTypeInfo<I extends INamed
 
     AnnotationSpec.Builder memberAnnotation = ObjectUtils.notNull(AnnotationSpec.builder(getBindingAnnotation()));
 
-    TypeInfoUtils.buildCommonBindingAnnotationValues(getInstance(), memberAnnotation);
+    I instance = getInstance();
+
+    TypeInfoUtils.buildCommonBindingAnnotationValues(instance, memberAnnotation);
+
+    // Add discriminatorValue if it differs from useName
+    String discriminatorValue = instance.getEffectiveDisciminatorValue();
+    String useName = instance.getEffectiveName();
+    if (!discriminatorValue.equals(useName)) {
+      memberAnnotation.addMember("discriminatorValue", "$S", discriminatorValue);
+    }
 
     Set<IModelDefinition> retval = new LinkedHashSet<>();
-
-    I instance = getInstance();
-    IModelDefinition definition = getInstance().getDefinition();
+    IModelDefinition definition = instance.getDefinition();
 
     IChoiceGroupTypeInfo choiceGroupTypeInfo = getChoiceGroupTypeInfo();
     ITypeResolver typeResolver = choiceGroupTypeInfo.getParentTypeInfo().getTypeResolver();

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/FieldInstanceTypeInfoImpl.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/FieldInstanceTypeInfoImpl.java
@@ -82,9 +82,8 @@ public class FieldInstanceTypeInfoImpl
     // handle the field value related info
     if (!definition.hasChildren()) {
       // this is a simple field, without flags
-      if (!MetaschemaDataTypeProvider.DEFAULT_DATA_TYPE.equals(adapter)) {
-        annotation.addMember("typeAdapter", "$T.class", adapter.getClass());
-      }
+      // Always add typeAdapter so the reader knows to treat this as a simple value
+      annotation.addMember("typeAdapter", "$T.class", adapter.getClass());
       AnnotationGenerator.buildValueConstraints(annotation, definition);
     }
     return retval;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/AssemblyModel.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/AssemblyModel.java
@@ -50,12 +50,21 @@ public class AssemblyModel implements IBoundObject {
   @BoundChoiceGroup(
       maxOccurs = -1,
       assemblies = {
-          @BoundGroupedAssembly(formalName = "Assembly Reference", useName = "assembly",
+          @BoundGroupedAssembly(formalName = "Assembly Reference",
+              useName = "assembly",
+              discriminatorValue = "assembly-ref",
               binding = AssemblyReference.class),
-          @BoundGroupedAssembly(formalName = "Inline Assembly Definition", useName = "define-assembly",
+          @BoundGroupedAssembly(formalName = "Inline Assembly Definition",
+              useName = "define-assembly",
+              discriminatorValue = "assembly",
               binding = InlineDefineAssembly.class),
-          @BoundGroupedAssembly(formalName = "Field Reference", useName = "field", binding = FieldReference.class),
-          @BoundGroupedAssembly(formalName = "Inline Field Definition", useName = "define-field",
+          @BoundGroupedAssembly(formalName = "Field Reference",
+              useName = "field",
+              discriminatorValue = "field-ref",
+              binding = FieldReference.class),
+          @BoundGroupedAssembly(formalName = "Inline Field Definition",
+              useName = "define-field",
+              discriminatorValue = "field",
               binding = InlineDefineField.class),
           @BoundGroupedAssembly(formalName = "Choice", useName = "choice", binding = Choice.class),
           @BoundGroupedAssembly(formalName = "Choice Grouping", useName = "choice-group", binding = ChoiceGroup.class)
@@ -113,12 +122,21 @@ public class AssemblyModel implements IBoundObject {
         minOccurs = 1,
         maxOccurs = -1,
         assemblies = {
-            @BoundGroupedAssembly(formalName = "Assembly Reference", useName = "assembly",
+            @BoundGroupedAssembly(formalName = "Assembly Reference",
+                useName = "assembly",
+                discriminatorValue = "assembly-ref",
                 binding = AssemblyReference.class),
-            @BoundGroupedAssembly(formalName = "Inline Assembly Definition", useName = "define-assembly",
+            @BoundGroupedAssembly(formalName = "Inline Assembly Definition",
+                useName = "define-assembly",
+                discriminatorValue = "assembly",
                 binding = InlineDefineAssembly.class),
-            @BoundGroupedAssembly(formalName = "Field Reference", useName = "field", binding = FieldReference.class),
-            @BoundGroupedAssembly(formalName = "Inline Field Definition", useName = "define-field",
+            @BoundGroupedAssembly(formalName = "Field Reference",
+                useName = "field",
+                discriminatorValue = "field-ref",
+                binding = FieldReference.class),
+            @BoundGroupedAssembly(formalName = "Inline Field Definition",
+                useName = "define-field",
+                discriminatorValue = "field",
                 binding = InlineDefineField.class)
         },
         groupAs = @GroupAs(name = "choices", inJson = JsonGroupAsBehavior.LIST))
@@ -210,12 +228,21 @@ public class AssemblyModel implements IBoundObject {
         minOccurs = 1,
         maxOccurs = -1,
         assemblies = {
-            @BoundGroupedAssembly(formalName = "Grouping Assembly Reference", useName = "assembly",
+            @BoundGroupedAssembly(formalName = "Grouping Assembly Reference",
+                useName = "assembly",
+                discriminatorValue = "assembly-ref",
                 binding = Assembly.class),
-            @BoundGroupedAssembly(formalName = "Inline Assembly Definition", useName = "define-assembly",
+            @BoundGroupedAssembly(formalName = "Inline Assembly Definition",
+                useName = "define-assembly",
+                discriminatorValue = "assembly",
                 binding = DefineAssembly.class),
-            @BoundGroupedAssembly(formalName = "Grouping Field Reference", useName = "field", binding = Field.class),
-            @BoundGroupedAssembly(formalName = "Inline Field Definition", useName = "define-field",
+            @BoundGroupedAssembly(formalName = "Grouping Field Reference",
+                useName = "field",
+                discriminatorValue = "field-ref",
+                binding = Field.class),
+            @BoundGroupedAssembly(formalName = "Inline Field Definition",
+                useName = "define-field",
+                discriminatorValue = "field",
                 binding = DefineField.class)
         },
         groupAs = @GroupAs(name = "choices", inJson = JsonGroupAsBehavior.LIST))
@@ -330,7 +357,8 @@ public class AssemblyModel implements IBoundObject {
       @BoundField(
           formalName = "Formal Name",
           description = "A formal name for the data construct, to be presented in documentation.",
-          useName = "formal-name")
+          useName = "formal-name",
+          typeAdapter = StringAdapter.class)
       private String _formalName;
 
       @BoundField(
@@ -513,7 +541,8 @@ public class AssemblyModel implements IBoundObject {
       @BoundField(
           formalName = "Formal Name",
           description = "A formal name for the data construct, to be presented in documentation.",
-          useName = "formal-name")
+          useName = "formal-name",
+          typeAdapter = StringAdapter.class)
       private String _formalName;
 
       @BoundField(
@@ -539,9 +568,14 @@ public class AssemblyModel implements IBoundObject {
       @BoundChoiceGroup(
           maxOccurs = -1,
           assemblies = {
-              @BoundGroupedAssembly(formalName = "Inline Flag Definition", useName = "define-flag",
+              @BoundGroupedAssembly(formalName = "Inline Flag Definition",
+                  useName = "define-flag",
+                  discriminatorValue = "flag",
                   binding = InlineDefineFlag.class),
-              @BoundGroupedAssembly(formalName = "Flag Reference", useName = "flag", binding = FlagReference.class)
+              @BoundGroupedAssembly(formalName = "Flag Reference",
+                  useName = "flag",
+                  discriminatorValue = "flag-ref",
+                  binding = FlagReference.class)
           },
           groupAs = @GroupAs(name = "flags", inJson = JsonGroupAsBehavior.LIST))
       private List<Object> _flags;
@@ -786,7 +820,8 @@ public class AssemblyModel implements IBoundObject {
       @BoundField(
           formalName = "Formal Name",
           description = "A formal name for the data construct, to be presented in documentation.",
-          useName = "formal-name")
+          useName = "formal-name",
+          typeAdapter = StringAdapter.class)
       private String _formalName;
 
       @BoundField(
@@ -1056,7 +1091,8 @@ public class AssemblyModel implements IBoundObject {
       @BoundField(
           formalName = "Formal Name",
           description = "A formal name for the data construct, to be presented in documentation.",
-          useName = "formal-name")
+          useName = "formal-name",
+          typeAdapter = StringAdapter.class)
       private String _formalName;
 
       @BoundField(
@@ -1093,9 +1129,14 @@ public class AssemblyModel implements IBoundObject {
       @BoundChoiceGroup(
           maxOccurs = -1,
           assemblies = {
-              @BoundGroupedAssembly(formalName = "Inline Flag Definition", useName = "define-flag",
+              @BoundGroupedAssembly(formalName = "Inline Flag Definition",
+                  useName = "define-flag",
+                  discriminatorValue = "flag",
                   binding = InlineDefineFlag.class),
-              @BoundGroupedAssembly(formalName = "Flag Reference", useName = "flag", binding = FlagReference.class)
+              @BoundGroupedAssembly(formalName = "Flag Reference",
+                  useName = "flag",
+                  discriminatorValue = "flag-ref",
+                  binding = FlagReference.class)
           },
           groupAs = @GroupAs(name = "flags", inJson = JsonGroupAsBehavior.LIST))
       private List<Object> _flags;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/AssemblyReference.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/AssemblyReference.java
@@ -80,7 +80,8 @@ public class AssemblyReference implements IBoundObject {
   @BoundField(
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
-      useName = "formal-name")
+      useName = "formal-name",
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   @BoundField(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FieldReference.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FieldReference.java
@@ -101,7 +101,8 @@ public class FieldReference implements IBoundObject {
   @BoundField(
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
-      useName = "formal-name")
+      useName = "formal-name",
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   @BoundField(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FlagAllowedValues.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FlagAllowedValues.java
@@ -5,6 +5,7 @@
 
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
+import gov.nist.secauto.metaschema.core.datatype.adapter.StringAdapter;
 import gov.nist.secauto.metaschema.core.datatype.adapter.TokenAdapter;
 import gov.nist.secauto.metaschema.core.datatype.markup.MarkupLine;
 import gov.nist.secauto.metaschema.core.datatype.markup.MarkupLineAdapter;
@@ -94,7 +95,8 @@ public class FlagAllowedValues implements IBoundObject, IConstraintBase {
   @BoundField(
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
-      useName = "formal-name")
+      useName = "formal-name",
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   @BoundField(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FlagExpect.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FlagExpect.java
@@ -75,7 +75,8 @@ public class FlagExpect implements IBoundObject, IConfigurableMessageConstraintB
   @BoundField(
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
-      useName = "formal-name")
+      useName = "formal-name",
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   @BoundField(
@@ -94,7 +95,8 @@ public class FlagExpect implements IBoundObject, IConfigurableMessageConstraintB
 
   @BoundField(
       formalName = "Constraint Condition Violation Message",
-      useName = "message")
+      useName = "message",
+      typeAdapter = StringAdapter.class)
   private String _message;
 
   @BoundField(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FlagIndexHasKey.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FlagIndexHasKey.java
@@ -5,6 +5,7 @@
 
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
+import gov.nist.secauto.metaschema.core.datatype.adapter.StringAdapter;
 import gov.nist.secauto.metaschema.core.datatype.adapter.TokenAdapter;
 import gov.nist.secauto.metaschema.core.datatype.markup.MarkupLine;
 import gov.nist.secauto.metaschema.core.datatype.markup.MarkupLineAdapter;
@@ -74,7 +75,8 @@ public class FlagIndexHasKey implements IBoundObject, IConfigurableMessageConstr
   @BoundField(
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
-      useName = "formal-name")
+      useName = "formal-name",
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   @BoundField(
@@ -101,7 +103,8 @@ public class FlagIndexHasKey implements IBoundObject, IConfigurableMessageConstr
 
   @BoundField(
       formalName = "Constraint Condition Violation Message",
-      useName = "message")
+      useName = "message",
+      typeAdapter = StringAdapter.class)
   private String _message;
 
   @BoundField(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FlagMatches.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FlagMatches.java
@@ -134,7 +134,8 @@ public class FlagMatches implements IBoundObject, IConfigurableMessageConstraint
   @BoundField(
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
-      useName = "formal-name")
+      useName = "formal-name",
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   @BoundField(
@@ -153,7 +154,8 @@ public class FlagMatches implements IBoundObject, IConfigurableMessageConstraint
 
   @BoundField(
       formalName = "Constraint Condition Violation Message",
-      useName = "message")
+      useName = "message",
+      typeAdapter = StringAdapter.class)
   private String _message;
 
   @BoundField(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FlagReference.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FlagReference.java
@@ -80,7 +80,8 @@ public class FlagReference implements IBoundObject {
   @BoundField(
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
-      useName = "formal-name")
+      useName = "formal-name",
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   @BoundField(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/InlineDefineAssembly.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/InlineDefineAssembly.java
@@ -82,7 +82,8 @@ public class InlineDefineAssembly implements IBoundObject {
   @BoundField(
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
-      useName = "formal-name")
+      useName = "formal-name",
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   @BoundField(
@@ -113,9 +114,14 @@ public class InlineDefineAssembly implements IBoundObject {
   @BoundChoiceGroup(
       maxOccurs = -1,
       assemblies = {
-          @BoundGroupedAssembly(formalName = "Inline Flag Definition", useName = "define-flag",
+          @BoundGroupedAssembly(formalName = "Inline Flag Definition",
+              useName = "define-flag",
+              discriminatorValue = "flag",
               binding = InlineDefineFlag.class),
-          @BoundGroupedAssembly(formalName = "Flag Reference", useName = "flag", binding = FlagReference.class)
+          @BoundGroupedAssembly(formalName = "Flag Reference",
+              useName = "flag",
+              discriminatorValue = "flag-ref",
+              binding = FlagReference.class)
       },
       groupAs = @GroupAs(name = "flags", inJson = JsonGroupAsBehavior.LIST))
   private List<Object> _flags;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/InlineDefineField.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/InlineDefineField.java
@@ -169,7 +169,8 @@ public class InlineDefineField implements IBoundObject {
   @BoundField(
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
-      useName = "formal-name")
+      useName = "formal-name",
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   @BoundField(
@@ -211,9 +212,14 @@ public class InlineDefineField implements IBoundObject {
   @BoundChoiceGroup(
       maxOccurs = -1,
       assemblies = {
-          @BoundGroupedAssembly(formalName = "Inline Flag Definition", useName = "define-flag",
+          @BoundGroupedAssembly(formalName = "Inline Flag Definition",
+              useName = "define-flag",
+              discriminatorValue = "flag",
               binding = InlineDefineFlag.class),
-          @BoundGroupedAssembly(formalName = "Flag Reference", useName = "flag", binding = FlagReference.class)
+          @BoundGroupedAssembly(formalName = "Flag Reference",
+              useName = "flag",
+              discriminatorValue = "flag-ref",
+              binding = FlagReference.class)
       },
       groupAs = @GroupAs(name = "flags", inJson = JsonGroupAsBehavior.LIST))
   private List<Object> _flags;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/InlineDefineFlag.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/InlineDefineFlag.java
@@ -141,7 +141,8 @@ public class InlineDefineFlag implements IBoundObject {
   @BoundField(
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
-      useName = "formal-name")
+      useName = "formal-name",
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   @BoundField(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/METASCHEMA.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/METASCHEMA.java
@@ -132,7 +132,8 @@ public class METASCHEMA implements IBoundObject {
   @BoundField(
       description = "A version string used to distinguish between multiple revisions of the same Metaschema module.",
       useName = "schema-version",
-      minOccurs = 1)
+      minOccurs = 1,
+      typeAdapter = StringAdapter.class)
   private String _schemaVersion;
 
   @BoundField(
@@ -186,10 +187,16 @@ public class METASCHEMA implements IBoundObject {
       assemblies = {
           @BoundGroupedAssembly(formalName = "Global Assembly Definition",
               description = "In XML, an element with structured element content. In JSON, an object with properties. Defined globally, an assembly can be assigned to appear in the `model` of any assembly (another assembly type, or itself), by `assembly` reference.",
-              useName = "define-assembly", binding = DefineAssembly.class),
-          @BoundGroupedAssembly(formalName = "Global Field Definition", useName = "define-field",
+              useName = "define-assembly",
+              discriminatorValue = "assembly",
+              binding = DefineAssembly.class),
+          @BoundGroupedAssembly(formalName = "Global Field Definition",
+              useName = "define-field",
+              discriminatorValue = "field",
               binding = DefineField.class),
-          @BoundGroupedAssembly(formalName = "Global Flag Definition", useName = "define-flag",
+          @BoundGroupedAssembly(formalName = "Global Flag Definition",
+              useName = "define-flag",
+              discriminatorValue = "flag",
               binding = DefineFlag.class)
       },
       groupAs = @GroupAs(name = "definitions", inJson = JsonGroupAsBehavior.LIST))
@@ -409,6 +416,7 @@ public class METASCHEMA implements IBoundObject {
       formalName = "Global Assembly Definition",
       description = "In XML, an element with structured element content. In JSON, an object with properties. Defined globally, an assembly can be assigned to appear in the `model` of any assembly (another assembly type, or itself), by `assembly` reference.",
       name = "define-assembly",
+
       moduleClass = MetaschemaModelModule.class)
   public static class DefineAssembly implements IBoundObject {
     private final IMetaschemaData __metaschemaData;
@@ -447,7 +455,8 @@ public class METASCHEMA implements IBoundObject {
     @BoundField(
         formalName = "Formal Name",
         description = "A formal name for the data construct, to be presented in documentation.",
-        useName = "formal-name")
+        useName = "formal-name",
+        typeAdapter = StringAdapter.class)
     private String _formalName;
 
     @BoundField(
@@ -486,9 +495,14 @@ public class METASCHEMA implements IBoundObject {
     @BoundChoiceGroup(
         maxOccurs = -1,
         assemblies = {
-            @BoundGroupedAssembly(formalName = "Inline Flag Definition", useName = "define-flag",
+            @BoundGroupedAssembly(formalName = "Inline Flag Definition",
+                useName = "define-flag",
+                discriminatorValue = "flag",
                 binding = InlineDefineFlag.class),
-            @BoundGroupedAssembly(formalName = "Flag Reference", useName = "flag", binding = FlagReference.class)
+            @BoundGroupedAssembly(formalName = "Flag Reference",
+                useName = "flag",
+                discriminatorValue = "flag-ref",
+                binding = FlagReference.class)
         },
         groupAs = @GroupAs(name = "flags", inJson = JsonGroupAsBehavior.LIST))
     private List<Object> _flags;
@@ -883,7 +897,8 @@ public class METASCHEMA implements IBoundObject {
     @BoundField(
         formalName = "Formal Name",
         description = "A formal name for the data construct, to be presented in documentation.",
-        useName = "formal-name")
+        useName = "formal-name",
+        typeAdapter = StringAdapter.class)
     private String _formalName;
 
     @BoundField(
@@ -926,9 +941,14 @@ public class METASCHEMA implements IBoundObject {
     @BoundChoiceGroup(
         maxOccurs = -1,
         assemblies = {
-            @BoundGroupedAssembly(formalName = "Inline Flag Definition", useName = "define-flag",
+            @BoundGroupedAssembly(formalName = "Inline Flag Definition",
+                useName = "define-flag",
+                discriminatorValue = "flag",
                 binding = InlineDefineFlag.class),
-            @BoundGroupedAssembly(formalName = "Flag Reference", useName = "flag", binding = FlagReference.class)
+            @BoundGroupedAssembly(formalName = "Flag Reference",
+                useName = "flag",
+                discriminatorValue = "flag-ref",
+                binding = FlagReference.class)
         },
         groupAs = @GroupAs(name = "flags", inJson = JsonGroupAsBehavior.LIST))
     private List<Object> _flags;
@@ -1269,7 +1289,8 @@ public class METASCHEMA implements IBoundObject {
     @BoundField(
         formalName = "Formal Name",
         description = "A formal name for the data construct, to be presented in documentation.",
-        useName = "formal-name")
+        useName = "formal-name",
+        typeAdapter = StringAdapter.class)
     private String _formalName;
 
     @BoundField(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/MetaschemaModuleConstraints.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/MetaschemaModuleConstraints.java
@@ -64,13 +64,15 @@ public class MetaschemaModuleConstraints implements IBoundObject {
   @BoundField(
       description = "The name of this constraint set.",
       useName = "name",
-      minOccurs = 1)
+      minOccurs = 1,
+      typeAdapter = StringAdapter.class)
   private String _name;
 
   @BoundField(
       description = "The version of this constraint set. A version string used to distinguish between multiple revisions of the same resource.",
       useName = "version",
-      minOccurs = 1)
+      minOccurs = 1,
+      typeAdapter = StringAdapter.class)
   private String _version;
 
   @BoundAssembly(
@@ -315,7 +317,8 @@ public class MetaschemaModuleConstraints implements IBoundObject {
 
     @BoundField(
         formalName = "Constraint Condition Violation Message",
-        useName = "message")
+        useName = "message",
+        typeAdapter = StringAdapter.class)
     private String _message;
 
     @BoundField(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedAllowedValuesConstraint.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedAllowedValuesConstraint.java
@@ -102,7 +102,8 @@ public class TargetedAllowedValuesConstraint implements IBoundObject, ITargetedC
   @BoundField(
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
-      useName = "formal-name")
+      useName = "formal-name",
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   @BoundField(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedExpectConstraint.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedExpectConstraint.java
@@ -84,7 +84,8 @@ public class TargetedExpectConstraint
   @BoundField(
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
-      useName = "formal-name")
+      useName = "formal-name",
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   @BoundField(
@@ -103,7 +104,8 @@ public class TargetedExpectConstraint
 
   @BoundField(
       formalName = "Constraint Condition Violation Message",
-      useName = "message")
+      useName = "message",
+      typeAdapter = StringAdapter.class)
   private String _message;
 
   @BoundField(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedHasCardinalityConstraint.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedHasCardinalityConstraint.java
@@ -94,7 +94,8 @@ public class TargetedHasCardinalityConstraint
   @BoundField(
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
-      useName = "formal-name")
+      useName = "formal-name",
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   @BoundField(
@@ -113,7 +114,8 @@ public class TargetedHasCardinalityConstraint
 
   @BoundField(
       formalName = "Constraint Condition Violation Message",
-      useName = "message")
+      useName = "message",
+      typeAdapter = StringAdapter.class)
   private String _message;
 
   @BoundField(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedIndexConstraint.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedIndexConstraint.java
@@ -84,7 +84,8 @@ public class TargetedIndexConstraint
   @BoundField(
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
-      useName = "formal-name")
+      useName = "formal-name",
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   @BoundField(
@@ -111,7 +112,8 @@ public class TargetedIndexConstraint
 
   @BoundField(
       formalName = "Constraint Condition Violation Message",
-      useName = "message")
+      useName = "message",
+      typeAdapter = StringAdapter.class)
   private String _message;
 
   @BoundField(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedIndexHasKeyConstraint.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedIndexHasKeyConstraint.java
@@ -84,7 +84,8 @@ public class TargetedIndexHasKeyConstraint
   @BoundField(
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
-      useName = "formal-name")
+      useName = "formal-name",
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   @BoundField(
@@ -111,7 +112,8 @@ public class TargetedIndexHasKeyConstraint
 
   @BoundField(
       formalName = "Constraint Condition Violation Message",
-      useName = "message")
+      useName = "message",
+      typeAdapter = StringAdapter.class)
   private String _message;
 
   @BoundField(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedIsUniqueConstraint.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedIsUniqueConstraint.java
@@ -77,7 +77,8 @@ public class TargetedIsUniqueConstraint
   @BoundField(
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
-      useName = "formal-name")
+      useName = "formal-name",
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   @BoundField(
@@ -104,7 +105,8 @@ public class TargetedIsUniqueConstraint
 
   @BoundField(
       formalName = "Constraint Condition Violation Message",
-      useName = "message")
+      useName = "message",
+      typeAdapter = StringAdapter.class)
   private String _message;
 
   @BoundField(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedMatchesConstraint.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedMatchesConstraint.java
@@ -143,7 +143,8 @@ public class TargetedMatchesConstraint
   @BoundField(
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
-      useName = "formal-name")
+      useName = "formal-name",
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   @BoundField(
@@ -162,7 +163,8 @@ public class TargetedMatchesConstraint
 
   @BoundField(
       formalName = "Constraint Condition Violation Message",
-      useName = "message")
+      useName = "message",
+      typeAdapter = StringAdapter.class)
   private String _message;
 
   @BoundField(

--- a/metaschema-cli/src/test/java/gov/nist/secauto/metaschema/cli/CLITest.java
+++ b/metaschema-cli/src/test/java/gov/nist/secauto/metaschema/cli/CLITest.java
@@ -258,6 +258,15 @@ public class CLITest {
                 "../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml",
             },
             ExitCode.OK, NO_EXCEPTION_CLASS));
+        // Test markup-line datatype validation with YAML module
+        add(Arguments.of(
+            new String[] { "validate-content",
+                "-m",
+                "src/test/resources/content/test-markup-line-module.yaml",
+                "src/test/resources/content/test-markup-line-content.json",
+                "--as=json"
+            },
+            ExitCode.OK, NO_EXCEPTION_CLASS));
       }
     };
     return values.stream();

--- a/metaschema-cli/src/test/resources/content/test-markup-line-content.json
+++ b/metaschema-cli/src/test/resources/content/test-markup-line-content.json
@@ -1,0 +1,5 @@
+{
+  "test-root": {
+    "title": "This is a **simple** line of _markup_ content."
+  }
+}

--- a/metaschema-cli/src/test/resources/content/test-markup-line-module.yaml
+++ b/metaschema-cli/src/test/resources/content/test-markup-line-module.yaml
@@ -1,0 +1,21 @@
+METASCHEMA:
+  schema-name: Markup Line Test Module
+  schema-version: "1.0.0"
+  short-name: markup-line-test
+  namespace: https://example.com/markup-line-test
+  json-base-uri: https://example.com/markup-line-test
+  definitions:
+    - object-type: assembly
+      name: root
+      root-name:
+        name: test-root
+      formal-name: Test Root
+      description: A test root assembly with a markup-line field.
+      model:
+        instances:
+          - object-type: field
+            name: title
+            as-type: markup-line
+            min-occurs: 1
+            formal-name: Title
+            description: A single line of markup content.


### PR DESCRIPTION
## Summary

Fixes critical bugs preventing YAML/JSON Metaschema module loading:

- **Add discriminatorValue to @BoundGroupedAssembly annotations** in code generator. Without this, choice group items cannot be properly identified during deserialization, causing "Unrecognized JSON discriminator property" errors.

- **Add explicit typeAdapter annotations** to @BoundField with String/MarkupLine types in handwritten binding files. The framework requires explicit type adapters - omitting them causes the deserializer to expect complex objects (START_OBJECT) instead of scalar values (VALUE_STRING).

### Files Changed

**Code Generator (2 files):**
- `AbstractGroupedNamedModelInstanceTypeInfo.java` - adds discriminatorValue generation
- `FieldInstanceTypeInfoImpl.java` - adds typeAdapter generation for field instances

**Binding Files (20 files):**
- All constraint binding classes (Flag*, Targeted*)
- Model binding classes (AssemblyModel, *Reference, InlineDefine*)
- Module binding classes (METASCHEMA, MetaschemaModuleConstraints)

**Tests (3 files):**
- New test case for YAML module with markup-line field validation

## Test plan

- [x] All existing tests pass (`mvn clean install -PCI -Prelease`)
- [x] New CLI test validates YAML module loading with markup-line content
- [x] JSON schema validation works for markup-line fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved polymorphic type discrimination for model bindings through discriminator values.
  * Standardized string field serialization across binding annotations.

* **Tests**
  * Added test coverage for markup-line datatype validation with YAML-based modules.

* **Chores**
  * Updated Git configuration to ignore worktree directories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->