### PR TITLE
Refactor processCommand method to reduce complexity

### DIFF
--- a/PRDs/20251217-cli-processor-refactor/design.md
+++ b/PRDs/20251217-cli-processor-refactor/design.md
@@ -1,0 +1,271 @@
+# Design: Refactor processCommand in CLIProcessor
+
+**Issue:** [#252](https://github.com/metaschema-framework/metaschema-java/issues/252)
+**Date:** 2025-12-17
+**Status:** Approved
+
+## Problem Statement
+
+The `processCommand` method in `CLIProcessor.java` has high cyclomatic and NPath complexity, requiring PMD suppressions. The `CallingContext` inner class is also flagged as a GodClass. This makes the code harder to test, understand, and maintain.
+
+## Goals
+
+1. Reduce complexity metrics to remove PMD suppressions
+2. Improve testability with comprehensive unit and integration tests
+3. Extract `CallingContext` to a top-level package-private class
+4. Use result-chaining pattern for clean flow control
+5. Allow minor improvements with explicit approval for functional changes
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Test coverage | Both integration + unit tests | Most comprehensive coverage |
+| Method visibility | Protected | Allows subclassing for testing/extension |
+| CallingContext location | Top-level, package-private | Clean separation, proper encapsulation |
+| Flow control pattern | Optional-based chaining | Idiomatic Java, clean flow, easy to test |
+
+## Architecture
+
+### File Structure
+
+```
+cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/
+├── CLIProcessor.java          (simplified, delegates to CallingContext)
+├── CallingContext.java        (NEW - extracted, package-private)
+└── ... (existing files unchanged)
+
+cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/
+├── CLIProcessorTest.java      (NEW - integration tests)
+├── CallingContextTest.java    (NEW - unit tests for phases)
+└── ExitCodeTest.java          (existing)
+```
+
+### Phase Flow
+
+```
+processCommand()
+    → checkHelpAndVersion()     : Optional<ExitStatus>
+    → parseOptions()            : CommandLine (throws ParseException)
+    → validateExtraArguments()  : Optional<ExitStatus>
+    → validateCalledCommands()  : Optional<ExitStatus>
+    → applyGlobalOptions()      : void
+    → invokeCommand()           : ExitStatus
+```
+
+## Implementation Details
+
+### Refactored processCommand()
+
+```java
+@NonNull
+public ExitStatus processCommand() {
+    // Phase 1: Check help/version before full parsing
+    Optional<ExitStatus> earlyExit = checkHelpAndVersion();
+    if (earlyExit.isPresent()) {
+        return earlyExit.get();
+    }
+
+    // Phase 2: Parse all options
+    CommandLine cmdLine;
+    try {
+        cmdLine = parseOptions();
+    } catch (ParseException ex) {
+        return handleInvalidCommand(ex.getMessage());
+    }
+
+    // Phase 3-4: Validate arguments and options
+    Optional<ExitStatus> validationResult = validateExtraArguments(cmdLine)
+        .or(() -> validateCalledCommands(cmdLine));
+    if (validationResult.isPresent()) {
+        return validationResult.get();
+    }
+
+    // Phase 5: Apply global options and execute
+    applyGlobalOptions(cmdLine);
+    return invokeCommand(cmdLine);
+}
+```
+
+### Phase Method Signatures
+
+```java
+// Phase 1: Check --help and --version (before full parsing)
+protected Optional<ExitStatus> checkHelpAndVersion()
+
+// Phase 2: Parse all command line options
+protected CommandLine parseOptions() throws ParseException
+
+// Phase 3: Validate target command's extra arguments
+protected Optional<ExitStatus> validateExtraArguments(@NonNull CommandLine cmdLine)
+
+// Phase 4: Validate options for all called commands
+protected Optional<ExitStatus> validateCalledCommands(@NonNull CommandLine cmdLine)
+
+// Phase 5: Apply global options (--no-color, --quiet)
+protected void applyGlobalOptions(@NonNull CommandLine cmdLine)
+```
+
+### Phase Implementations
+
+**Phase 1 - checkHelpAndVersion():**
+
+```java
+protected Optional<ExitStatus> checkHelpAndVersion() {
+    Options phase1Options = new Options();
+    phase1Options.addOption(HELP_OPTION);
+    phase1Options.addOption(VERSION_OPTION);
+
+    try {
+        CommandLine cmdLine = new DefaultParser()
+            .parse(phase1Options, getExtraArgs().toArray(new String[0]), true);
+
+        if (cmdLine.hasOption(VERSION_OPTION)) {
+            getCLIProcessor().showVersion();
+            return Optional.of(ExitCode.OK.exit());
+        }
+        if (cmdLine.hasOption(HELP_OPTION)) {
+            showHelp();
+            return Optional.of(ExitCode.OK.exit());
+        }
+    } catch (ParseException ex) {
+        return Optional.of(handleInvalidCommand(ex.getMessage()));
+    }
+    return Optional.empty();
+}
+```
+
+**Phase 2 - parseOptions():**
+
+```java
+protected CommandLine parseOptions() throws ParseException {
+    return new DefaultParser().parse(toOptions(), getExtraArgs().toArray(new String[0]));
+}
+```
+
+**Phase 3 - validateExtraArguments():**
+
+```java
+protected Optional<ExitStatus> validateExtraArguments(@NonNull CommandLine cmdLine) {
+    ICommand target = getTargetCommand();
+    if (target == null) {
+        return Optional.empty();
+    }
+    try {
+        target.validateExtraArguments(this, cmdLine);
+        return Optional.empty();
+    } catch (InvalidArgumentException ex) {
+        return Optional.of(handleError(
+            ExitCode.INVALID_ARGUMENTS.exitMessage(ex.getLocalizedMessage()),
+            cmdLine, true));
+    }
+}
+```
+
+**Phase 4 - validateCalledCommands():**
+
+```java
+protected Optional<ExitStatus> validateCalledCommands(@NonNull CommandLine cmdLine) {
+    for (ICommand cmd : getCalledCommands()) {
+        try {
+            cmd.validateOptions(this, cmdLine);
+        } catch (InvalidArgumentException ex) {
+            return Optional.of(handleInvalidCommand(ex.getMessage()));
+        }
+    }
+    return Optional.empty();
+}
+```
+
+**Phase 5 - applyGlobalOptions():**
+
+```java
+protected void applyGlobalOptions(@NonNull CommandLine cmdLine) {
+    if (cmdLine.hasOption(NO_COLOR_OPTION)) {
+        handleNoColor();
+    }
+    if (cmdLine.hasOption(QUIET_OPTION)) {
+        handleQuiet();
+    }
+}
+```
+
+## Testing Strategy
+
+### Integration Tests (CLIProcessorTest.java)
+
+Test the public API through `process(String... args)`:
+
+- `--version` shows version info and returns OK
+- `--help` shows help and returns OK
+- Invalid command returns INVALID_COMMAND
+- Invalid option returns INVALID_COMMAND
+- Valid command executes successfully
+- `--quiet` option works
+- `--no-color` option works
+
+### Unit Tests (CallingContextTest.java)
+
+Test individual phases via protected methods:
+
+**checkHelpAndVersion():**
+- Returns ExitStatus for --version
+- Returns ExitStatus for --help
+- Returns empty for other args
+
+**parseOptions():**
+- Parses valid options
+- Throws on invalid option
+
+**validateExtraArguments():**
+- Returns empty when no target command
+- Returns empty when arguments valid
+- Returns error when arguments invalid
+
+**validateCalledCommands():**
+- Returns empty when all commands valid
+- Returns error on first invalid command
+
+**applyGlobalOptions():**
+- Applies --no-color without error
+- Applies --quiet without error
+
+### Test Fixtures
+
+```java
+// Minimal command for basic tests
+class TestCommand implements ICommand { ... }
+
+// Command that accepts extra arguments
+class TestCommandWithArgs implements ICommand { ... }
+
+// Command that requires extra arguments
+class TestCommandRequiringArgs implements ICommand { ... }
+
+// Command with required option
+class TestCommandWithRequiredOption implements ICommand { ... }
+```
+
+## Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Breaking existing CLI behavior | High | Write characterization tests first, run full test suite after each change |
+| CallingContext extraction breaks internal references | Medium | `CLIProcessor.this` references need updating; search for all usages |
+| Test fixtures become complex/fragile | Medium | Keep test commands minimal; use builder pattern if needed |
+| PMD/Checkstyle finds new issues in refactored code | Low | Run `mvn checkstyle:check` incrementally |
+
+## Success Criteria
+
+- [ ] All existing tests pass (ExitCodeTest + any integration tests)
+- [ ] New tests provide coverage for all phases
+- [ ] `@SuppressWarnings` for PMD complexity removed from `processCommand()`
+- [ ] `@SuppressWarnings("PMD.GodClass")` removed from `CallingContext`
+- [ ] `mvn install -PCI -Prelease` passes
+- [ ] No functional behavior changes (unless explicitly approved)
+
+## Out of Scope
+
+- Refactoring `invokeCommand()` (already reasonably sized)
+- Refactoring help/footer building methods (not complexity issues)
+- Changes to `ICommand` interface or other classes

--- a/PRDs/20251217-cli-processor-refactor/design.md
+++ b/PRDs/20251217-cli-processor-refactor/design.md
@@ -30,7 +30,7 @@ The `processCommand` method in `CLIProcessor.java` has high cyclomatic and NPath
 
 ### File Structure
 
-```
+```text
 cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/
 ├── CLIProcessor.java          (simplified, delegates to CallingContext)
 ├── CallingContext.java        (NEW - extracted, package-private)
@@ -44,7 +44,7 @@ cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/
 
 ### Phase Flow
 
-```
+```text
 processCommand()
     → checkHelpAndVersion()     : Optional<ExitStatus>
     → parseOptions()            : CommandLine (throws ParseException)

--- a/PRDs/20251217-cli-processor-refactor/design.md
+++ b/PRDs/20251217-cli-processor-refactor/design.md
@@ -3,6 +3,7 @@
 **Issue:** [#252](https://github.com/metaschema-framework/metaschema-java/issues/252)
 **Date:** 2025-12-17
 **Status:** Approved
+**Depends On:** [PR #551](https://github.com/metaschema-framework/metaschema-java/pull/551) (shell completion)
 
 ## Problem Statement
 
@@ -246,12 +247,33 @@ class TestCommandRequiringArgs implements ICommand { ... }
 class TestCommandWithRequiredOption implements ICommand { ... }
 ```
 
+## Dependencies
+
+### PR #551 Impact
+
+This refactoring must be based on PR #551 (shell completion). That PR introduces:
+
+1. **`getTopLevelCommands()` visibility change** - Changed from `protected` to `public`. No impact on our design.
+
+2. **`ShellCompletionCommand`** - New command that imports `CLIProcessor.CallingContext`. When we extract `CallingContext` to a top-level class, we must update this import:
+
+```java
+// Before (PR #551)
+import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
+
+// After (our refactor)
+import gov.nist.secauto.metaschema.cli.processor.CallingContext;
+```
+
+3. **`ExtraArgument.getType()`** - New method for completion hints. No impact on our design.
+
 ## Risks & Mitigations
 
 | Risk | Impact | Mitigation |
 |------|--------|------------|
 | Breaking existing CLI behavior | High | Write characterization tests first, run full test suite after each change |
 | CallingContext extraction breaks internal references | Medium | `CLIProcessor.this` references need updating; search for all usages |
+| ShellCompletionCommand import breaks | Low | Update import when extracting CallingContext |
 | Test fixtures become complex/fragile | Medium | Keep test commands minimal; use builder pattern if needed |
 | PMD/Checkstyle finds new issues in refactored code | Low | Run `mvn checkstyle:check` incrementally |
 

--- a/PRDs/20251217-cli-processor-refactor/implementation-plan.md
+++ b/PRDs/20251217-cli-processor-refactor/implementation-plan.md
@@ -982,7 +982,7 @@ mvn -pl cli-processor test
 
 Expected: BUILD SUCCESS
 
-### Step 3: Commit
+### Step 3: Commit ShellCompletionCommand update
 
 ```bash
 git add cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/ShellCompletionCommand.java
@@ -1289,7 +1289,7 @@ mvn -pl cli-processor test -Dtest=CallingContextTest#*parseOptions*
 
 Expected: BUILD SUCCESS
 
-### Step 3: Commit
+### Step 3: Commit parseOptions method
 
 ```bash
 git add cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java
@@ -1340,7 +1340,7 @@ mvn -pl cli-processor test -Dtest=CallingContextTest#*validateExtraArguments*
 
 Expected: BUILD SUCCESS
 
-### Step 3: Commit
+### Step 3: Commit validateExtraArguments method
 
 ```bash
 git add cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java
@@ -1388,7 +1388,7 @@ mvn -pl cli-processor test -Dtest=CallingContextTest#*validateCalledCommands*
 
 Expected: BUILD SUCCESS
 
-### Step 3: Commit
+### Step 3: Commit validateCalledCommands method
 
 ```bash
 git add cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java
@@ -1430,7 +1430,7 @@ mvn -pl cli-processor test -Dtest=CallingContextTest#*applyGlobalOptions*
 
 Expected: BUILD SUCCESS
 
-### Step 3: Commit
+### Step 3: Commit applyGlobalOptions method
 
 ```bash
 git add cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java

--- a/PRDs/20251217-cli-processor-refactor/implementation-plan.md
+++ b/PRDs/20251217-cli-processor-refactor/implementation-plan.md
@@ -1,7 +1,5 @@
 # CLIProcessor Refactoring Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
-
 **Goal:** Refactor `processCommand` method and extract `CallingContext` to reduce complexity and improve testability.
 
 **Architecture:** Extract `CallingContext` inner class to a package-private top-level class. Refactor `processCommand()` into discrete phases using Optional-based result chaining. Each phase either returns an exit status (stop) or empty (continue).
@@ -16,20 +14,20 @@
 
 **Prerequisites:** PR #551 must be merged into `develop`
 
-**Step 1: Fetch latest develop**
+### Step 1: Fetch latest develop
 
 ```bash
 cd ../metaschema-java-252
 git fetch origin develop
 ```
 
-**Step 2: Rebase branch**
+### Step 2: Rebase branch
 
 ```bash
 git rebase origin/develop
 ```
 
-**Step 3: Verify build**
+### Step 3: Verify build
 
 ```bash
 mvn -pl cli-processor test
@@ -47,7 +45,7 @@ Expected: BUILD SUCCESS
 - Create: `cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/TestVersionInfo.java`
 - Create: `cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/TestCommand.java`
 
-**Step 1: Create TestVersionInfo**
+### Step 1: Create TestVersionInfo
 
 ```java
 /*
@@ -110,7 +108,7 @@ class TestVersionInfo implements IVersionInfo {
 }
 ```
 
-**Step 2: Create TestCommand**
+### Step 2: Create TestCommand
 
 ```java
 /*
@@ -160,7 +158,7 @@ class TestCommand extends AbstractTerminalCommand {
 }
 ```
 
-**Step 3: Verify compilation**
+### Step 3: Verify compilation
 
 ```bash
 mvn -pl cli-processor test-compile
@@ -168,7 +166,7 @@ mvn -pl cli-processor test-compile
 
 Expected: BUILD SUCCESS
 
-**Step 4: Commit**
+### Step 4: Commit
 
 ```bash
 git add cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/TestVersionInfo.java
@@ -183,7 +181,7 @@ git commit -m "test: add test fixtures for CLIProcessor testing"
 **Files:**
 - Create: `cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/CLIProcessorTest.java`
 
-**Step 1: Write integration test class with version test**
+### Step 1: Write integration test class with version test
 
 ```java
 /*
@@ -308,7 +306,7 @@ class CLIProcessorTest {
 }
 ```
 
-**Step 2: Run tests to verify they pass with existing code**
+### Step 2: Run tests to verify they pass with existing code
 
 ```bash
 mvn -pl cli-processor test -Dtest=CLIProcessorTest
@@ -316,7 +314,7 @@ mvn -pl cli-processor test -Dtest=CLIProcessorTest
 
 Expected: BUILD SUCCESS (all tests pass - these characterize existing behavior)
 
-**Step 3: Commit**
+### Step 3: Commit
 
 ```bash
 git add cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/CLIProcessorTest.java
@@ -332,7 +330,7 @@ git commit -m "test: add integration tests for CLIProcessor existing behavior"
 **Files:**
 - Create: `cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java`
 
-**Step 1: Create new CallingContext.java file**
+### Step 1: Create new CallingContext.java file
 
 Copy the inner class to a new file, adding package-private visibility and updating `CLIProcessor.this` references:
 
@@ -842,7 +840,7 @@ class CallingContext {
 }
 ```
 
-**Step 2: Verify compilation**
+### Step 2: Verify compilation
 
 ```bash
 mvn -pl cli-processor compile
@@ -850,7 +848,7 @@ mvn -pl cli-processor compile
 
 Expected: BUILD SUCCESS
 
-**Step 3: Commit**
+### Step 3: Commit
 
 ```bash
 git add cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java
@@ -864,7 +862,7 @@ git commit -m "refactor: extract CallingContext to top-level package-private cla
 **Files:**
 - Modify: `cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CLIProcessor.java`
 
-**Step 1: Add package-private getter for outputStream**
+### Step 1: Add package-private getter for outputStream
 
 Add this method to `CLIProcessor.java` (needed by extracted `CallingContext`):
 
@@ -880,7 +878,7 @@ PrintStream getOutputStream() {
 }
 ```
 
-**Step 2: Make OPTIONS package-private**
+### Step 2: Make OPTIONS package-private
 
 Change the `OPTIONS` field visibility from `private` to package-private:
 
@@ -894,7 +892,7 @@ static final List<Option> OPTIONS = ObjectUtils.notNull(List.of(
     VERSION_OPTION));
 ```
 
-**Step 3: Make handleNoColor and handleQuiet package-private**
+### Step 3: Make handleNoColor and handleQuiet package-private
 
 Change visibility from `private`/`public` to package-private (no modifier):
 
@@ -912,7 +910,7 @@ static void handleQuiet() {
 }
 ```
 
-**Step 4: Update parseCommand to use new CallingContext constructor**
+### Step 4: Update parseCommand to use new CallingContext constructor
 
 ```java
 @NonNull
@@ -939,11 +937,11 @@ private ExitStatus parseCommand(String... args) {
 }
 ```
 
-**Step 5: Remove the inner CallingContext class**
+### Step 5: Remove the inner CallingContext class
 
 Delete the entire inner class `CallingContext` from `CLIProcessor.java` (lines 328-802 approximately).
 
-**Step 6: Run tests to verify behavior preserved**
+### Step 6: Run tests to verify behavior preserved
 
 ```bash
 mvn -pl cli-processor test
@@ -951,7 +949,7 @@ mvn -pl cli-processor test
 
 Expected: BUILD SUCCESS (all tests pass)
 
-**Step 7: Commit**
+### Step 7: Commit
 
 ```bash
 git add cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CLIProcessor.java
@@ -965,7 +963,7 @@ git commit -m "refactor: update CLIProcessor to use extracted CallingContext"
 **Files:**
 - Modify: `cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/ShellCompletionCommand.java`
 
-**Step 1: Update import statement**
+### Step 1: Update import statement
 
 Change:
 ```java
@@ -977,7 +975,7 @@ To:
 import gov.nist.secauto.metaschema.cli.processor.CallingContext;
 ```
 
-**Step 2: Run tests**
+### Step 2: Run tests
 
 ```bash
 mvn -pl cli-processor test
@@ -985,7 +983,7 @@ mvn -pl cli-processor test
 
 Expected: BUILD SUCCESS
 
-**Step 3: Commit**
+### Step 3: Commit
 
 ```bash
 git add cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/ShellCompletionCommand.java
@@ -1001,7 +999,7 @@ git commit -m "refactor: update ShellCompletionCommand import for extracted Call
 **Files:**
 - Create: `cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/CallingContextTest.java`
 
-**Step 1: Create CallingContextTest with phase tests**
+### Step 1: Create CallingContextTest with phase tests
 
 ```java
 /*
@@ -1178,7 +1176,7 @@ class CallingContextTest {
 }
 ```
 
-**Step 2: Run tests - they will fail (methods don't exist yet)**
+### Step 2: Run tests - they will fail (methods don't exist yet)
 
 ```bash
 mvn -pl cli-processor test -Dtest=CallingContextTest
@@ -1186,7 +1184,7 @@ mvn -pl cli-processor test -Dtest=CallingContextTest
 
 Expected: COMPILATION ERROR (methods not found) - this is expected for TDD
 
-**Step 3: Commit test file**
+### Step 3: Commit test file
 
 ```bash
 git add cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/CallingContextTest.java
@@ -1200,7 +1198,7 @@ git commit -m "test: add unit tests for CallingContext phase methods (TDD - red)
 **Files:**
 - Modify: `cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java`
 
-**Step 1: Add checkHelpAndVersion method**
+### Step 1: Add checkHelpAndVersion method
 
 Add this method to `CallingContext.java`:
 
@@ -1237,13 +1235,13 @@ protected Optional<ExitStatus> checkHelpAndVersion() {
 }
 ```
 
-**Step 2: Add import for Optional**
+### Step 2: Add import for Optional
 
 ```java
 import java.util.Optional;
 ```
 
-**Step 3: Run tests for checkHelpAndVersion**
+### Step 3: Run tests for checkHelpAndVersion
 
 ```bash
 mvn -pl cli-processor test -Dtest=CallingContextTest#*checkHelpAndVersion*
@@ -1251,7 +1249,7 @@ mvn -pl cli-processor test -Dtest=CallingContextTest#*checkHelpAndVersion*
 
 Expected: BUILD SUCCESS
 
-**Step 4: Commit**
+### Step 4: Commit
 
 ```bash
 git add cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java
@@ -1265,7 +1263,7 @@ git commit -m "refactor: extract checkHelpAndVersion phase method"
 **Files:**
 - Modify: `cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java`
 
-**Step 1: Add parseOptions method**
+### Step 1: Add parseOptions method
 
 ```java
 /**
@@ -1283,7 +1281,7 @@ protected CommandLine parseOptions() throws ParseException {
 }
 ```
 
-**Step 2: Run tests for parseOptions**
+### Step 2: Run tests for parseOptions
 
 ```bash
 mvn -pl cli-processor test -Dtest=CallingContextTest#*parseOptions*
@@ -1291,7 +1289,7 @@ mvn -pl cli-processor test -Dtest=CallingContextTest#*parseOptions*
 
 Expected: BUILD SUCCESS
 
-**Step 3: Commit**
+### Step 3: Commit
 
 ```bash
 git add cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java
@@ -1305,7 +1303,7 @@ git commit -m "refactor: extract parseOptions phase method"
 **Files:**
 - Modify: `cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java`
 
-**Step 1: Add validateExtraArguments method**
+### Step 1: Add validateExtraArguments method
 
 ```java
 /**
@@ -1334,7 +1332,7 @@ protected Optional<ExitStatus> validateExtraArguments(@NonNull CommandLine cmdLi
 }
 ```
 
-**Step 2: Run tests for validateExtraArguments**
+### Step 2: Run tests for validateExtraArguments
 
 ```bash
 mvn -pl cli-processor test -Dtest=CallingContextTest#*validateExtraArguments*
@@ -1342,7 +1340,7 @@ mvn -pl cli-processor test -Dtest=CallingContextTest#*validateExtraArguments*
 
 Expected: BUILD SUCCESS
 
-**Step 3: Commit**
+### Step 3: Commit
 
 ```bash
 git add cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java
@@ -1356,7 +1354,7 @@ git commit -m "refactor: extract validateExtraArguments phase method"
 **Files:**
 - Modify: `cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java`
 
-**Step 1: Add validateCalledCommands method**
+### Step 1: Add validateCalledCommands method
 
 ```java
 /**
@@ -1382,7 +1380,7 @@ protected Optional<ExitStatus> validateCalledCommands(@NonNull CommandLine cmdLi
 }
 ```
 
-**Step 2: Run tests for validateCalledCommands**
+### Step 2: Run tests for validateCalledCommands
 
 ```bash
 mvn -pl cli-processor test -Dtest=CallingContextTest#*validateCalledCommands*
@@ -1390,7 +1388,7 @@ mvn -pl cli-processor test -Dtest=CallingContextTest#*validateCalledCommands*
 
 Expected: BUILD SUCCESS
 
-**Step 3: Commit**
+### Step 3: Commit
 
 ```bash
 git add cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java
@@ -1404,7 +1402,7 @@ git commit -m "refactor: extract validateCalledCommands phase method"
 **Files:**
 - Modify: `cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java`
 
-**Step 1: Add applyGlobalOptions method**
+### Step 1: Add applyGlobalOptions method
 
 ```java
 /**
@@ -1424,7 +1422,7 @@ protected void applyGlobalOptions(@NonNull CommandLine cmdLine) {
 }
 ```
 
-**Step 2: Run tests for applyGlobalOptions**
+### Step 2: Run tests for applyGlobalOptions
 
 ```bash
 mvn -pl cli-processor test -Dtest=CallingContextTest#*applyGlobalOptions*
@@ -1432,7 +1430,7 @@ mvn -pl cli-processor test -Dtest=CallingContextTest#*applyGlobalOptions*
 
 Expected: BUILD SUCCESS
 
-**Step 3: Commit**
+### Step 3: Commit
 
 ```bash
 git add cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java
@@ -1446,7 +1444,7 @@ git commit -m "refactor: extract applyGlobalOptions phase method"
 **Files:**
 - Modify: `cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java`
 
-**Step 1: Replace processCommand implementation**
+### Step 1: Replace processCommand implementation
 
 Replace the entire `processCommand()` method with:
 
@@ -1487,7 +1485,7 @@ public ExitStatus processCommand() {
 }
 ```
 
-**Step 2: Remove PMD suppressions from processCommand**
+### Step 2: Remove PMD suppressions from processCommand
 
 Remove this annotation from processCommand:
 
@@ -1499,7 +1497,7 @@ Remove this annotation from processCommand:
 })
 ```
 
-**Step 3: Run all tests**
+### Step 3: Run all tests
 
 ```bash
 mvn -pl cli-processor test
@@ -1507,7 +1505,7 @@ mvn -pl cli-processor test
 
 Expected: BUILD SUCCESS
 
-**Step 4: Run full CI build**
+### Step 4: Run full CI build
 
 ```bash
 mvn -pl cli-processor install -PCI
@@ -1515,7 +1513,7 @@ mvn -pl cli-processor install -PCI
 
 Expected: BUILD SUCCESS (no PMD violations)
 
-**Step 5: Commit**
+### Step 5: Commit
 
 ```bash
 git add cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java
@@ -1534,7 +1532,7 @@ Removes PMD suppressions for complexity warnings."
 **Files:**
 - Modify: `cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java`
 
-**Step 1: Remove GodClass suppression**
+### Step 1: Remove GodClass suppression
 
 Remove this line from `CallingContext.java`:
 
@@ -1542,7 +1540,7 @@ Remove this line from `CallingContext.java`:
 @SuppressWarnings("PMD.GodClass")
 ```
 
-**Step 2: Run PMD check**
+### Step 2: Run PMD check
 
 ```bash
 mvn -pl cli-processor pmd:check
@@ -1550,7 +1548,7 @@ mvn -pl cli-processor pmd:check
 
 Expected: BUILD SUCCESS (if GodClass warning persists, we may need additional extraction - but try first)
 
-**Step 3: Run full CI build**
+### Step 3: Run full CI build
 
 ```bash
 mvn install -PCI -Prelease
@@ -1558,7 +1556,7 @@ mvn install -PCI -Prelease
 
 Expected: BUILD SUCCESS
 
-**Step 4: Commit**
+### Step 4: Commit
 
 ```bash
 git add cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java
@@ -1571,7 +1569,7 @@ git commit -m "refactor: remove PMD GodClass suppression from CallingContext"
 
 ### Task 14: Full Build Verification
 
-**Step 1: Run complete CI build**
+### Step 1: Run complete CI build
 
 ```bash
 mvn clean install -PCI -Prelease
@@ -1579,7 +1577,7 @@ mvn clean install -PCI -Prelease
 
 Expected: BUILD SUCCESS
 
-**Step 2: Verify all tests pass**
+### Step 2: Verify all tests pass
 
 ```bash
 mvn test
@@ -1587,7 +1585,7 @@ mvn test
 
 Expected: All tests pass
 
-**Step 3: Verify no checkstyle issues**
+### Step 3: Verify no checkstyle issues
 
 ```bash
 mvn checkstyle:check
@@ -1595,7 +1593,7 @@ mvn checkstyle:check
 
 Expected: BUILD SUCCESS
 
-**Step 4: Review commit history**
+### Step 4: Review commit history
 
 ```bash
 git log --oneline -15

--- a/PRDs/20251217-cli-processor-refactor/implementation-plan.md
+++ b/PRDs/20251217-cli-processor-refactor/implementation-plan.md
@@ -1,0 +1,1625 @@
+# CLIProcessor Refactoring Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Refactor `processCommand` method and extract `CallingContext` to reduce complexity and improve testability.
+
+**Architecture:** Extract `CallingContext` inner class to a package-private top-level class. Refactor `processCommand()` into discrete phases using Optional-based result chaining. Each phase either returns an exit status (stop) or empty (continue).
+
+**Tech Stack:** Java 11, JUnit 5, Apache Commons CLI, Maven
+
+---
+
+## Pre-Implementation Setup
+
+### Task 0: Rebase on PR #551
+
+**Prerequisites:** PR #551 must be merged into `develop`
+
+**Step 1: Fetch latest develop**
+
+```bash
+cd ../metaschema-java-252
+git fetch origin develop
+```
+
+**Step 2: Rebase branch**
+
+```bash
+git rebase origin/develop
+```
+
+**Step 3: Verify build**
+
+```bash
+mvn -pl cli-processor test
+```
+
+Expected: BUILD SUCCESS
+
+---
+
+## Phase 1: Test Infrastructure
+
+### Task 1: Create Test Fixtures
+
+**Files:**
+- Create: `cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/TestVersionInfo.java`
+- Create: `cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/TestCommand.java`
+
+**Step 1: Create TestVersionInfo**
+
+```java
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.cli.processor;
+
+import gov.nist.secauto.metaschema.core.util.IVersionInfo;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * A simple version info implementation for testing.
+ */
+class TestVersionInfo implements IVersionInfo {
+
+  @Override
+  @NonNull
+  public String getName() {
+    return "test-cli";
+  }
+
+  @Override
+  @NonNull
+  public String getVersion() {
+    return "1.0.0-test";
+  }
+
+  @Override
+  @NonNull
+  public String getBuildTimestamp() {
+    return "2025-01-01T00:00:00Z";
+  }
+
+  @Override
+  @NonNull
+  public String getGitOriginUrl() {
+    return "https://example.com/test.git";
+  }
+
+  @Override
+  @NonNull
+  public String getGitBranch() {
+    return "test-branch";
+  }
+
+  @Override
+  @NonNull
+  public String getGitCommit() {
+    return "abc1234";
+  }
+
+  @Override
+  @NonNull
+  public String getGitClosestTag() {
+    return "v1.0.0";
+  }
+}
+```
+
+**Step 2: Create TestCommand**
+
+```java
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.cli.processor;
+
+import gov.nist.secauto.metaschema.cli.processor.command.AbstractTerminalCommand;
+import gov.nist.secauto.metaschema.cli.processor.command.ICommandExecutor;
+
+import org.apache.commons.cli.CommandLine;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * A minimal command implementation for testing.
+ */
+class TestCommand extends AbstractTerminalCommand {
+
+  @Override
+  @NonNull
+  public String getName() {
+    return "test-cmd";
+  }
+
+  @Override
+  @NonNull
+  public String getDescription() {
+    return "A test command";
+  }
+
+  @Override
+  public ICommandExecutor newExecutor(
+      @NonNull CLIProcessor.CallingContext callingContext,
+      @NonNull CommandLine cmdLine) {
+    return ICommandExecutor.using(callingContext, cmdLine, this::executeCommand);
+  }
+
+  @NonNull
+  private void executeCommand(
+      @NonNull CLIProcessor.CallingContext callingContext,
+      @NonNull CommandLine cmdLine) {
+    // Do nothing - success
+  }
+}
+```
+
+**Step 3: Verify compilation**
+
+```bash
+mvn -pl cli-processor test-compile
+```
+
+Expected: BUILD SUCCESS
+
+**Step 4: Commit**
+
+```bash
+git add cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/TestVersionInfo.java
+git add cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/TestCommand.java
+git commit -m "test: add test fixtures for CLIProcessor testing"
+```
+
+---
+
+### Task 2: Create Integration Tests for Existing Behavior
+
+**Files:**
+- Create: `cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/CLIProcessorTest.java`
+
+**Step 1: Write integration test class with version test**
+
+```java
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.cli.processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for {@link CLIProcessor}.
+ * <p>
+ * Tests the public API through {@code process(String... args)}.
+ */
+@DisplayName("CLIProcessor Integration Tests")
+class CLIProcessorTest {
+
+  private CLIProcessor processor;
+  private ByteArrayOutputStream outputCapture;
+
+  @BeforeEach
+  void setUp() {
+    outputCapture = new ByteArrayOutputStream();
+    PrintStream printStream = new PrintStream(outputCapture, true, StandardCharsets.UTF_8);
+    processor = new CLIProcessor(
+        "test-cli",
+        Map.of(CLIProcessor.COMMAND_VERSION, new TestVersionInfo()),
+        printStream);
+  }
+
+  @Nested
+  @DisplayName("Global Options")
+  class GlobalOptionsTests {
+
+    @Test
+    @DisplayName("--version shows version info and returns OK")
+    void testVersionOption() {
+      ExitStatus status = processor.process("--version");
+
+      assertAll(
+          () -> assertEquals(ExitCode.OK, status.getExitCode()),
+          () -> assertThat(outputCapture.toString(StandardCharsets.UTF_8)).contains("test-cli"),
+          () -> assertThat(outputCapture.toString(StandardCharsets.UTF_8)).contains("1.0.0-test"));
+    }
+
+    @Test
+    @DisplayName("--help shows help and returns OK")
+    void testHelpOption() {
+      ExitStatus status = processor.process("--help");
+
+      assertAll(
+          () -> assertEquals(ExitCode.OK, status.getExitCode()),
+          () -> assertThat(outputCapture.toString(StandardCharsets.UTF_8)).contains("--help"));
+    }
+
+    @Test
+    @DisplayName("--quiet option is accepted")
+    void testQuietOption() {
+      processor.addCommandHandler(new TestCommand());
+
+      ExitStatus status = processor.process("--quiet", "test-cmd");
+
+      assertEquals(ExitCode.OK, status.getExitCode());
+    }
+  }
+
+  @Nested
+  @DisplayName("Command Execution")
+  class CommandExecutionTests {
+
+    @Test
+    @DisplayName("Valid command executes successfully")
+    void testValidCommandExecution() {
+      processor.addCommandHandler(new TestCommand());
+
+      ExitStatus status = processor.process("test-cmd");
+
+      assertEquals(ExitCode.OK, status.getExitCode());
+    }
+
+    @Test
+    @DisplayName("Unknown command returns INVALID_COMMAND")
+    void testUnknownCommand() {
+      ExitStatus status = processor.process("nonexistent-command");
+
+      assertEquals(ExitCode.INVALID_COMMAND, status.getExitCode());
+    }
+
+    @Test
+    @DisplayName("Invalid option returns INVALID_COMMAND")
+    void testInvalidOption() {
+      ExitStatus status = processor.process("--invalid-option-xyz");
+
+      assertEquals(ExitCode.INVALID_COMMAND, status.getExitCode());
+    }
+
+    @Test
+    @DisplayName("Empty args returns INVALID_COMMAND with help")
+    void testEmptyArgs() {
+      ExitStatus status = processor.process();
+
+      assertAll(
+          () -> assertEquals(ExitCode.INVALID_COMMAND, status.getExitCode()),
+          () -> assertThat(outputCapture.toString(StandardCharsets.UTF_8)).contains("--help"));
+    }
+  }
+}
+```
+
+**Step 2: Run tests to verify they pass with existing code**
+
+```bash
+mvn -pl cli-processor test -Dtest=CLIProcessorTest
+```
+
+Expected: BUILD SUCCESS (all tests pass - these characterize existing behavior)
+
+**Step 3: Commit**
+
+```bash
+git add cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/CLIProcessorTest.java
+git commit -m "test: add integration tests for CLIProcessor existing behavior"
+```
+
+---
+
+## Phase 2: Extract CallingContext
+
+### Task 3: Create CallingContext Top-Level Class (Copy)
+
+**Files:**
+- Create: `cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java`
+
+**Step 1: Create new CallingContext.java file**
+
+Copy the inner class to a new file, adding package-private visibility and updating `CLIProcessor.this` references:
+
+```java
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.cli.processor;
+
+import static org.fusesource.jansi.Ansi.ansi;
+
+import gov.nist.secauto.metaschema.cli.processor.command.ExtraArgument;
+import gov.nist.secauto.metaschema.cli.processor.command.ICommand;
+import gov.nist.secauto.metaschema.cli.processor.command.ICommandExecutor;
+import gov.nist.secauto.metaschema.cli.processor.command.CommandExecutionException;
+import gov.nist.secauto.metaschema.core.util.AutoCloser;
+import gov.nist.secauto.metaschema.core.util.CollectionUtil;
+import gov.nist.secauto.metaschema.core.util.ObjectUtils;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.fusesource.jansi.AnsiPrintStream;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * Records information about the command line options and called command
+ * hierarchy.
+ */
+@SuppressWarnings("PMD.GodClass")
+class CallingContext {
+  @NonNull
+  private final CLIProcessor cliProcessor;
+  @NonNull
+  private final List<Option> options;
+  @NonNull
+  private final List<ICommand> calledCommands;
+  @Nullable
+  private final ICommand targetCommand;
+  @NonNull
+  private final List<String> extraArgs;
+
+  @SuppressFBWarnings(value = "CT_CONSTRUCTOR_THROW", justification = "Use of final fields")
+  CallingContext(@NonNull CLIProcessor cliProcessor, @NonNull List<String> args) {
+    this.cliProcessor = cliProcessor;
+
+    @SuppressWarnings("PMD.LooseCoupling") // needed to support getLast
+    LinkedList<ICommand> calledCommands = new LinkedList<>();
+    List<Option> options = new LinkedList<>(CLIProcessor.OPTIONS);
+    List<String> extraArgs = new LinkedList<>();
+
+    AtomicBoolean endArgs = new AtomicBoolean();
+    args.forEach(arg -> {
+      if (endArgs.get() || arg.startsWith("-")) {
+        extraArgs.add(arg);
+      } else if ("--".equals(arg)) {
+        endArgs.set(true);
+      } else {
+        ICommand command = calledCommands.isEmpty()
+            ? cliProcessor.getTopLevelCommandsByName().get(arg)
+            : calledCommands.getLast().getSubCommandByName(arg);
+
+        if (command == null) {
+          extraArgs.add(arg);
+          endArgs.set(true);
+        } else {
+          calledCommands.add(command);
+          options.addAll(command.gatherOptions());
+        }
+      }
+    });
+
+    this.calledCommands = CollectionUtil.unmodifiableList(calledCommands);
+    this.targetCommand = calledCommands.peekLast();
+    this.options = CollectionUtil.unmodifiableList(options);
+    this.extraArgs = CollectionUtil.unmodifiableList(extraArgs);
+  }
+
+  /**
+   * Get the command line processor instance that generated this calling context.
+   *
+   * @return the instance
+   */
+  @NonNull
+  public CLIProcessor getCLIProcessor() {
+    return cliProcessor;
+  }
+
+  /**
+   * Get the command that was triggered by the CLI arguments.
+   *
+   * @return the command or {@code null} if no command was triggered
+   */
+  @Nullable
+  public ICommand getTargetCommand() {
+    return targetCommand;
+  }
+
+  /**
+   * Get the options that are in scope for the current command context.
+   *
+   * @return the list of options
+   */
+  @NonNull
+  List<Option> getOptionsList() {
+    return options;
+  }
+
+  @NonNull
+  List<ICommand> getCalledCommands() {
+    return calledCommands;
+  }
+
+  /**
+   * Get any left over arguments that were not consumed by CLI options.
+   *
+   * @return the list of remaining arguments, which may be empty
+   */
+  @NonNull
+  List<String> getExtraArgs() {
+    return extraArgs;
+  }
+
+  /**
+   * Get the collections of in scope options as an options group.
+   *
+   * @return the options group
+   */
+  Options toOptions() {
+    Options retval = new Options();
+    for (Option option : getOptionsList()) {
+      retval.addOption(option);
+    }
+    return retval;
+  }
+
+  /**
+   * Process the command identified by the CLI arguments.
+   *
+   * @return the result of processing the command
+   */
+  @SuppressWarnings({
+      "PMD.OnlyOneReturn",
+      "PMD.NPathComplexity",
+      "PMD.CyclomaticComplexity"
+  })
+  @NonNull
+  public ExitStatus processCommand() {
+    // TODO: Refactor in subsequent commits
+    CommandLineParser parser = new DefaultParser();
+
+    // phase 1
+    CommandLine cmdLine;
+    try {
+      Options phase1Options = new Options();
+      phase1Options.addOption(CLIProcessor.HELP_OPTION);
+      phase1Options.addOption(CLIProcessor.VERSION_OPTION);
+
+      cmdLine = ObjectUtils.notNull(parser.parse(phase1Options, getExtraArgs().toArray(new String[0]), true));
+    } catch (ParseException ex) {
+      String msg = ex.getMessage();
+      assert msg != null;
+      return handleInvalidCommand(msg);
+    }
+
+    if (cmdLine.hasOption(CLIProcessor.VERSION_OPTION)) {
+      cliProcessor.showVersion();
+      return ExitCode.OK.exit();
+    }
+    if (cmdLine.hasOption(CLIProcessor.HELP_OPTION)) {
+      showHelp();
+      return ExitCode.OK.exit();
+    }
+
+    // phase 2
+    try {
+      cmdLine = ObjectUtils.notNull(parser.parse(toOptions(), getExtraArgs().toArray(new String[0])));
+    } catch (ParseException ex) {
+      String msg = ex.getMessage();
+      assert msg != null;
+      return handleInvalidCommand(msg);
+    }
+
+    ICommand targetCommand = getTargetCommand();
+    if (targetCommand != null) {
+      try {
+        targetCommand.validateExtraArguments(this, cmdLine);
+      } catch (InvalidArgumentException ex) {
+        return handleError(
+            ExitCode.INVALID_ARGUMENTS.exitMessage(ex.getLocalizedMessage()),
+            cmdLine,
+            true);
+      }
+    }
+
+    for (ICommand cmd : getCalledCommands()) {
+      try {
+        cmd.validateOptions(this, cmdLine);
+      } catch (InvalidArgumentException ex) {
+        String msg = ex.getMessage();
+        assert msg != null;
+        return handleInvalidCommand(msg);
+      }
+    }
+
+    // phase 3
+    if (cmdLine.hasOption(CLIProcessor.NO_COLOR_OPTION)) {
+      CLIProcessor.handleNoColor();
+    }
+
+    if (cmdLine.hasOption(CLIProcessor.QUIET_OPTION)) {
+      CLIProcessor.handleQuiet();
+    }
+    return invokeCommand(cmdLine);
+  }
+
+  /**
+   * Directly execute the logic associated with the command.
+   *
+   * @param cmdLine
+   *          the command line information
+   * @return the result of executing the command
+   */
+  @SuppressWarnings({
+      "PMD.OnlyOneReturn", // readability
+      "PMD.AvoidCatchingGenericException" // needed here
+  })
+  @NonNull
+  private ExitStatus invokeCommand(@NonNull CommandLine cmdLine) {
+    ExitStatus retval;
+    try {
+      ICommand targetCommand = getTargetCommand();
+      if (targetCommand == null) {
+        retval = ExitCode.INVALID_COMMAND.exit();
+      } else {
+        ICommandExecutor executor = targetCommand.newExecutor(this, cmdLine);
+        try {
+          executor.execute();
+          retval = ExitCode.OK.exit();
+        } catch (CommandExecutionException ex) {
+          retval = ex.toExitStatus();
+        } catch (RuntimeException ex) {
+          retval = ExitCode.RUNTIME_ERROR
+              .exitMessage("Unexpected error occured: " + ex.getLocalizedMessage())
+              .withThrowable(ex);
+        }
+      }
+    } catch (RuntimeException ex) {
+      retval = ExitCode.RUNTIME_ERROR
+          .exitMessage(String.format("An uncaught runtime error occurred. %s", ex.getLocalizedMessage()))
+          .withThrowable(ex);
+    }
+
+    if (!ExitCode.OK.equals(retval.getExitCode())) {
+      retval.generateMessage(cmdLine.hasOption(CLIProcessor.SHOW_STACK_TRACE_OPTION));
+
+      if (ExitCode.INVALID_COMMAND.equals(retval.getExitCode())) {
+        showHelp();
+      }
+    }
+    return retval;
+  }
+
+  /**
+   * Handle an error that occurred while executing the command.
+   *
+   * @param exitStatus
+   *          the execution result
+   * @param cmdLine
+   *          the command line information
+   * @param showHelp
+   *          if {@code true} show the help information
+   * @return the resulting exit status
+   */
+  @NonNull
+  public ExitStatus handleError(
+      @NonNull ExitStatus exitStatus,
+      @NonNull CommandLine cmdLine,
+      boolean showHelp) {
+    exitStatus.generateMessage(cmdLine.hasOption(CLIProcessor.SHOW_STACK_TRACE_OPTION));
+    if (showHelp) {
+      showHelp();
+    }
+    return exitStatus;
+  }
+
+  /**
+   * Generate the help message and exit status for an invalid command using the
+   * provided message.
+   *
+   * @param message
+   *          the error message
+   * @return the resulting exit status
+   */
+  @NonNull
+  public ExitStatus handleInvalidCommand(
+      @NonNull String message) {
+    showHelp();
+
+    ExitStatus retval = ExitCode.INVALID_COMMAND.exitMessage(message);
+    retval.generateMessage(false);
+    return retval;
+  }
+
+  /**
+   * Callback for providing a help header.
+   *
+   * @return the header or {@code null}
+   */
+  @Nullable
+  private String buildHelpHeader() {
+    // TODO: build a suitable header
+    return null;
+  }
+
+  /**
+   * Callback for providing a help footer.
+   *
+   * @return the footer or {@code null}
+   */
+  @NonNull
+  private String buildHelpFooter() {
+    ICommand targetCommand = getTargetCommand();
+    Collection<ICommand> subCommands;
+    if (targetCommand == null) {
+      subCommands = cliProcessor.getTopLevelCommands();
+    } else {
+      subCommands = targetCommand.getSubCommands();
+    }
+
+    String retval;
+    if (subCommands.isEmpty()) {
+      retval = "";
+    } else {
+      StringBuilder builder = new StringBuilder(128);
+      builder
+          .append(System.lineSeparator())
+          .append("The following are available commands:")
+          .append(System.lineSeparator());
+
+      int length = subCommands.stream()
+          .mapToInt(command -> command.getName().length())
+          .max().orElse(0);
+
+      for (ICommand command : subCommands) {
+        builder.append(
+            ansi()
+                .render(String.format("   @|bold %-" + length + "s|@ %s%n",
+                    command.getName(),
+                    command.getDescription())));
+      }
+      builder
+          .append(System.lineSeparator())
+          .append('\'')
+          .append(cliProcessor.getExec())
+          .append(" <command> --help' will show help on that specific command.")
+          .append(System.lineSeparator());
+      retval = builder.toString();
+      assert retval != null;
+    }
+    return retval;
+  }
+
+  /**
+   * Get the CLI syntax.
+   *
+   * @return the CLI syntax to display in help output
+   */
+  private String buildHelpCliSyntax() {
+    StringBuilder builder = new StringBuilder(64);
+    builder.append(cliProcessor.getExec());
+
+    List<ICommand> calledCommands = getCalledCommands();
+    if (!calledCommands.isEmpty()) {
+      builder.append(calledCommands.stream()
+          .map(ICommand::getName)
+          .collect(Collectors.joining(" ", " ", "")));
+    }
+
+    // output calling commands
+    ICommand targetCommand = getTargetCommand();
+    if (targetCommand == null) {
+      builder.append(" <command>");
+    } else {
+      builder.append(getSubCommands(targetCommand));
+    }
+
+    // output required options
+    getOptionsList().stream()
+        .filter(Option::isRequired)
+        .forEach(option -> {
+          builder
+              .append(' ')
+              .append(OptionUtils.toArgument(ObjectUtils.notNull(option)));
+          if (option.hasArg()) {
+            builder
+                .append('=')
+                .append(option.getArgName());
+          }
+        });
+
+    // output non-required option placeholder
+    builder.append(" [<options>]");
+
+    // output extra arguments
+    if (targetCommand != null) {
+      // handle extra arguments
+      builder.append(getExtraArguments(targetCommand));
+    }
+
+    String retval = builder.toString();
+    assert retval != null;
+    return retval;
+  }
+
+  @NonNull
+  private CharSequence getSubCommands(ICommand targetCommand) {
+    Collection<ICommand> subCommands = targetCommand.getSubCommands();
+
+    StringBuilder builder = new StringBuilder();
+    if (!subCommands.isEmpty()) {
+      builder.append(' ');
+      if (!targetCommand.isSubCommandRequired()) {
+        builder.append('[');
+      }
+
+      builder.append("<command>");
+
+      if (!targetCommand.isSubCommandRequired()) {
+        builder.append(']');
+      }
+    }
+    return builder;
+  }
+
+  @NonNull
+  private CharSequence getExtraArguments(@NonNull ICommand targetCommand) {
+    StringBuilder builder = new StringBuilder();
+    for (ExtraArgument argument : targetCommand.getExtraArguments()) {
+      builder.append(' ');
+      if (!argument.isRequired()) {
+        builder.append('[');
+      }
+
+      builder.append('<')
+          .append(argument.getName())
+          .append('>');
+
+      if (argument.getNumber() > 1) {
+        builder.append("...");
+      }
+
+      if (!argument.isRequired()) {
+        builder.append(']');
+      }
+    }
+    return builder;
+  }
+
+  /**
+   * Output the help text to the console.
+   */
+  public void showHelp() {
+    HelpFormatter formatter = new HelpFormatter();
+    formatter.setLongOptSeparator("=");
+
+    PrintStream out = cliProcessor.getOutputStream();
+    int terminalWidth = (out instanceof AnsiPrintStream)
+        ? ((AnsiPrintStream) out).getTerminalWidth()
+        : 80;
+
+    try (PrintWriter writer = new PrintWriter( // NOPMD not owned
+        AutoCloser.preventClose(out),
+        true,
+        StandardCharsets.UTF_8)) {
+      formatter.printHelp(
+          writer,
+          Math.max(terminalWidth, 50),
+          buildHelpCliSyntax(),
+          buildHelpHeader(),
+          toOptions(),
+          HelpFormatter.DEFAULT_LEFT_PAD,
+          HelpFormatter.DEFAULT_DESC_PAD,
+          buildHelpFooter(),
+          false);
+      writer.flush();
+    }
+  }
+}
+```
+
+**Step 2: Verify compilation**
+
+```bash
+mvn -pl cli-processor compile
+```
+
+Expected: BUILD SUCCESS
+
+**Step 3: Commit**
+
+```bash
+git add cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java
+git commit -m "refactor: extract CallingContext to top-level package-private class"
+```
+
+---
+
+### Task 4: Update CLIProcessor to Use Extracted CallingContext
+
+**Files:**
+- Modify: `cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CLIProcessor.java`
+
+**Step 1: Add package-private getter for outputStream**
+
+Add this method to `CLIProcessor.java` (needed by extracted `CallingContext`):
+
+```java
+/**
+ * Get the output stream used for writing CLI output.
+ *
+ * @return the output stream
+ */
+@NonNull
+PrintStream getOutputStream() {
+  return outputStream;
+}
+```
+
+**Step 2: Make OPTIONS package-private**
+
+Change the `OPTIONS` field visibility from `private` to package-private:
+
+```java
+@NonNull
+static final List<Option> OPTIONS = ObjectUtils.notNull(List.of(
+    HELP_OPTION,
+    NO_COLOR_OPTION,
+    QUIET_OPTION,
+    SHOW_STACK_TRACE_OPTION,
+    VERSION_OPTION));
+```
+
+**Step 3: Make handleNoColor and handleQuiet package-private**
+
+Change visibility from `private`/`public` to package-private (no modifier):
+
+```java
+static void handleNoColor() {
+  System.setProperty(AnsiConsole.JANSI_MODE, AnsiConsole.JANSI_MODE_STRIP);
+  AnsiConsole.systemUninstall();
+}
+
+/**
+ * Configure the logger to only report errors.
+ */
+static void handleQuiet() {
+  // ... existing implementation
+}
+```
+
+**Step 4: Update parseCommand to use new CallingContext constructor**
+
+```java
+@NonNull
+private ExitStatus parseCommand(String... args) {
+  List<String> commandArgs = Arrays.asList(args);
+  assert commandArgs != null;
+  CallingContext callingContext = new CallingContext(this, commandArgs);
+
+  if (LOGGER.isDebugEnabled()) {
+    String commandChain = callingContext.getCalledCommands().stream()
+        .map(ICommand::getName)
+        .collect(Collectors.joining(" -> "));
+    LOGGER.debug("Processing command chain: {}", commandChain);
+  }
+
+  ExitStatus status;
+  if (commandArgs.isEmpty()) {
+    status = ExitCode.INVALID_COMMAND.exit();
+    callingContext.showHelp();
+  } else {
+    status = callingContext.processCommand();
+  }
+  return status;
+}
+```
+
+**Step 5: Remove the inner CallingContext class**
+
+Delete the entire inner class `CallingContext` from `CLIProcessor.java` (lines 328-802 approximately).
+
+**Step 6: Run tests to verify behavior preserved**
+
+```bash
+mvn -pl cli-processor test
+```
+
+Expected: BUILD SUCCESS (all tests pass)
+
+**Step 7: Commit**
+
+```bash
+git add cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CLIProcessor.java
+git commit -m "refactor: update CLIProcessor to use extracted CallingContext"
+```
+
+---
+
+### Task 5: Update ShellCompletionCommand Import
+
+**Files:**
+- Modify: `cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/ShellCompletionCommand.java`
+
+**Step 1: Update import statement**
+
+Change:
+```java
+import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
+```
+
+To:
+```java
+import gov.nist.secauto.metaschema.cli.processor.CallingContext;
+```
+
+**Step 2: Run tests**
+
+```bash
+mvn -pl cli-processor test
+```
+
+Expected: BUILD SUCCESS
+
+**Step 3: Commit**
+
+```bash
+git add cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/ShellCompletionCommand.java
+git commit -m "refactor: update ShellCompletionCommand import for extracted CallingContext"
+```
+
+---
+
+## Phase 3: Refactor processCommand
+
+### Task 6: Add Unit Tests for Phase Methods
+
+**Files:**
+- Create: `cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/CallingContextTest.java`
+
+**Step 1: Create CallingContextTest with phase tests**
+
+```java
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.cli.processor;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.ParseException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Unit tests for {@link CallingContext} phase methods.
+ */
+@DisplayName("CallingContext Unit Tests")
+class CallingContextTest {
+
+  private CLIProcessor processor;
+
+  @BeforeEach
+  void setUp() {
+    PrintStream nullOutput = new PrintStream(OutputStream.nullOutputStream(), true, StandardCharsets.UTF_8);
+    processor = new CLIProcessor(
+        "test-cli",
+        Map.of(CLIProcessor.COMMAND_VERSION, new TestVersionInfo()),
+        nullOutput);
+  }
+
+  private CallingContext createContext(String... args) {
+    return new CallingContext(processor, Arrays.asList(args));
+  }
+
+  @Nested
+  @DisplayName("checkHelpAndVersion()")
+  class CheckHelpAndVersionTests {
+
+    @Test
+    @DisplayName("returns ExitStatus for --version")
+    void returnsExitStatusForVersionOption() {
+      CallingContext ctx = createContext("--version");
+
+      Optional<ExitStatus> result = ctx.checkHelpAndVersion();
+
+      assertAll(
+          () -> assertTrue(result.isPresent()),
+          () -> assertEquals(ExitCode.OK, result.get().getExitCode()));
+    }
+
+    @Test
+    @DisplayName("returns ExitStatus for --help")
+    void returnsExitStatusForHelpOption() {
+      CallingContext ctx = createContext("--help");
+
+      Optional<ExitStatus> result = ctx.checkHelpAndVersion();
+
+      assertAll(
+          () -> assertTrue(result.isPresent()),
+          () -> assertEquals(ExitCode.OK, result.get().getExitCode()));
+    }
+
+    @Test
+    @DisplayName("returns empty for other args")
+    void returnsEmptyForOtherArgs() {
+      processor.addCommandHandler(new TestCommand());
+      CallingContext ctx = createContext("test-cmd");
+
+      Optional<ExitStatus> result = ctx.checkHelpAndVersion();
+
+      assertTrue(result.isEmpty());
+    }
+  }
+
+  @Nested
+  @DisplayName("parseOptions()")
+  class ParseOptionsTests {
+
+    @Test
+    @DisplayName("parses valid options")
+    void parsesValidOptions() throws ParseException {
+      processor.addCommandHandler(new TestCommand());
+      CallingContext ctx = createContext("test-cmd", "--quiet");
+
+      CommandLine cmdLine = ctx.parseOptions();
+
+      assertTrue(cmdLine.hasOption(CLIProcessor.QUIET_OPTION));
+    }
+
+    @Test
+    @DisplayName("throws on invalid option")
+    void throwsOnInvalidOption() {
+      CallingContext ctx = createContext("--invalid-option-xyz");
+
+      assertThrows(ParseException.class, ctx::parseOptions);
+    }
+  }
+
+  @Nested
+  @DisplayName("validateExtraArguments()")
+  class ValidateExtraArgumentsTests {
+
+    @Test
+    @DisplayName("returns empty when no target command")
+    void returnsEmptyWhenNoTargetCommand() throws ParseException {
+      CallingContext ctx = createContext("--help");
+      CommandLine cmdLine = ctx.parseOptions();
+
+      Optional<ExitStatus> result = ctx.validateExtraArguments(cmdLine);
+
+      assertTrue(result.isEmpty());
+    }
+
+    @Test
+    @DisplayName("returns empty when arguments valid")
+    void returnsEmptyWhenArgumentsValid() throws ParseException {
+      processor.addCommandHandler(new TestCommand());
+      CallingContext ctx = createContext("test-cmd");
+      CommandLine cmdLine = ctx.parseOptions();
+
+      Optional<ExitStatus> result = ctx.validateExtraArguments(cmdLine);
+
+      assertTrue(result.isEmpty());
+    }
+  }
+
+  @Nested
+  @DisplayName("validateCalledCommands()")
+  class ValidateCalledCommandsTests {
+
+    @Test
+    @DisplayName("returns empty when all commands valid")
+    void returnsEmptyWhenAllCommandsValid() throws ParseException {
+      processor.addCommandHandler(new TestCommand());
+      CallingContext ctx = createContext("test-cmd");
+      CommandLine cmdLine = ctx.parseOptions();
+
+      Optional<ExitStatus> result = ctx.validateCalledCommands(cmdLine);
+
+      assertTrue(result.isEmpty());
+    }
+  }
+
+  @Nested
+  @DisplayName("applyGlobalOptions()")
+  class ApplyGlobalOptionsTests {
+
+    @Test
+    @DisplayName("applies --quiet without error")
+    void appliesQuietOption() throws ParseException {
+      processor.addCommandHandler(new TestCommand());
+      CallingContext ctx = createContext("test-cmd", "--quiet");
+      CommandLine cmdLine = ctx.parseOptions();
+
+      assertDoesNotThrow(() -> ctx.applyGlobalOptions(cmdLine));
+    }
+  }
+}
+```
+
+**Step 2: Run tests - they will fail (methods don't exist yet)**
+
+```bash
+mvn -pl cli-processor test -Dtest=CallingContextTest
+```
+
+Expected: COMPILATION ERROR (methods not found) - this is expected for TDD
+
+**Step 3: Commit test file**
+
+```bash
+git add cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/CallingContextTest.java
+git commit -m "test: add unit tests for CallingContext phase methods (TDD - red)"
+```
+
+---
+
+### Task 7: Extract checkHelpAndVersion Method
+
+**Files:**
+- Modify: `cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java`
+
+**Step 1: Add checkHelpAndVersion method**
+
+Add this method to `CallingContext.java`:
+
+```java
+/**
+ * Check for --help and --version options before full parsing.
+ * <p>
+ * This is phase 1 of command processing.
+ *
+ * @return an exit status if help or version was requested, or empty to continue
+ */
+@NonNull
+protected Optional<ExitStatus> checkHelpAndVersion() {
+  Options phase1Options = new Options();
+  phase1Options.addOption(CLIProcessor.HELP_OPTION);
+  phase1Options.addOption(CLIProcessor.VERSION_OPTION);
+
+  try {
+    CommandLine cmdLine = new DefaultParser()
+        .parse(phase1Options, getExtraArgs().toArray(new String[0]), true);
+
+    if (cmdLine.hasOption(CLIProcessor.VERSION_OPTION)) {
+      cliProcessor.showVersion();
+      return Optional.of(ExitCode.OK.exit());
+    }
+    if (cmdLine.hasOption(CLIProcessor.HELP_OPTION)) {
+      showHelp();
+      return Optional.of(ExitCode.OK.exit());
+    }
+  } catch (ParseException ex) {
+    return Optional.of(handleInvalidCommand(ObjectUtils.notNull(ex.getMessage())));
+  }
+  return Optional.empty();
+}
+```
+
+**Step 2: Add import for Optional**
+
+```java
+import java.util.Optional;
+```
+
+**Step 3: Run tests for checkHelpAndVersion**
+
+```bash
+mvn -pl cli-processor test -Dtest=CallingContextTest#*checkHelpAndVersion*
+```
+
+Expected: BUILD SUCCESS
+
+**Step 4: Commit**
+
+```bash
+git add cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java
+git commit -m "refactor: extract checkHelpAndVersion phase method"
+```
+
+---
+
+### Task 8: Extract parseOptions Method
+
+**Files:**
+- Modify: `cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java`
+
+**Step 1: Add parseOptions method**
+
+```java
+/**
+ * Parse all command line options.
+ * <p>
+ * This is phase 2 of command processing.
+ *
+ * @return the parsed command line
+ * @throws ParseException if parsing fails
+ */
+@NonNull
+protected CommandLine parseOptions() throws ParseException {
+  return ObjectUtils.notNull(
+      new DefaultParser().parse(toOptions(), getExtraArgs().toArray(new String[0])));
+}
+```
+
+**Step 2: Run tests for parseOptions**
+
+```bash
+mvn -pl cli-processor test -Dtest=CallingContextTest#*parseOptions*
+```
+
+Expected: BUILD SUCCESS
+
+**Step 3: Commit**
+
+```bash
+git add cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java
+git commit -m "refactor: extract parseOptions phase method"
+```
+
+---
+
+### Task 9: Extract validateExtraArguments Method
+
+**Files:**
+- Modify: `cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java`
+
+**Step 1: Add validateExtraArguments method**
+
+```java
+/**
+ * Validate extra arguments for the target command.
+ * <p>
+ * This is phase 3 of command processing.
+ *
+ * @param cmdLine the parsed command line
+ * @return an exit status if validation failed, or empty to continue
+ */
+@NonNull
+protected Optional<ExitStatus> validateExtraArguments(@NonNull CommandLine cmdLine) {
+  ICommand target = getTargetCommand();
+  if (target == null) {
+    return Optional.empty();
+  }
+  try {
+    target.validateExtraArguments(this, cmdLine);
+    return Optional.empty();
+  } catch (InvalidArgumentException ex) {
+    return Optional.of(handleError(
+        ExitCode.INVALID_ARGUMENTS.exitMessage(ex.getLocalizedMessage()),
+        cmdLine,
+        true));
+  }
+}
+```
+
+**Step 2: Run tests for validateExtraArguments**
+
+```bash
+mvn -pl cli-processor test -Dtest=CallingContextTest#*validateExtraArguments*
+```
+
+Expected: BUILD SUCCESS
+
+**Step 3: Commit**
+
+```bash
+git add cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java
+git commit -m "refactor: extract validateExtraArguments phase method"
+```
+
+---
+
+### Task 10: Extract validateCalledCommands Method
+
+**Files:**
+- Modify: `cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java`
+
+**Step 1: Add validateCalledCommands method**
+
+```java
+/**
+ * Validate options for all called commands in the chain.
+ * <p>
+ * This is phase 4 of command processing.
+ *
+ * @param cmdLine the parsed command line
+ * @return an exit status if validation failed, or empty to continue
+ */
+@NonNull
+protected Optional<ExitStatus> validateCalledCommands(@NonNull CommandLine cmdLine) {
+  for (ICommand cmd : getCalledCommands()) {
+    try {
+      cmd.validateOptions(this, cmdLine);
+    } catch (InvalidArgumentException ex) {
+      String msg = ex.getMessage();
+      assert msg != null;
+      return Optional.of(handleInvalidCommand(msg));
+    }
+  }
+  return Optional.empty();
+}
+```
+
+**Step 2: Run tests for validateCalledCommands**
+
+```bash
+mvn -pl cli-processor test -Dtest=CallingContextTest#*validateCalledCommands*
+```
+
+Expected: BUILD SUCCESS
+
+**Step 3: Commit**
+
+```bash
+git add cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java
+git commit -m "refactor: extract validateCalledCommands phase method"
+```
+
+---
+
+### Task 11: Extract applyGlobalOptions Method
+
+**Files:**
+- Modify: `cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java`
+
+**Step 1: Add applyGlobalOptions method**
+
+```java
+/**
+ * Apply global options like --no-color and --quiet.
+ * <p>
+ * This is phase 5 of command processing.
+ *
+ * @param cmdLine the parsed command line
+ */
+protected void applyGlobalOptions(@NonNull CommandLine cmdLine) {
+  if (cmdLine.hasOption(CLIProcessor.NO_COLOR_OPTION)) {
+    CLIProcessor.handleNoColor();
+  }
+  if (cmdLine.hasOption(CLIProcessor.QUIET_OPTION)) {
+    CLIProcessor.handleQuiet();
+  }
+}
+```
+
+**Step 2: Run tests for applyGlobalOptions**
+
+```bash
+mvn -pl cli-processor test -Dtest=CallingContextTest#*applyGlobalOptions*
+```
+
+Expected: BUILD SUCCESS
+
+**Step 3: Commit**
+
+```bash
+git add cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java
+git commit -m "refactor: extract applyGlobalOptions phase method"
+```
+
+---
+
+### Task 12: Refactor processCommand to Use Phase Methods
+
+**Files:**
+- Modify: `cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java`
+
+**Step 1: Replace processCommand implementation**
+
+Replace the entire `processCommand()` method with:
+
+```java
+/**
+ * Process the command identified by the CLI arguments.
+ *
+ * @return the result of processing the command
+ */
+@NonNull
+public ExitStatus processCommand() {
+  // Phase 1: Check help/version before full parsing
+  Optional<ExitStatus> earlyExit = checkHelpAndVersion();
+  if (earlyExit.isPresent()) {
+    return earlyExit.get();
+  }
+
+  // Phase 2: Parse all options
+  CommandLine cmdLine;
+  try {
+    cmdLine = parseOptions();
+  } catch (ParseException ex) {
+    String msg = ex.getMessage();
+    assert msg != null;
+    return handleInvalidCommand(msg);
+  }
+
+  // Phase 3-4: Validate arguments and options
+  Optional<ExitStatus> validationResult = validateExtraArguments(cmdLine)
+      .or(() -> validateCalledCommands(cmdLine));
+  if (validationResult.isPresent()) {
+    return validationResult.get();
+  }
+
+  // Phase 5: Apply global options and execute
+  applyGlobalOptions(cmdLine);
+  return invokeCommand(cmdLine);
+}
+```
+
+**Step 2: Remove PMD suppressions from processCommand**
+
+Remove this annotation from processCommand:
+
+```java
+@SuppressWarnings({
+    "PMD.OnlyOneReturn",
+    "PMD.NPathComplexity",
+    "PMD.CyclomaticComplexity"
+})
+```
+
+**Step 3: Run all tests**
+
+```bash
+mvn -pl cli-processor test
+```
+
+Expected: BUILD SUCCESS
+
+**Step 4: Run full CI build**
+
+```bash
+mvn -pl cli-processor install -PCI
+```
+
+Expected: BUILD SUCCESS (no PMD violations)
+
+**Step 5: Commit**
+
+```bash
+git add cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java
+git commit -m "refactor: simplify processCommand using extracted phase methods
+
+Reduces cyclomatic complexity by delegating to focused phase methods.
+Removes PMD suppressions for complexity warnings."
+```
+
+---
+
+## Phase 4: Remove GodClass Warning
+
+### Task 13: Verify GodClass Warning Resolved
+
+**Files:**
+- Modify: `cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java`
+
+**Step 1: Remove GodClass suppression**
+
+Remove this line from `CallingContext.java`:
+
+```java
+@SuppressWarnings("PMD.GodClass")
+```
+
+**Step 2: Run PMD check**
+
+```bash
+mvn -pl cli-processor pmd:check
+```
+
+Expected: BUILD SUCCESS (if GodClass warning persists, we may need additional extraction - but try first)
+
+**Step 3: Run full CI build**
+
+```bash
+mvn install -PCI -Prelease
+```
+
+Expected: BUILD SUCCESS
+
+**Step 4: Commit**
+
+```bash
+git add cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java
+git commit -m "refactor: remove PMD GodClass suppression from CallingContext"
+```
+
+---
+
+## Phase 5: Final Verification
+
+### Task 14: Full Build Verification
+
+**Step 1: Run complete CI build**
+
+```bash
+mvn clean install -PCI -Prelease
+```
+
+Expected: BUILD SUCCESS
+
+**Step 2: Verify all tests pass**
+
+```bash
+mvn test
+```
+
+Expected: All tests pass
+
+**Step 3: Verify no checkstyle issues**
+
+```bash
+mvn checkstyle:check
+```
+
+Expected: BUILD SUCCESS
+
+**Step 4: Review commit history**
+
+```bash
+git log --oneline -15
+```
+
+Verify commits are clean and well-organized.
+
+---
+
+## Summary
+
+| Task | Description | Files |
+|------|-------------|-------|
+| 0 | Rebase on PR #551 | - |
+| 1 | Create test fixtures | TestVersionInfo.java, TestCommand.java |
+| 2 | Create integration tests | CLIProcessorTest.java |
+| 3 | Extract CallingContext | CallingContext.java (new) |
+| 4 | Update CLIProcessor | CLIProcessor.java |
+| 5 | Update ShellCompletionCommand | ShellCompletionCommand.java |
+| 6 | Add unit tests | CallingContextTest.java |
+| 7-11 | Extract phase methods | CallingContext.java |
+| 12 | Refactor processCommand | CallingContext.java |
+| 13 | Remove GodClass warning | CallingContext.java |
+| 14 | Final verification | - |
+
+**Estimated commits:** 14
+**Estimated time:** 2-3 hours

--- a/PRDs/20251217-cli-processor-refactor/implementation-plan.md
+++ b/PRDs/20251217-cli-processor-refactor/implementation-plan.md
@@ -144,14 +144,13 @@ class TestCommand extends AbstractTerminalCommand {
 
   @Override
   public ICommandExecutor newExecutor(
-      @NonNull CLIProcessor.CallingContext callingContext,
+      @NonNull CallingContext callingContext,
       @NonNull CommandLine cmdLine) {
     return ICommandExecutor.using(callingContext, cmdLine, this::executeCommand);
   }
 
-  @NonNull
   private void executeCommand(
-      @NonNull CLIProcessor.CallingContext callingContext,
+      @NonNull CallingContext callingContext,
       @NonNull CommandLine cmdLine) {
     // Do nothing - success
   }
@@ -1046,7 +1045,8 @@ class CallingContextTest {
         nullOutput);
   }
 
-  private CallingContext createContext(String... args) {
+  @NonNull
+  private CallingContext createContext(@NonNull String... args) {
     return new CallingContext(processor, Arrays.asList(args));
   }
 

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CLIProcessor.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CLIProcessor.java
@@ -7,23 +7,13 @@ package gov.nist.secauto.metaschema.cli.processor;
 
 import static org.fusesource.jansi.Ansi.ansi;
 
-import gov.nist.secauto.metaschema.cli.processor.command.CommandExecutionException;
 import gov.nist.secauto.metaschema.cli.processor.command.CommandService;
-import gov.nist.secauto.metaschema.cli.processor.command.ExtraArgument;
 import gov.nist.secauto.metaschema.cli.processor.command.ICommand;
-import gov.nist.secauto.metaschema.cli.processor.command.ICommandExecutor;
-import gov.nist.secauto.metaschema.core.util.AutoCloser;
 import gov.nist.secauto.metaschema.core.util.CollectionUtil;
 import gov.nist.secauto.metaschema.core.util.IVersionInfo;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -31,23 +21,17 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.fusesource.jansi.AnsiConsole;
-import org.fusesource.jansi.AnsiPrintStream;
 
 import java.io.PrintStream;
-import java.io.PrintWriter;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Processes command line arguments and dispatches called commands.
@@ -102,7 +86,7 @@ public class CLIProcessor {
       .get());
 
   @NonNull
-  private static final List<Option> OPTIONS = ObjectUtils.notNull(List.of(
+  static final List<Option> OPTIONS = ObjectUtils.notNull(List.of(
       HELP_OPTION,
       NO_COLOR_OPTION,
       QUIET_OPTION,
@@ -240,7 +224,7 @@ public class CLIProcessor {
   private ExitStatus parseCommand(String... args) {
     List<String> commandArgs = Arrays.asList(args);
     assert commandArgs != null;
-    CallingContext callingContext = new CallingContext(commandArgs);
+    CallingContext callingContext = new CallingContext(this, commandArgs);
 
     if (LOGGER.isDebugEnabled()) {
       String commandChain = callingContext.getCalledCommands().stream()
@@ -284,15 +268,25 @@ public class CLIProcessor {
         .collect(Collectors.toUnmodifiableMap(ICommand::getName, Function.identity())));
   }
 
-  private static void handleNoColor() {
+  static void handleNoColor() {
     System.setProperty(AnsiConsole.JANSI_MODE, AnsiConsole.JANSI_MODE_STRIP);
     AnsiConsole.systemUninstall();
   }
 
   /**
+   * Get the output stream used for writing CLI output.
+   *
+   * @return the output stream
+   */
+  @NonNull
+  PrintStream getOutputStream() {
+    return outputStream;
+  }
+
+  /**
    * Configure the logger to only report errors.
    */
-  public static void handleQuiet() {
+  static void handleQuiet() {
     LoggerContext ctx = (LoggerContext) LogManager.getContext(false); // NOPMD not closable here
     Configuration config = ctx.getConfiguration();
     LoggerConfig loggerConfig = config.getLoggerConfig(LogManager.ROOT_LOGGER_NAME);
@@ -323,481 +317,5 @@ public class CLIProcessor {
           .reset());
     });
     outputStream.flush();
-  }
-
-  /**
-   * Records information about the command line options and called command
-   * hierarchy.
-   */
-  @SuppressWarnings("PMD.GodClass")
-  public final class CallingContext {
-    @NonNull
-    private final List<Option> options;
-    @NonNull
-    private final List<ICommand> calledCommands;
-    @Nullable
-    private final ICommand targetCommand;
-    @NonNull
-    private final List<String> extraArgs;
-
-    @SuppressFBWarnings(value = "CT_CONSTRUCTOR_THROW", justification = "Use of final fields")
-    private CallingContext(@NonNull List<String> args) {
-      @SuppressWarnings("PMD.LooseCoupling") // needed to support getLast
-      LinkedList<ICommand> calledCommands = new LinkedList<>();
-      List<Option> options = new LinkedList<>(OPTIONS);
-      List<String> extraArgs = new LinkedList<>();
-
-      AtomicBoolean endArgs = new AtomicBoolean();
-      args.forEach(arg -> {
-        if (endArgs.get() || arg.startsWith("-")) {
-          extraArgs.add(arg);
-        } else if ("--".equals(arg)) {
-          endArgs.set(true);
-        } else {
-          ICommand command = calledCommands.isEmpty()
-              ? getTopLevelCommandsByName().get(arg)
-              : calledCommands.getLast().getSubCommandByName(arg);
-
-          if (command == null) {
-            extraArgs.add(arg);
-            endArgs.set(true);
-          } else {
-            calledCommands.add(command);
-            options.addAll(command.gatherOptions());
-          }
-        }
-      });
-
-      this.calledCommands = CollectionUtil.unmodifiableList(calledCommands);
-      this.targetCommand = calledCommands.peekLast();
-      this.options = CollectionUtil.unmodifiableList(options);
-      this.extraArgs = CollectionUtil.unmodifiableList(extraArgs);
-    }
-
-    /**
-     * Get the command line processor instance that generated this calling context.
-     *
-     * @return the instance
-     */
-    @NonNull
-    public CLIProcessor getCLIProcessor() {
-      return CLIProcessor.this;
-    }
-
-    /**
-     * Get the command that was triggered by the CLI arguments.
-     *
-     * @return the command or {@code null} if no command was triggered
-     */
-    @Nullable
-    public ICommand getTargetCommand() {
-      return targetCommand;
-    }
-
-    /**
-     * Get the options that are in scope for the current command context.
-     *
-     * @return the list of options
-     */
-    @NonNull
-    private List<Option> getOptionsList() {
-      return options;
-    }
-
-    @NonNull
-    private List<ICommand> getCalledCommands() {
-      return calledCommands;
-    }
-
-    /**
-     * Get any left over arguments that were not consumed by CLI options.
-     *
-     * @return the list of remaining arguments, which may be empty
-     */
-    @NonNull
-    private List<String> getExtraArgs() {
-      return extraArgs;
-    }
-
-    /**
-     * Get the collections of in scope options as an options group.
-     *
-     * @return the options group
-     */
-    private Options toOptions() {
-      Options retval = new Options();
-      for (Option option : getOptionsList()) {
-        retval.addOption(option);
-      }
-      return retval;
-    }
-
-    /**
-     * Process the command identified by the CLI arguments.
-     *
-     * @return the result of processing the command
-     */
-    @SuppressWarnings({
-        "PMD.OnlyOneReturn",
-        "PMD.NPathComplexity",
-        "PMD.CyclomaticComplexity"
-    })
-    @NonNull
-    public ExitStatus processCommand() {
-      // TODO: Consider refactoring as follows to reduce complexity:
-      // - Extract the parsing logic for each phase into separate methods (e.g.,
-      // parsePhaseOneOptions, parsePhaseTwoOptions).
-      // - Encapsulate error handling into dedicated methods.
-      // - Separate command execution logic into its own method if possible.
-      CommandLineParser parser = new DefaultParser();
-
-      // this uses a three phase approach where:
-      // phase 1: checks if help or version are used
-      // phase 2: parse and validate arguments
-      // phase 3: executes the command
-
-      // phase 1
-      CommandLine cmdLine;
-      try {
-        Options phase1Options = new Options();
-        phase1Options.addOption(HELP_OPTION);
-        phase1Options.addOption(VERSION_OPTION);
-
-        cmdLine = ObjectUtils.notNull(parser.parse(phase1Options, getExtraArgs().toArray(new String[0]), true));
-      } catch (ParseException ex) {
-        String msg = ex.getMessage();
-        assert msg != null;
-        return handleInvalidCommand(msg);
-      }
-
-      if (cmdLine.hasOption(VERSION_OPTION)) {
-        showVersion();
-        return ExitCode.OK.exit();
-      }
-      if (cmdLine.hasOption(HELP_OPTION)) {
-        showHelp();
-        return ExitCode.OK.exit();
-      }
-
-      // phase 2
-      try {
-        cmdLine = ObjectUtils.notNull(parser.parse(toOptions(), getExtraArgs().toArray(new String[0])));
-      } catch (ParseException ex) {
-        String msg = ex.getMessage();
-        assert msg != null;
-        return handleInvalidCommand(msg);
-      }
-
-      ICommand targetCommand = getTargetCommand();
-      if (targetCommand != null) {
-        try {
-          targetCommand.validateExtraArguments(this, cmdLine);
-        } catch (InvalidArgumentException ex) {
-          return handleError(
-              ExitCode.INVALID_ARGUMENTS.exitMessage(ex.getLocalizedMessage()),
-              cmdLine,
-              true);
-        }
-      }
-
-      for (ICommand cmd : getCalledCommands()) {
-        try {
-          cmd.validateOptions(this, cmdLine);
-        } catch (InvalidArgumentException ex) {
-          String msg = ex.getMessage();
-          assert msg != null;
-          return handleInvalidCommand(msg);
-        }
-      }
-
-      // phase 3
-      if (cmdLine.hasOption(NO_COLOR_OPTION)) {
-        handleNoColor();
-      }
-
-      if (cmdLine.hasOption(QUIET_OPTION)) {
-        handleQuiet();
-      }
-      return invokeCommand(cmdLine);
-    }
-
-    /**
-     * Directly execute the logic associated with the command.
-     *
-     * @param cmdLine
-     *          the command line information
-     * @return the result of executing the command
-     */
-    @SuppressWarnings({
-        "PMD.OnlyOneReturn", // readability
-        "PMD.AvoidCatchingGenericException" // needed here
-    })
-    @NonNull
-    private ExitStatus invokeCommand(@NonNull CommandLine cmdLine) {
-      ExitStatus retval;
-      try {
-        ICommand targetCommand = getTargetCommand();
-        if (targetCommand == null) {
-          retval = ExitCode.INVALID_COMMAND.exit();
-        } else {
-          ICommandExecutor executor = targetCommand.newExecutor(this, cmdLine);
-          try {
-            executor.execute();
-            retval = ExitCode.OK.exit();
-          } catch (CommandExecutionException ex) {
-            retval = ex.toExitStatus();
-          } catch (RuntimeException ex) {
-            retval = ExitCode.RUNTIME_ERROR
-                .exitMessage("Unexpected error occured: " + ex.getLocalizedMessage())
-                .withThrowable(ex);
-          }
-        }
-      } catch (RuntimeException ex) {
-        retval = ExitCode.RUNTIME_ERROR
-            .exitMessage(String.format("An uncaught runtime error occurred. %s", ex.getLocalizedMessage()))
-            .withThrowable(ex);
-      }
-
-      if (!ExitCode.OK.equals(retval.getExitCode())) {
-        retval.generateMessage(cmdLine.hasOption(SHOW_STACK_TRACE_OPTION));
-
-        if (ExitCode.INVALID_COMMAND.equals(retval.getExitCode())) {
-          showHelp();
-        }
-      }
-      return retval;
-    }
-
-    /**
-     * Handle an error that occurred while executing the command.
-     *
-     * @param exitStatus
-     *          the execution result
-     * @param cmdLine
-     *          the command line information
-     * @param showHelp
-     *          if {@code true} show the help information
-     * @return the resulting exit status
-     */
-    @NonNull
-    public ExitStatus handleError(
-        @NonNull ExitStatus exitStatus,
-        @NonNull CommandLine cmdLine,
-        boolean showHelp) {
-      exitStatus.generateMessage(cmdLine.hasOption(SHOW_STACK_TRACE_OPTION));
-      if (showHelp) {
-        showHelp();
-      }
-      return exitStatus;
-    }
-
-    /**
-     * Generate the help message and exit status for an invalid command using the
-     * provided message.
-     *
-     * @param message
-     *          the error message
-     * @return the resulting exit status
-     */
-    @NonNull
-    public ExitStatus handleInvalidCommand(
-        @NonNull String message) {
-      showHelp();
-
-      ExitStatus retval = ExitCode.INVALID_COMMAND.exitMessage(message);
-      retval.generateMessage(false);
-      return retval;
-    }
-
-    /**
-     * Callback for providing a help header.
-     *
-     * @return the header or {@code null}
-     */
-    @Nullable
-    private String buildHelpHeader() {
-      // TODO: build a suitable header
-      return null;
-    }
-
-    /**
-     * Callback for providing a help footer.
-     *
-     * @param exec
-     *          the executable name
-     *
-     * @return the footer or {@code null}
-     */
-    @NonNull
-    private String buildHelpFooter() {
-
-      ICommand targetCommand = getTargetCommand();
-      Collection<ICommand> subCommands;
-      if (targetCommand == null) {
-        subCommands = getTopLevelCommands();
-      } else {
-        subCommands = targetCommand.getSubCommands();
-      }
-
-      String retval;
-      if (subCommands.isEmpty()) {
-        retval = "";
-      } else {
-        StringBuilder builder = new StringBuilder(128);
-        builder
-            .append(System.lineSeparator())
-            .append("The following are available commands:")
-            .append(System.lineSeparator());
-
-        int length = subCommands.stream()
-            .mapToInt(command -> command.getName().length())
-            .max().orElse(0);
-
-        for (ICommand command : subCommands) {
-          builder.append(
-              ansi()
-                  .render(String.format("   @|bold %-" + length + "s|@ %s%n",
-                      command.getName(),
-                      command.getDescription())));
-        }
-        builder
-            .append(System.lineSeparator())
-            .append('\'')
-            .append(getExec())
-            .append(" <command> --help' will show help on that specific command.")
-            .append(System.lineSeparator());
-        retval = builder.toString();
-        assert retval != null;
-      }
-      return retval;
-    }
-
-    /**
-     * Get the CLI syntax.
-     *
-     * @return the CLI syntax to display in help output
-     */
-    private String buildHelpCliSyntax() {
-
-      StringBuilder builder = new StringBuilder(64);
-      builder.append(getExec());
-
-      List<ICommand> calledCommands = getCalledCommands();
-      if (!calledCommands.isEmpty()) {
-        builder.append(calledCommands.stream()
-            .map(ICommand::getName)
-            .collect(Collectors.joining(" ", " ", "")));
-      }
-
-      // output calling commands
-      ICommand targetCommand = getTargetCommand();
-      if (targetCommand == null) {
-        builder.append(" <command>");
-      } else {
-        builder.append(getSubCommands(targetCommand));
-      }
-
-      // output required options
-      getOptionsList().stream()
-          .filter(Option::isRequired)
-          .forEach(option -> {
-            builder
-                .append(' ')
-                .append(OptionUtils.toArgument(ObjectUtils.notNull(option)));
-            if (option.hasArg()) {
-              builder
-                  .append('=')
-                  .append(option.getArgName());
-            }
-          });
-
-      // output non-required option placeholder
-      builder.append(" [<options>]");
-
-      // output extra arguments
-      if (targetCommand != null) {
-        // handle extra arguments
-        builder.append(getExtraArguments(targetCommand));
-      }
-
-      String retval = builder.toString();
-      assert retval != null;
-      return retval;
-    }
-
-    @NonNull
-    private CharSequence getSubCommands(ICommand targetCommand) {
-      Collection<ICommand> subCommands = targetCommand.getSubCommands();
-
-      StringBuilder builder = new StringBuilder();
-      if (!subCommands.isEmpty()) {
-        builder.append(' ');
-        if (!targetCommand.isSubCommandRequired()) {
-          builder.append('[');
-        }
-
-        builder.append("<command>");
-
-        if (!targetCommand.isSubCommandRequired()) {
-          builder.append(']');
-        }
-      }
-      return builder;
-    }
-
-    @NonNull
-    private CharSequence getExtraArguments(@NonNull ICommand targetCommand) {
-      StringBuilder builder = new StringBuilder();
-      for (ExtraArgument argument : targetCommand.getExtraArguments()) {
-        builder.append(' ');
-        if (!argument.isRequired()) {
-          builder.append('[');
-        }
-
-        builder.append('<')
-            .append(argument.getName())
-            .append('>');
-
-        if (argument.getNumber() > 1) {
-          builder.append("...");
-        }
-
-        if (!argument.isRequired()) {
-          builder.append(']');
-        }
-      }
-      return builder;
-    }
-
-    /**
-     * Output the help text to the console.
-     */
-    public void showHelp() {
-
-      HelpFormatter formatter = new HelpFormatter();
-      formatter.setLongOptSeparator("=");
-
-      PrintStream out = outputStream;
-      int terminalWidth = (out instanceof AnsiPrintStream)
-          ? ((AnsiPrintStream) out).getTerminalWidth()
-          : 80;
-
-      try (PrintWriter writer = new PrintWriter( // NOPMD not owned
-          AutoCloser.preventClose(out),
-          true,
-          StandardCharsets.UTF_8)) {
-        formatter.printHelp(
-            writer,
-            Math.max(terminalWidth, 50),
-            buildHelpCliSyntax(),
-            buildHelpHeader(),
-            toOptions(),
-            HelpFormatter.DEFAULT_LEFT_PAD,
-            HelpFormatter.DEFAULT_DESC_PAD,
-            buildHelpFooter(),
-            false);
-        writer.flush();
-      }
-    }
   }
 }

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java
@@ -30,6 +30,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
@@ -146,6 +147,118 @@ public class CallingContext {
       retval.addOption(option);
     }
     return retval;
+  }
+
+  /**
+   * Check for --help and --version options before full parsing.
+   * <p>
+   * This is phase 1 of command processing.
+   *
+   * @return an exit status if help or version was requested, or empty to continue
+   */
+  @NonNull
+  protected Optional<ExitStatus> checkHelpAndVersion() {
+    Options phase1Options = new Options();
+    phase1Options.addOption(CLIProcessor.HELP_OPTION);
+    phase1Options.addOption(CLIProcessor.VERSION_OPTION);
+
+    try {
+      CommandLine cmdLine = new DefaultParser()
+          .parse(phase1Options, getExtraArgs().toArray(new String[0]), true);
+
+      if (cmdLine.hasOption(CLIProcessor.VERSION_OPTION)) {
+        cliProcessor.showVersion();
+        return Optional.of(ExitCode.OK.exit());
+      }
+      if (cmdLine.hasOption(CLIProcessor.HELP_OPTION)) {
+        showHelp();
+        return Optional.of(ExitCode.OK.exit());
+      }
+    } catch (ParseException ex) {
+      return Optional.of(handleInvalidCommand(ObjectUtils.notNull(ex.getMessage())));
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Parse all command line options.
+   * <p>
+   * This is phase 2 of command processing.
+   *
+   * @return the parsed command line
+   * @throws ParseException
+   *           if parsing fails
+   */
+  @NonNull
+  protected CommandLine parseOptions() throws ParseException {
+    return ObjectUtils.notNull(
+        new DefaultParser().parse(toOptions(), getExtraArgs().toArray(new String[0])));
+  }
+
+  /**
+   * Validate extra arguments for the target command.
+   * <p>
+   * This is phase 3 of command processing.
+   *
+   * @param cmdLine
+   *          the parsed command line
+   * @return an exit status if validation failed, or empty to continue
+   */
+  @NonNull
+  protected Optional<ExitStatus> validateExtraArguments(@NonNull CommandLine cmdLine) {
+    ICommand target = getTargetCommand();
+    if (target == null) {
+      return Optional.empty();
+    }
+    try {
+      target.validateExtraArguments(this, cmdLine);
+      return Optional.empty();
+    } catch (InvalidArgumentException ex) {
+      return Optional.of(handleError(
+          ExitCode.INVALID_ARGUMENTS.exitMessage(ex.getLocalizedMessage()),
+          cmdLine,
+          true));
+    }
+  }
+
+  /**
+   * Validate options for all called commands in the chain.
+   * <p>
+   * This is phase 4 of command processing.
+   *
+   * @param cmdLine
+   *          the parsed command line
+   * @return an exit status if validation failed, or empty to continue
+   */
+  @NonNull
+  protected Optional<ExitStatus> validateCalledCommands(@NonNull CommandLine cmdLine) {
+    for (ICommand cmd : getCalledCommands()) {
+      try {
+        cmd.validateOptions(this, cmdLine);
+      } catch (InvalidArgumentException ex) {
+        String msg = ex.getMessage();
+        assert msg != null;
+        return Optional.of(handleInvalidCommand(msg));
+      }
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Apply global options like --no-color and --quiet.
+   * <p>
+   * This is phase 5 of command processing.
+   *
+   * @param cmdLine
+   *          the parsed command line
+   */
+  protected void applyGlobalOptions(@NonNull CommandLine cmdLine) {
+    if (cmdLine.hasOption(CLIProcessor.NO_COLOR_OPTION)) {
+      CLIProcessor.handleNoColor();
+    }
+    if (cmdLine.hasOption(CLIProcessor.QUIET_OPTION)) {
+      CLIProcessor.handleQuiet();
+    }
   }
 
   /**

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java
@@ -322,7 +322,7 @@ public class CallingContext {
           retval = ex.toExitStatus();
         } catch (RuntimeException ex) {
           retval = ExitCode.RUNTIME_ERROR
-              .exitMessage("Unexpected error occured: " + ex.getLocalizedMessage())
+              .exitMessage("Unexpected error occurred: " + ex.getLocalizedMessage())
               .withThrowable(ex);
         }
       }

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java
@@ -1,0 +1,502 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.cli.processor;
+
+import static org.fusesource.jansi.Ansi.ansi;
+
+import gov.nist.secauto.metaschema.cli.processor.command.CommandExecutionException;
+import gov.nist.secauto.metaschema.cli.processor.command.ExtraArgument;
+import gov.nist.secauto.metaschema.cli.processor.command.ICommand;
+import gov.nist.secauto.metaschema.cli.processor.command.ICommandExecutor;
+import gov.nist.secauto.metaschema.core.util.AutoCloser;
+import gov.nist.secauto.metaschema.core.util.CollectionUtil;
+import gov.nist.secauto.metaschema.core.util.ObjectUtils;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.fusesource.jansi.AnsiPrintStream;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * Records information about the command line options and called command
+ * hierarchy.
+ */
+@SuppressWarnings("PMD.GodClass")
+public class CallingContext {
+  @NonNull
+  private final CLIProcessor cliProcessor;
+  @NonNull
+  private final List<Option> options;
+  @NonNull
+  private final List<ICommand> calledCommands;
+  @Nullable
+  private final ICommand targetCommand;
+  @NonNull
+  private final List<String> extraArgs;
+
+  @SuppressFBWarnings(value = "CT_CONSTRUCTOR_THROW", justification = "Use of final fields")
+  CallingContext(@NonNull CLIProcessor cliProcessor, @NonNull List<String> args) {
+    this.cliProcessor = cliProcessor;
+
+    @SuppressWarnings("PMD.LooseCoupling") // needed to support getLast
+    LinkedList<ICommand> calledCommands = new LinkedList<>();
+    List<Option> options = new LinkedList<>(CLIProcessor.OPTIONS);
+    List<String> extraArgs = new LinkedList<>();
+
+    AtomicBoolean endArgs = new AtomicBoolean();
+    args.forEach(arg -> {
+      if (endArgs.get() || arg.startsWith("-")) {
+        extraArgs.add(arg);
+      } else if ("--".equals(arg)) {
+        endArgs.set(true);
+      } else {
+        ICommand command = calledCommands.isEmpty()
+            ? cliProcessor.getTopLevelCommandsByName().get(arg)
+            : calledCommands.getLast().getSubCommandByName(arg);
+
+        if (command == null) {
+          extraArgs.add(arg);
+          endArgs.set(true);
+        } else {
+          calledCommands.add(command);
+          options.addAll(command.gatherOptions());
+        }
+      }
+    });
+
+    this.calledCommands = CollectionUtil.unmodifiableList(calledCommands);
+    this.targetCommand = calledCommands.peekLast();
+    this.options = CollectionUtil.unmodifiableList(options);
+    this.extraArgs = CollectionUtil.unmodifiableList(extraArgs);
+  }
+
+  /**
+   * Get the command line processor instance that generated this calling context.
+   *
+   * @return the instance
+   */
+  @NonNull
+  public CLIProcessor getCLIProcessor() {
+    return cliProcessor;
+  }
+
+  /**
+   * Get the command that was triggered by the CLI arguments.
+   *
+   * @return the command or {@code null} if no command was triggered
+   */
+  @Nullable
+  public ICommand getTargetCommand() {
+    return targetCommand;
+  }
+
+  /**
+   * Get the options that are in scope for the current command context.
+   *
+   * @return the list of options
+   */
+  @NonNull
+  List<Option> getOptionsList() {
+    return options;
+  }
+
+  @NonNull
+  List<ICommand> getCalledCommands() {
+    return calledCommands;
+  }
+
+  /**
+   * Get any left over arguments that were not consumed by CLI options.
+   *
+   * @return the list of remaining arguments, which may be empty
+   */
+  @NonNull
+  List<String> getExtraArgs() {
+    return extraArgs;
+  }
+
+  /**
+   * Get the collections of in scope options as an options group.
+   *
+   * @return the options group
+   */
+  Options toOptions() {
+    Options retval = new Options();
+    for (Option option : getOptionsList()) {
+      retval.addOption(option);
+    }
+    return retval;
+  }
+
+  /**
+   * Process the command identified by the CLI arguments.
+   *
+   * @return the result of processing the command
+   */
+  @SuppressWarnings({
+      "PMD.OnlyOneReturn",
+      "PMD.NPathComplexity",
+      "PMD.CyclomaticComplexity"
+  })
+  @NonNull
+  public ExitStatus processCommand() {
+    CommandLineParser parser = new DefaultParser();
+
+    // phase 1
+    CommandLine cmdLine;
+    try {
+      Options phase1Options = new Options();
+      phase1Options.addOption(CLIProcessor.HELP_OPTION);
+      phase1Options.addOption(CLIProcessor.VERSION_OPTION);
+
+      cmdLine = ObjectUtils.notNull(parser.parse(phase1Options, getExtraArgs().toArray(new String[0]), true));
+    } catch (ParseException ex) {
+      String msg = ex.getMessage();
+      assert msg != null;
+      return handleInvalidCommand(msg);
+    }
+
+    if (cmdLine.hasOption(CLIProcessor.VERSION_OPTION)) {
+      cliProcessor.showVersion();
+      return ExitCode.OK.exit();
+    }
+    if (cmdLine.hasOption(CLIProcessor.HELP_OPTION)) {
+      showHelp();
+      return ExitCode.OK.exit();
+    }
+
+    // phase 2
+    try {
+      cmdLine = ObjectUtils.notNull(parser.parse(toOptions(), getExtraArgs().toArray(new String[0])));
+    } catch (ParseException ex) {
+      String msg = ex.getMessage();
+      assert msg != null;
+      return handleInvalidCommand(msg);
+    }
+
+    ICommand targetCommand = getTargetCommand();
+    if (targetCommand != null) {
+      try {
+        targetCommand.validateExtraArguments(this, cmdLine);
+      } catch (InvalidArgumentException ex) {
+        return handleError(
+            ExitCode.INVALID_ARGUMENTS.exitMessage(ex.getLocalizedMessage()),
+            cmdLine,
+            true);
+      }
+    }
+
+    for (ICommand cmd : getCalledCommands()) {
+      try {
+        cmd.validateOptions(this, cmdLine);
+      } catch (InvalidArgumentException ex) {
+        String msg = ex.getMessage();
+        assert msg != null;
+        return handleInvalidCommand(msg);
+      }
+    }
+
+    // phase 3
+    if (cmdLine.hasOption(CLIProcessor.NO_COLOR_OPTION)) {
+      CLIProcessor.handleNoColor();
+    }
+
+    if (cmdLine.hasOption(CLIProcessor.QUIET_OPTION)) {
+      CLIProcessor.handleQuiet();
+    }
+    return invokeCommand(cmdLine);
+  }
+
+  /**
+   * Directly execute the logic associated with the command.
+   *
+   * @param cmdLine
+   *          the command line information
+   * @return the result of executing the command
+   */
+  @SuppressWarnings({
+      "PMD.OnlyOneReturn", // readability
+      "PMD.AvoidCatchingGenericException" // needed here
+  })
+  @NonNull
+  private ExitStatus invokeCommand(@NonNull CommandLine cmdLine) {
+    ExitStatus retval;
+    try {
+      ICommand targetCommand = getTargetCommand();
+      if (targetCommand == null) {
+        retval = ExitCode.INVALID_COMMAND.exit();
+      } else {
+        ICommandExecutor executor = targetCommand.newExecutor(this, cmdLine);
+        try {
+          executor.execute();
+          retval = ExitCode.OK.exit();
+        } catch (CommandExecutionException ex) {
+          retval = ex.toExitStatus();
+        } catch (RuntimeException ex) {
+          retval = ExitCode.RUNTIME_ERROR
+              .exitMessage("Unexpected error occured: " + ex.getLocalizedMessage())
+              .withThrowable(ex);
+        }
+      }
+    } catch (RuntimeException ex) {
+      retval = ExitCode.RUNTIME_ERROR
+          .exitMessage(String.format("An uncaught runtime error occurred. %s", ex.getLocalizedMessage()))
+          .withThrowable(ex);
+    }
+
+    if (!ExitCode.OK.equals(retval.getExitCode())) {
+      retval.generateMessage(cmdLine.hasOption(CLIProcessor.SHOW_STACK_TRACE_OPTION));
+
+      if (ExitCode.INVALID_COMMAND.equals(retval.getExitCode())) {
+        showHelp();
+      }
+    }
+    return retval;
+  }
+
+  /**
+   * Handle an error that occurred while executing the command.
+   *
+   * @param exitStatus
+   *          the execution result
+   * @param cmdLine
+   *          the command line information
+   * @param showHelp
+   *          if {@code true} show the help information
+   * @return the resulting exit status
+   */
+  @NonNull
+  public ExitStatus handleError(
+      @NonNull ExitStatus exitStatus,
+      @NonNull CommandLine cmdLine,
+      boolean showHelp) {
+    exitStatus.generateMessage(cmdLine.hasOption(CLIProcessor.SHOW_STACK_TRACE_OPTION));
+    if (showHelp) {
+      showHelp();
+    }
+    return exitStatus;
+  }
+
+  /**
+   * Generate the help message and exit status for an invalid command using the
+   * provided message.
+   *
+   * @param message
+   *          the error message
+   * @return the resulting exit status
+   */
+  @NonNull
+  public ExitStatus handleInvalidCommand(
+      @NonNull String message) {
+    showHelp();
+
+    ExitStatus retval = ExitCode.INVALID_COMMAND.exitMessage(message);
+    retval.generateMessage(false);
+    return retval;
+  }
+
+  /**
+   * Callback for providing a help header.
+   *
+   * @return the header or {@code null}
+   */
+  @Nullable
+  private String buildHelpHeader() {
+    // TODO: build a suitable header
+    return null;
+  }
+
+  /**
+   * Callback for providing a help footer.
+   *
+   * @return the footer or {@code null}
+   */
+  @NonNull
+  private String buildHelpFooter() {
+    ICommand targetCommand = getTargetCommand();
+    Collection<ICommand> subCommands;
+    if (targetCommand == null) {
+      subCommands = cliProcessor.getTopLevelCommands();
+    } else {
+      subCommands = targetCommand.getSubCommands();
+    }
+
+    String retval;
+    if (subCommands.isEmpty()) {
+      retval = "";
+    } else {
+      StringBuilder builder = new StringBuilder(128);
+      builder
+          .append(System.lineSeparator())
+          .append("The following are available commands:")
+          .append(System.lineSeparator());
+
+      int length = subCommands.stream()
+          .mapToInt(command -> command.getName().length())
+          .max().orElse(0);
+
+      for (ICommand command : subCommands) {
+        builder.append(
+            ansi()
+                .render(String.format("   @|bold %-" + length + "s|@ %s%n",
+                    command.getName(),
+                    command.getDescription())));
+      }
+      builder
+          .append(System.lineSeparator())
+          .append('\'')
+          .append(cliProcessor.getExec())
+          .append(" <command> --help' will show help on that specific command.")
+          .append(System.lineSeparator());
+      retval = builder.toString();
+      assert retval != null;
+    }
+    return retval;
+  }
+
+  /**
+   * Get the CLI syntax.
+   *
+   * @return the CLI syntax to display in help output
+   */
+  private String buildHelpCliSyntax() {
+    StringBuilder builder = new StringBuilder(64);
+    builder.append(cliProcessor.getExec());
+
+    List<ICommand> calledCommands = getCalledCommands();
+    if (!calledCommands.isEmpty()) {
+      builder.append(calledCommands.stream()
+          .map(ICommand::getName)
+          .collect(Collectors.joining(" ", " ", "")));
+    }
+
+    // output calling commands
+    ICommand targetCommand = getTargetCommand();
+    if (targetCommand == null) {
+      builder.append(" <command>");
+    } else {
+      builder.append(getSubCommands(targetCommand));
+    }
+
+    // output required options
+    getOptionsList().stream()
+        .filter(Option::isRequired)
+        .forEach(option -> {
+          builder
+              .append(' ')
+              .append(OptionUtils.toArgument(ObjectUtils.notNull(option)));
+          if (option.hasArg()) {
+            builder
+                .append('=')
+                .append(option.getArgName());
+          }
+        });
+
+    // output non-required option placeholder
+    builder.append(" [<options>]");
+
+    // output extra arguments
+    if (targetCommand != null) {
+      // handle extra arguments
+      builder.append(getExtraArguments(targetCommand));
+    }
+
+    String retval = builder.toString();
+    assert retval != null;
+    return retval;
+  }
+
+  @NonNull
+  private CharSequence getSubCommands(ICommand targetCommand) {
+    Collection<ICommand> subCommands = targetCommand.getSubCommands();
+
+    StringBuilder builder = new StringBuilder();
+    if (!subCommands.isEmpty()) {
+      builder.append(' ');
+      if (!targetCommand.isSubCommandRequired()) {
+        builder.append('[');
+      }
+
+      builder.append("<command>");
+
+      if (!targetCommand.isSubCommandRequired()) {
+        builder.append(']');
+      }
+    }
+    return builder;
+  }
+
+  @NonNull
+  private CharSequence getExtraArguments(@NonNull ICommand targetCommand) {
+    StringBuilder builder = new StringBuilder();
+    for (ExtraArgument argument : targetCommand.getExtraArguments()) {
+      builder.append(' ');
+      if (!argument.isRequired()) {
+        builder.append('[');
+      }
+
+      builder.append('<')
+          .append(argument.getName())
+          .append('>');
+
+      if (argument.getNumber() > 1) {
+        builder.append("...");
+      }
+
+      if (!argument.isRequired()) {
+        builder.append(']');
+      }
+    }
+    return builder;
+  }
+
+  /**
+   * Output the help text to the console.
+   */
+  public void showHelp() {
+    HelpFormatter formatter = new HelpFormatter();
+    formatter.setLongOptSeparator("=");
+
+    PrintStream out = cliProcessor.getOutputStream();
+    int terminalWidth = (out instanceof AnsiPrintStream)
+        ? ((AnsiPrintStream) out).getTerminalWidth()
+        : 80;
+
+    try (PrintWriter writer = new PrintWriter( // NOPMD not owned
+        AutoCloser.preventClose(out),
+        true,
+        StandardCharsets.UTF_8)) {
+      formatter.printHelp(
+          writer,
+          Math.max(terminalWidth, 50),
+          buildHelpCliSyntax(),
+          buildHelpHeader(),
+          toOptions(),
+          HelpFormatter.DEFAULT_LEFT_PAD,
+          HelpFormatter.DEFAULT_DESC_PAD,
+          buildHelpFooter(),
+          false);
+      writer.flush();
+    }
+  }
+}

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java
@@ -266,77 +266,33 @@ public class CallingContext {
    *
    * @return the result of processing the command
    */
-  @SuppressWarnings({
-      "PMD.OnlyOneReturn",
-      "PMD.NPathComplexity",
-      "PMD.CyclomaticComplexity"
-  })
   @NonNull
   public ExitStatus processCommand() {
-    CommandLineParser parser = new DefaultParser();
+    // Phase 1: Check help/version before full parsing
+    Optional<ExitStatus> earlyExit = checkHelpAndVersion();
+    if (earlyExit.isPresent()) {
+      return earlyExit.get();
+    }
 
-    // phase 1
+    // Phase 2: Parse all options
     CommandLine cmdLine;
     try {
-      Options phase1Options = new Options();
-      phase1Options.addOption(CLIProcessor.HELP_OPTION);
-      phase1Options.addOption(CLIProcessor.VERSION_OPTION);
-
-      cmdLine = ObjectUtils.notNull(parser.parse(phase1Options, getExtraArgs().toArray(new String[0]), true));
+      cmdLine = parseOptions();
     } catch (ParseException ex) {
       String msg = ex.getMessage();
       assert msg != null;
       return handleInvalidCommand(msg);
     }
 
-    if (cmdLine.hasOption(CLIProcessor.VERSION_OPTION)) {
-      cliProcessor.showVersion();
-      return ExitCode.OK.exit();
-    }
-    if (cmdLine.hasOption(CLIProcessor.HELP_OPTION)) {
-      showHelp();
-      return ExitCode.OK.exit();
+    // Phase 3-4: Validate arguments and options
+    Optional<ExitStatus> validationResult = validateExtraArguments(cmdLine)
+        .or(() -> validateCalledCommands(cmdLine));
+    if (validationResult.isPresent()) {
+      return validationResult.get();
     }
 
-    // phase 2
-    try {
-      cmdLine = ObjectUtils.notNull(parser.parse(toOptions(), getExtraArgs().toArray(new String[0])));
-    } catch (ParseException ex) {
-      String msg = ex.getMessage();
-      assert msg != null;
-      return handleInvalidCommand(msg);
-    }
-
-    ICommand targetCommand = getTargetCommand();
-    if (targetCommand != null) {
-      try {
-        targetCommand.validateExtraArguments(this, cmdLine);
-      } catch (InvalidArgumentException ex) {
-        return handleError(
-            ExitCode.INVALID_ARGUMENTS.exitMessage(ex.getLocalizedMessage()),
-            cmdLine,
-            true);
-      }
-    }
-
-    for (ICommand cmd : getCalledCommands()) {
-      try {
-        cmd.validateOptions(this, cmdLine);
-      } catch (InvalidArgumentException ex) {
-        String msg = ex.getMessage();
-        assert msg != null;
-        return handleInvalidCommand(msg);
-      }
-    }
-
-    // phase 3
-    if (cmdLine.hasOption(CLIProcessor.NO_COLOR_OPTION)) {
-      CLIProcessor.handleNoColor();
-    }
-
-    if (cmdLine.hasOption(CLIProcessor.QUIET_OPTION)) {
-      CLIProcessor.handleQuiet();
-    }
+    // Phase 5: Apply global options and execute
+    applyGlobalOptions(cmdLine);
     return invokeCommand(cmdLine);
   }
 

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/CallingContext.java
@@ -42,7 +42,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * Records information about the command line options and called command
  * hierarchy.
  */
-@SuppressWarnings("PMD.GodClass")
 public class CallingContext {
   @NonNull
   private final CLIProcessor cliProcessor;

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/AbstractCommandExecutor.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/AbstractCommandExecutor.java
@@ -5,7 +5,7 @@
 
 package gov.nist.secauto.metaschema.cli.processor.command;
 
-import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
+import gov.nist.secauto.metaschema.cli.processor.CallingContext;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
 import org.apache.commons.cli.CommandLine;

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/AbstractParentCommand.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/AbstractParentCommand.java
@@ -5,7 +5,7 @@
 
 package gov.nist.secauto.metaschema.cli.processor.command;
 
-import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
+import gov.nist.secauto.metaschema.cli.processor.CallingContext;
 import gov.nist.secauto.metaschema.cli.processor.ExitCode;
 import gov.nist.secauto.metaschema.cli.processor.ExitStatus;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/ICommand.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/ICommand.java
@@ -5,7 +5,7 @@
 
 package gov.nist.secauto.metaschema.cli.processor.command;
 
-import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
+import gov.nist.secauto.metaschema.cli.processor.CallingContext;
 import gov.nist.secauto.metaschema.cli.processor.InvalidArgumentException;
 import gov.nist.secauto.metaschema.core.util.CollectionUtil;
 

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/ICommandExecutor.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/ICommandExecutor.java
@@ -5,7 +5,7 @@
 
 package gov.nist.secauto.metaschema.cli.processor.command;
 
-import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
+import gov.nist.secauto.metaschema.cli.processor.CallingContext;
 
 import org.apache.commons.cli.CommandLine;
 

--- a/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/ShellCompletionCommand.java
+++ b/cli-processor/src/main/java/gov/nist/secauto/metaschema/cli/processor/command/ShellCompletionCommand.java
@@ -6,7 +6,7 @@
 package gov.nist.secauto.metaschema.cli.processor.command;
 
 import gov.nist.secauto.metaschema.cli.processor.CLIProcessor;
-import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
+import gov.nist.secauto.metaschema.cli.processor.CallingContext;
 import gov.nist.secauto.metaschema.cli.processor.ExitCode;
 import gov.nist.secauto.metaschema.cli.processor.completion.CompletionScriptGenerator;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;

--- a/cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/CLIProcessorTest.java
+++ b/cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/CLIProcessorTest.java
@@ -1,0 +1,122 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.cli.processor;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for {@link CLIProcessor}.
+ * <p>
+ * Tests the public API through {@code process(String... args)}.
+ */
+@DisplayName("CLIProcessor Integration Tests")
+class CLIProcessorTest {
+
+  private CLIProcessor processor;
+  private ByteArrayOutputStream outputCapture;
+
+  @BeforeEach
+  void setUp() {
+    outputCapture = new ByteArrayOutputStream();
+    PrintStream printStream = new PrintStream(outputCapture, true, StandardCharsets.UTF_8);
+    processor = new CLIProcessor(
+        "test-cli",
+        Map.of(CLIProcessor.COMMAND_VERSION, new TestVersionInfo()),
+        printStream);
+  }
+
+  @Nested
+  @DisplayName("Global Options")
+  class GlobalOptionsTests {
+
+    @Test
+    @DisplayName("--version shows version info and returns OK")
+    void testVersionOption() {
+      ExitStatus status = processor.process("--version");
+
+      String output = outputCapture.toString(StandardCharsets.UTF_8);
+      assertAll(
+          () -> assertEquals(ExitCode.OK, status.getExitCode()),
+          () -> assertTrue(output.contains("test-cli"), "Output should contain 'test-cli'"),
+          () -> assertTrue(output.contains("1.0.0-test"), "Output should contain '1.0.0-test'"));
+    }
+
+    @Test
+    @DisplayName("--help shows help and returns OK")
+    void testHelpOption() {
+      ExitStatus status = processor.process("--help");
+
+      String output = outputCapture.toString(StandardCharsets.UTF_8);
+      assertAll(
+          () -> assertEquals(ExitCode.OK, status.getExitCode()),
+          () -> assertTrue(output.contains("--help"), "Output should contain '--help'"));
+    }
+
+    @Test
+    @DisplayName("--quiet option is accepted")
+    void testQuietOption() {
+      processor.addCommandHandler(new TestCommand());
+
+      ExitStatus status = processor.process("--quiet", "test-cmd");
+
+      assertEquals(ExitCode.OK, status.getExitCode());
+    }
+  }
+
+  @Nested
+  @DisplayName("Command Execution")
+  class CommandExecutionTests {
+
+    @Test
+    @DisplayName("Valid command executes successfully")
+    void testValidCommandExecution() {
+      processor.addCommandHandler(new TestCommand());
+
+      ExitStatus status = processor.process("test-cmd");
+
+      assertEquals(ExitCode.OK, status.getExitCode());
+    }
+
+    @Test
+    @DisplayName("Unknown command returns INVALID_COMMAND")
+    void testUnknownCommand() {
+      ExitStatus status = processor.process("nonexistent-command");
+
+      assertEquals(ExitCode.INVALID_COMMAND, status.getExitCode());
+    }
+
+    @Test
+    @DisplayName("Invalid option returns INVALID_COMMAND")
+    void testInvalidOption() {
+      ExitStatus status = processor.process("--invalid-option-xyz");
+
+      assertEquals(ExitCode.INVALID_COMMAND, status.getExitCode());
+    }
+
+    @Test
+    @DisplayName("Empty args returns INVALID_COMMAND with help")
+    void testEmptyArgs() {
+      ExitStatus status = processor.process();
+
+      String output = outputCapture.toString(StandardCharsets.UTF_8);
+      assertAll(
+          () -> assertEquals(ExitCode.INVALID_COMMAND, status.getExitCode()),
+          () -> assertTrue(output.contains("--help"), "Output should contain '--help'"));
+    }
+  }
+}

--- a/cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/CLIProcessorTest.java
+++ b/cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/CLIProcessorTest.java
@@ -9,15 +9,17 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Map;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 /**
  * Integration tests for {@link CLIProcessor}.
@@ -27,7 +29,9 @@ import org.junit.jupiter.api.Test;
 @DisplayName("CLIProcessor Integration Tests")
 class CLIProcessorTest {
 
+  @NonNull
   private CLIProcessor processor;
+  @NonNull
   private ByteArrayOutputStream outputCapture;
 
   @BeforeEach

--- a/cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/CallingContextTest.java
+++ b/cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/CallingContextTest.java
@@ -11,6 +11,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.ParseException;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,7 +44,8 @@ class CallingContextTest {
         nullOutput);
   }
 
-  private CallingContext createContext(String... args) {
+  @NonNull
+  private CallingContext createContext(@NonNull String... args) {
     return new CallingContext(processor, Arrays.asList(args));
   }
 

--- a/cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/CallingContextTest.java
+++ b/cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/CallingContextTest.java
@@ -1,0 +1,172 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.cli.processor;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.ParseException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Unit tests for {@link CallingContext} phase methods.
+ */
+@DisplayName("CallingContext Unit Tests")
+class CallingContextTest {
+
+  private CLIProcessor processor;
+
+  @BeforeEach
+  void setUp() {
+    PrintStream nullOutput = new PrintStream(OutputStream.nullOutputStream(), true, StandardCharsets.UTF_8);
+    processor = new CLIProcessor(
+        "test-cli",
+        Map.of(CLIProcessor.COMMAND_VERSION, new TestVersionInfo()),
+        nullOutput);
+  }
+
+  private CallingContext createContext(String... args) {
+    return new CallingContext(processor, Arrays.asList(args));
+  }
+
+  @Nested
+  @DisplayName("checkHelpAndVersion()")
+  class CheckHelpAndVersionTests {
+
+    @Test
+    @DisplayName("returns ExitStatus for --version")
+    void returnsExitStatusForVersionOption() {
+      CallingContext ctx = createContext("--version");
+
+      Optional<ExitStatus> result = ctx.checkHelpAndVersion();
+
+      assertAll(
+          () -> assertTrue(result.isPresent()),
+          () -> assertEquals(ExitCode.OK, result.get().getExitCode()));
+    }
+
+    @Test
+    @DisplayName("returns ExitStatus for --help")
+    void returnsExitStatusForHelpOption() {
+      CallingContext ctx = createContext("--help");
+
+      Optional<ExitStatus> result = ctx.checkHelpAndVersion();
+
+      assertAll(
+          () -> assertTrue(result.isPresent()),
+          () -> assertEquals(ExitCode.OK, result.get().getExitCode()));
+    }
+
+    @Test
+    @DisplayName("returns empty for other args")
+    void returnsEmptyForOtherArgs() {
+      processor.addCommandHandler(new TestCommand());
+      CallingContext ctx = createContext("test-cmd");
+
+      Optional<ExitStatus> result = ctx.checkHelpAndVersion();
+
+      assertTrue(result.isEmpty());
+    }
+  }
+
+  @Nested
+  @DisplayName("parseOptions()")
+  class ParseOptionsTests {
+
+    @Test
+    @DisplayName("parses valid options")
+    void parsesValidOptions() throws ParseException {
+      processor.addCommandHandler(new TestCommand());
+      CallingContext ctx = createContext("test-cmd", "--quiet");
+
+      CommandLine cmdLine = ctx.parseOptions();
+
+      assertTrue(cmdLine.hasOption(CLIProcessor.QUIET_OPTION));
+    }
+
+    @Test
+    @DisplayName("throws on invalid option")
+    void throwsOnInvalidOption() {
+      CallingContext ctx = createContext("--invalid-option-xyz");
+
+      assertThrows(ParseException.class, ctx::parseOptions);
+    }
+  }
+
+  @Nested
+  @DisplayName("validateExtraArguments()")
+  class ValidateExtraArgumentsTests {
+
+    @Test
+    @DisplayName("returns empty when no target command")
+    void returnsEmptyWhenNoTargetCommand() throws ParseException {
+      CallingContext ctx = createContext("--help");
+      CommandLine cmdLine = ctx.parseOptions();
+
+      Optional<ExitStatus> result = ctx.validateExtraArguments(cmdLine);
+
+      assertTrue(result.isEmpty());
+    }
+
+    @Test
+    @DisplayName("returns empty when arguments valid")
+    void returnsEmptyWhenArgumentsValid() throws ParseException {
+      processor.addCommandHandler(new TestCommand());
+      CallingContext ctx = createContext("test-cmd");
+      CommandLine cmdLine = ctx.parseOptions();
+
+      Optional<ExitStatus> result = ctx.validateExtraArguments(cmdLine);
+
+      assertTrue(result.isEmpty());
+    }
+  }
+
+  @Nested
+  @DisplayName("validateCalledCommands()")
+  class ValidateCalledCommandsTests {
+
+    @Test
+    @DisplayName("returns empty when all commands valid")
+    void returnsEmptyWhenAllCommandsValid() throws ParseException {
+      processor.addCommandHandler(new TestCommand());
+      CallingContext ctx = createContext("test-cmd");
+      CommandLine cmdLine = ctx.parseOptions();
+
+      Optional<ExitStatus> result = ctx.validateCalledCommands(cmdLine);
+
+      assertTrue(result.isEmpty());
+    }
+  }
+
+  @Nested
+  @DisplayName("applyGlobalOptions()")
+  class ApplyGlobalOptionsTests {
+
+    @Test
+    @DisplayName("applies --quiet without error")
+    void appliesQuietOption() throws ParseException {
+      processor.addCommandHandler(new TestCommand());
+      CallingContext ctx = createContext("test-cmd", "--quiet");
+      CommandLine cmdLine = ctx.parseOptions();
+
+      assertDoesNotThrow(() -> ctx.applyGlobalOptions(cmdLine));
+    }
+  }
+}

--- a/cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/CallingContextTest.java
+++ b/cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/CallingContextTest.java
@@ -111,6 +111,14 @@ class CallingContextTest {
 
       assertThrows(ParseException.class, ctx::parseOptions);
     }
+
+    @Test
+    @DisplayName("throws on multiple invalid options")
+    void throwsOnMultipleInvalidOptions() {
+      CallingContext ctx = createContext("--invalid-one", "--invalid-two", "--invalid-three");
+
+      assertThrows(ParseException.class, ctx::parseOptions);
+    }
   }
 
   @Nested
@@ -139,6 +147,34 @@ class CallingContextTest {
 
       assertTrue(result.isEmpty());
     }
+
+    @Test
+    @DisplayName("returns error when required argument missing")
+    void returnsErrorWhenRequiredArgumentMissing() throws ParseException {
+      processor.addCommandHandler(new TestCommandWithRequiredArg());
+      CallingContext ctx = createContext("test-cmd-with-arg");
+      CommandLine cmdLine = ctx.parseOptions();
+
+      Optional<ExitStatus> result = ctx.validateExtraArguments(cmdLine);
+
+      assertAll(
+          () -> assertTrue(result.isPresent()),
+          () -> assertEquals(ExitCode.INVALID_ARGUMENTS, result.get().getExitCode()));
+    }
+
+    @Test
+    @DisplayName("returns error when too many arguments provided")
+    void returnsErrorWhenTooManyArguments() throws ParseException {
+      processor.addCommandHandler(new TestCommand());
+      CallingContext ctx = createContext("test-cmd", "extra-arg-1", "extra-arg-2");
+      CommandLine cmdLine = ctx.parseOptions();
+
+      Optional<ExitStatus> result = ctx.validateExtraArguments(cmdLine);
+
+      assertAll(
+          () -> assertTrue(result.isPresent()),
+          () -> assertEquals(ExitCode.INVALID_ARGUMENTS, result.get().getExitCode()));
+    }
   }
 
   @Nested
@@ -156,6 +192,32 @@ class CallingContextTest {
 
       assertTrue(result.isEmpty());
     }
+
+    @Test
+    @DisplayName("returns error when required option missing")
+    void returnsErrorWhenRequiredOptionMissing() throws ParseException {
+      processor.addCommandHandler(new TestCommandWithRequiredOption());
+      CallingContext ctx = createContext("test-cmd-with-option");
+      CommandLine cmdLine = ctx.parseOptions();
+
+      Optional<ExitStatus> result = ctx.validateCalledCommands(cmdLine);
+
+      assertAll(
+          () -> assertTrue(result.isPresent()),
+          () -> assertEquals(ExitCode.INVALID_COMMAND, result.get().getExitCode()));
+    }
+
+    @Test
+    @DisplayName("returns empty when required option provided")
+    void returnsEmptyWhenRequiredOptionProvided() throws ParseException {
+      processor.addCommandHandler(new TestCommandWithRequiredOption());
+      CallingContext ctx = createContext("test-cmd-with-option", "--required-opt", "value");
+      CommandLine cmdLine = ctx.parseOptions();
+
+      Optional<ExitStatus> result = ctx.validateCalledCommands(cmdLine);
+
+      assertTrue(result.isEmpty());
+    }
   }
 
   @Nested
@@ -167,6 +229,26 @@ class CallingContextTest {
     void appliesQuietOption() throws ParseException {
       processor.addCommandHandler(new TestCommand());
       CallingContext ctx = createContext("test-cmd", "--quiet");
+      CommandLine cmdLine = ctx.parseOptions();
+
+      assertDoesNotThrow(() -> ctx.applyGlobalOptions(cmdLine));
+    }
+
+    @Test
+    @DisplayName("applies --no-color without error")
+    void appliesNoColorOption() throws ParseException {
+      processor.addCommandHandler(new TestCommand());
+      CallingContext ctx = createContext("test-cmd", "--no-color");
+      CommandLine cmdLine = ctx.parseOptions();
+
+      assertDoesNotThrow(() -> ctx.applyGlobalOptions(cmdLine));
+    }
+
+    @Test
+    @DisplayName("applies both --quiet and --no-color without error")
+    void appliesBothQuietAndNoColor() throws ParseException {
+      processor.addCommandHandler(new TestCommand());
+      CallingContext ctx = createContext("test-cmd", "--quiet", "--no-color");
       CommandLine cmdLine = ctx.parseOptions();
 
       assertDoesNotThrow(() -> ctx.applyGlobalOptions(cmdLine));

--- a/cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/TestCommand.java
+++ b/cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/TestCommand.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.cli.processor;
+
+import gov.nist.secauto.metaschema.cli.processor.command.AbstractTerminalCommand;
+import gov.nist.secauto.metaschema.cli.processor.command.ICommandExecutor;
+
+import org.apache.commons.cli.CommandLine;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * A minimal command implementation for testing.
+ */
+class TestCommand
+    extends AbstractTerminalCommand {
+
+  @Override
+  @NonNull
+  public String getName() {
+    return "test-cmd";
+  }
+
+  @Override
+  @NonNull
+  public String getDescription() {
+    return "A test command";
+  }
+
+  @Override
+  public ICommandExecutor newExecutor(
+      @NonNull CLIProcessor.CallingContext callingContext,
+      @NonNull CommandLine cmdLine) {
+    return ICommandExecutor.using(callingContext, cmdLine, this::executeCommand);
+  }
+
+  private void executeCommand(
+      @NonNull CLIProcessor.CallingContext callingContext,
+      @NonNull CommandLine cmdLine) {
+    // Do nothing - success
+  }
+}

--- a/cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/TestCommand.java
+++ b/cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/TestCommand.java
@@ -32,13 +32,13 @@ class TestCommand
 
   @Override
   public ICommandExecutor newExecutor(
-      @NonNull CLIProcessor.CallingContext callingContext,
+      @NonNull CallingContext callingContext,
       @NonNull CommandLine cmdLine) {
     return ICommandExecutor.using(callingContext, cmdLine, this::executeCommand);
   }
 
   private void executeCommand(
-      @NonNull CLIProcessor.CallingContext callingContext,
+      @NonNull CallingContext callingContext,
       @NonNull CommandLine cmdLine) {
     // Do nothing - success
   }

--- a/cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/TestCommandWithRequiredArg.java
+++ b/cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/TestCommandWithRequiredArg.java
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.cli.processor;
+
+import gov.nist.secauto.metaschema.cli.processor.command.AbstractTerminalCommand;
+import gov.nist.secauto.metaschema.cli.processor.command.ExtraArgument;
+import gov.nist.secauto.metaschema.cli.processor.command.ICommandExecutor;
+
+import org.apache.commons.cli.CommandLine;
+
+import java.util.List;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * A test command that requires an extra argument.
+ */
+class TestCommandWithRequiredArg
+    extends AbstractTerminalCommand {
+
+  @Override
+  @NonNull
+  public String getName() {
+    return "test-cmd-with-arg";
+  }
+
+  @Override
+  @NonNull
+  public String getDescription() {
+    return "A test command requiring an argument";
+  }
+
+  @Override
+  public List<ExtraArgument> getExtraArguments() {
+    return List.of(
+        ExtraArgument.newInstance("required-file", true));
+  }
+
+  @Override
+  public ICommandExecutor newExecutor(
+      @NonNull CallingContext callingContext,
+      @NonNull CommandLine cmdLine) {
+    return ICommandExecutor.using(callingContext, cmdLine, this::executeCommand);
+  }
+
+  private void executeCommand(
+      @NonNull CallingContext callingContext,
+      @NonNull CommandLine cmdLine) {
+    // Do nothing - success
+  }
+}

--- a/cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/TestCommandWithRequiredOption.java
+++ b/cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/TestCommandWithRequiredOption.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.cli.processor;
+
+import gov.nist.secauto.metaschema.cli.processor.command.AbstractTerminalCommand;
+import gov.nist.secauto.metaschema.cli.processor.command.ICommandExecutor;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+
+import java.util.Collection;
+import java.util.List;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * A test command that requires a specific option.
+ */
+class TestCommandWithRequiredOption
+    extends AbstractTerminalCommand {
+
+  private static final Option REQUIRED_OPTION = Option.builder()
+      .longOpt("required-opt")
+      .desc("A required option for testing")
+      .hasArg()
+      .argName("VALUE")
+      .build();
+
+  @Override
+  @NonNull
+  public String getName() {
+    return "test-cmd-with-option";
+  }
+
+  @Override
+  @NonNull
+  public String getDescription() {
+    return "A test command requiring an option";
+  }
+
+  @Override
+  public Collection<? extends Option> gatherOptions() {
+    return List.of(REQUIRED_OPTION);
+  }
+
+  @Override
+  public void validateOptions(
+      @NonNull CallingContext callingContext,
+      @NonNull CommandLine cmdLine) throws InvalidArgumentException {
+    if (!cmdLine.hasOption(REQUIRED_OPTION)) {
+      throw new InvalidArgumentException("The '--required-opt' option is required.");
+    }
+  }
+
+  @Override
+  public ICommandExecutor newExecutor(
+      @NonNull CallingContext callingContext,
+      @NonNull CommandLine cmdLine) {
+    return ICommandExecutor.using(callingContext, cmdLine, this::executeCommand);
+  }
+
+  private void executeCommand(
+      @NonNull CallingContext callingContext,
+      @NonNull CommandLine cmdLine) {
+    // Do nothing - success
+  }
+}

--- a/cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/TestVersionInfo.java
+++ b/cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/TestVersionInfo.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.cli.processor;
+
+import gov.nist.secauto.metaschema.core.util.IVersionInfo;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * A simple version info implementation for testing.
+ */
+class TestVersionInfo implements IVersionInfo {
+
+  @Override
+  @NonNull
+  public String getName() {
+    return "test-cli";
+  }
+
+  @Override
+  @NonNull
+  public String getVersion() {
+    return "1.0.0-test";
+  }
+
+  @Override
+  @NonNull
+  public String getBuildTimestamp() {
+    return "2025-01-01T00:00:00Z";
+  }
+
+  @Override
+  @NonNull
+  public String getGitOriginUrl() {
+    return "https://example.com/test.git";
+  }
+
+  @Override
+  @NonNull
+  public String getGitBranch() {
+    return "test-branch";
+  }
+
+  @Override
+  @NonNull
+  public String getGitCommit() {
+    return "abc1234";
+  }
+
+  @Override
+  @NonNull
+  public String getGitClosestTag() {
+    return "v1.0.0";
+  }
+}

--- a/cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/completion/CompletionScriptGeneratorTest.java
+++ b/cli-processor/src/test/java/gov/nist/secauto/metaschema/cli/processor/completion/CompletionScriptGeneratorTest.java
@@ -8,7 +8,7 @@ package gov.nist.secauto.metaschema.cli.processor.completion;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
+import gov.nist.secauto.metaschema.cli.processor.CallingContext;
 import gov.nist.secauto.metaschema.cli.processor.command.ExtraArgument;
 import gov.nist.secauto.metaschema.cli.processor.command.ICommand;
 import gov.nist.secauto.metaschema.cli.processor.command.ICommandExecutor;

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractConvertSubcommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractConvertSubcommand.java
@@ -5,7 +5,7 @@
 
 package gov.nist.secauto.metaschema.cli.commands;
 
-import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
+import gov.nist.secauto.metaschema.cli.processor.CallingContext;
 import gov.nist.secauto.metaschema.cli.processor.ExitCode;
 import gov.nist.secauto.metaschema.cli.processor.command.AbstractCommandExecutor;
 import gov.nist.secauto.metaschema.cli.processor.command.AbstractTerminalCommand;

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractValidateContentCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractValidateContentCommand.java
@@ -6,7 +6,7 @@
 package gov.nist.secauto.metaschema.cli.commands;
 
 import gov.nist.secauto.metaschema.cli.processor.CLIProcessor;
-import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
+import gov.nist.secauto.metaschema.cli.processor.CallingContext;
 import gov.nist.secauto.metaschema.cli.processor.ExitCode;
 import gov.nist.secauto.metaschema.cli.processor.command.AbstractCommandExecutor;
 import gov.nist.secauto.metaschema.cli.processor.command.AbstractTerminalCommand;

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/ConvertContentUsingModuleCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/ConvertContentUsingModuleCommand.java
@@ -5,7 +5,7 @@
 
 package gov.nist.secauto.metaschema.cli.commands;
 
-import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
+import gov.nist.secauto.metaschema.cli.processor.CallingContext;
 import gov.nist.secauto.metaschema.cli.processor.command.CommandExecutionException;
 import gov.nist.secauto.metaschema.cli.processor.command.ICommandExecutor;
 import gov.nist.secauto.metaschema.core.model.IBoundObject;

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/GenerateDiagramCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/GenerateDiagramCommand.java
@@ -5,7 +5,7 @@
 
 package gov.nist.secauto.metaschema.cli.commands;
 
-import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
+import gov.nist.secauto.metaschema.cli.processor.CallingContext;
 import gov.nist.secauto.metaschema.cli.processor.ExitCode;
 import gov.nist.secauto.metaschema.cli.processor.command.AbstractTerminalCommand;
 import gov.nist.secauto.metaschema.cli.processor.command.CommandExecutionException;

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/GenerateSchemaCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/GenerateSchemaCommand.java
@@ -5,7 +5,7 @@
 
 package gov.nist.secauto.metaschema.cli.commands;
 
-import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
+import gov.nist.secauto.metaschema.cli.processor.CallingContext;
 import gov.nist.secauto.metaschema.cli.processor.ExitCode;
 import gov.nist.secauto.metaschema.cli.processor.command.AbstractTerminalCommand;
 import gov.nist.secauto.metaschema.cli.processor.command.CommandExecutionException;

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/ValidateContentUsingModuleCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/ValidateContentUsingModuleCommand.java
@@ -5,7 +5,7 @@
 
 package gov.nist.secauto.metaschema.cli.commands;
 
-import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
+import gov.nist.secauto.metaschema.cli.processor.CallingContext;
 import gov.nist.secauto.metaschema.cli.processor.command.CommandExecutionException;
 import gov.nist.secauto.metaschema.cli.processor.command.ICommandExecutor;
 import gov.nist.secauto.metaschema.core.configuration.DefaultConfiguration;

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/ValidateModuleCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/ValidateModuleCommand.java
@@ -5,7 +5,7 @@
 
 package gov.nist.secauto.metaschema.cli.commands;
 
-import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
+import gov.nist.secauto.metaschema.cli.processor.CallingContext;
 import gov.nist.secauto.metaschema.cli.processor.ExitCode;
 import gov.nist.secauto.metaschema.cli.processor.command.CommandExecutionException;
 import gov.nist.secauto.metaschema.cli.processor.command.ICommandExecutor;

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/metapath/EvaluateMetapathCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/metapath/EvaluateMetapathCommand.java
@@ -6,7 +6,7 @@
 package gov.nist.secauto.metaschema.cli.commands.metapath;
 
 import gov.nist.secauto.metaschema.cli.commands.MetaschemaCommands;
-import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
+import gov.nist.secauto.metaschema.cli.processor.CallingContext;
 import gov.nist.secauto.metaschema.cli.processor.ExitCode;
 import gov.nist.secauto.metaschema.cli.processor.command.AbstractTerminalCommand;
 import gov.nist.secauto.metaschema.cli.processor.command.CommandExecutionException;

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/metapath/ListFunctionsSubcommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/metapath/ListFunctionsSubcommand.java
@@ -5,7 +5,7 @@
 
 package gov.nist.secauto.metaschema.cli.commands.metapath;
 
-import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
+import gov.nist.secauto.metaschema.cli.processor.CallingContext;
 import gov.nist.secauto.metaschema.cli.processor.ExitCode;
 import gov.nist.secauto.metaschema.cli.processor.ExitStatus;
 import gov.nist.secauto.metaschema.cli.processor.command.AbstractTerminalCommand;


### PR DESCRIPTION
## Summary

- Extract `CallingContext` from inner class to top-level public class for better testability
- Add phase methods with `Optional<ExitStatus>` return pattern for clean flow control:
  - `checkHelpAndVersion()` - early exit for --help/--version
  - `parseOptions()` - parse all command line options
  - `validateExtraArguments()` - validate extra arguments
  - `validateCalledCommands()` - validate command chain
  - `applyGlobalOptions()` - apply --quiet/--no-color
- Simplify `processCommand()` using Optional-based result chaining
- Remove PMD GodClass suppression - complexity reduced through extraction
- Update CallingContext imports across cli-processor and metaschema-cli modules

## Test plan

- [x] All 56 cli-processor tests pass
- [x] Integration tests verify CLIProcessor public API behavior
- [x] Unit tests verify individual phase method behavior
- [x] TDD approach: tests written before implementation
- [x] Full build with `-DskipTests` succeeds

Closes #252

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * CLI processing reorganized into phased flow so help/version are handled earlier, validation is clearer, and global options (e.g., --no-color, --quiet) apply consistently.

* **Bug Fixes**
  * More consistent early-exit behavior and clearer error/help messaging for invalid commands, options, and argument validation.

* **Tests**
  * Added unit and integration tests covering phase flows, option parsing, help/version output, and argument/option validation.

* **Documentation**
  * Added design and implementation plan describing the refactor and rollout.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->