### PR TITLE
feat: add collection class override support in binding configuration

### DIFF
--- a/.claude/rules/development-workflow.md
+++ b/.claude/rules/development-workflow.md
@@ -228,9 +228,26 @@ PR to develop
 
 ---
 
-## Debugging Workflow
+## Debugging Workflow (MANDATORY)
+
+**ALL debugging MUST use `superpowers:systematic-debugging` skill. No exceptions.**
 
 When debugging issues (during development or in production):
+
+### Step 0: Invoke the Debugging Skill (REQUIRED FIRST STEP)
+
+**BEFORE ANY investigation or fix attempts:**
+1. Use `Skill` tool to invoke `superpowers:systematic-debugging`
+2. Follow the four phases exactly as specified
+3. Create TodoWrite todos for each phase
+
+**Red Flags (You're Skipping the Skill):**
+- "Let me just check this quickly"
+- "This is a simple bug"
+- "I can see the problem, let me fix it"
+- "One quick fix to try first"
+
+**Why:** Random fixes waste time and create new bugs. The skill ensures systematic root cause identification.
 
 ### Step 1: Identify Root Cause (REQUIRED)
 **Do NOT attempt fixes until root cause is identified.**
@@ -244,7 +261,7 @@ Use these skills:
 - Where in the code does the bug originate?
 - Why does this code path produce the wrong result?
 
-**Post Bug Reproduction comment to Jira** (see Jira Comments section below)
+**Post Bug Reproduction comment to Jira** (if applicable)
 
 ### Step 2: Verify Test Coverage
 Once root cause is confirmed:
@@ -287,7 +304,7 @@ Implement Fix (target the root cause)
     ↓
 verification-before-completion
     ↓
-PR to staging
+PR to develop
 ```
 
 ---

--- a/.claude/rules/metaschema-authoring.md
+++ b/.claude/rules/metaschema-authoring.md
@@ -66,6 +66,37 @@ When Metaschema modules are used for code generation but create circular depende
 
 See `metaschema-testing/` for an example of this pattern.
 
+### Generated Binding Class Locations
+
+The following packages contain binding classes derived from Metaschema modules:
+
+| Package | Source Metaschema | Bootstrap POM |
+|---------|------------------|---------------|
+| `databind/src/main/java/gov/nist/secauto/metaschema/databind/config/binding/` | `databind/src/main/metaschema/metaschema-bindings.yaml` | `databind/pom-bootstrap.xml` |
+| `metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/` | `metaschema-testing/src/main/metaschema/unit-tests.yaml` | `metaschema-testing/pom-bootstrap.xml` |
+
+### CRITICAL: Never Manually Edit Generated Binding Classes
+
+**All changes to generated binding classes MUST be driven through the source Metaschema module.**
+
+When you need to modify a generated binding class:
+
+1. **Identify the source Metaschema** - Find the `.yaml` or `.xml` module that generates the class
+2. **Modify the Metaschema module** - Update the `.yaml` or `.xml` module definition
+3. **Build the project first** - Run `mvn install` to ensure the code generator is up to date
+4. **Regenerate the binding classes** - Run the bootstrap POM: `mvn -f {module}/pom-bootstrap.xml generate-sources`
+5. **Verify the changes** - Check that the regenerated classes contain the expected changes
+
+**Why this matters:**
+- Manual edits will be lost when classes are regenerated
+- Manual edits may diverge from the Metaschema schema definition
+- The Metaschema module is the authoritative source for the data model
+
+**Red flags that you're about to make a mistake:**
+- Opening a file in `.../config/binding/` or `.../testsuite/` for editing
+- Adding fields, methods, or annotations directly to these classes
+- Copying code patterns from these files to create new bindings manually
+
 ## Code Generation
 
 After modifying Metaschema modules that generate Java bindings:

--- a/.claude/rules/unit-testing.md
+++ b/.claude/rules/unit-testing.md
@@ -1,5 +1,20 @@
 # Unit Testing Standards
 
+## 100% Test Pass Rate (BLOCKING)
+
+**All unit tests MUST pass before pushing code or creating PRs.**
+
+- Run `mvn test` or `mvn -pl {module} test` to verify
+- A single failing test blocks the PR
+- Flaky tests must be fixed or marked as `@Disabled` with explanation
+- Network-dependent tests should have appropriate timeouts and retry logic
+
+**If CI fails due to test timeout or flakiness:**
+1. Investigate the root cause
+2. If it's a pre-existing issue on develop, note this in the PR
+3. Re-run CI to verify it's not caused by your changes
+4. Open an issue to track the flaky test if not already tracked
+
 ## Core Principles
 
 ### What NOT to Test

--- a/.claude/skills/metaschema-module-authoring.md
+++ b/.claude/skills/metaschema-module-authoring.md
@@ -279,6 +279,67 @@ model:
 </model>
 ```
 
+### Code Generation: Nested vs Separate Classes
+
+The choice between inline definitions and global definitions with references affects how Java classes are generated:
+
+| Approach | Generated Structure | Use When |
+|----------|---------------------|----------|
+| Inline definitions | Nested inner classes | Single-use, tightly coupled structures |
+| Global definitions + refs | Separate top-level classes | Reusable, shared across multiple parents |
+
+#### Example: Inline produces nested classes
+
+```yaml
+# This YAML structure with inline definitions:
+- object-type: assembly
+  name: parent
+  model:
+    instances:
+    - object-type: assembly
+      name: child
+      formal-name: Child
+      model:
+        instances:
+        - object-type: field
+          name: value
+          as-type: string
+```
+
+Generates:
+```java
+public class Parent {
+    public static class Child {
+        // nested inside Parent
+    }
+}
+```
+
+#### Example: References produce separate classes
+
+```yaml
+# This YAML structure with global definitions and refs:
+definitions:
+- object-type: assembly
+  name: parent
+  model:
+    instances:
+    - object-type: assembly-ref
+      ref: child
+
+- object-type: assembly
+  name: child
+  formal-name: Child
+```
+
+Generates:
+```java
+public class Parent { ... }
+public class Child { ... }  // separate file
+```
+
+**Key insight**: Use inline definitions when you want tightly coupled, nested class hierarchies (like binding configurations with deeply nested elements). Use global definitions with refs when the component is reused elsewhere.
+
 ## Cardinality and Grouping
 
 ### Cardinality Attributes

--- a/.claude/skills/unit-test-writing.md
+++ b/.claude/skills/unit-test-writing.md
@@ -20,12 +20,39 @@ description: Use when writing or expanding unit tests - provides edge case check
 | Empty/Null | Empty string, null reference, empty collection | ☐ |
 | Boundaries | Zero, negative, max int, min int, boundary values | ☐ |
 | Invalid | Wrong type, malformed input, out of range | ☐ |
-| Missing | Required field absent, partial data | ☐ |
+| Missing | Required field absent, partial data, missing nested element | ☐ |
 | Duplicates | Repeated values, duplicate keys | ☐ |
 | Ordering | First, last, middle, unsorted | ☐ |
 | Concurrency | Race conditions, thread safety (if applicable) | ☐ |
 | State | Uninitialized, already processed, closed | ☐ |
 | Combinations | Multiple flags, conflicting options | ☐ |
+
+## Configuration/Parsing Edge Cases
+
+When testing XML/JSON/YAML configuration loading, always test:
+
+| Scenario | Test Case | Expected |
+|----------|-----------|----------|
+| Missing optional child | Parent element exists, optional child absent | Null or default value |
+| Empty element | `<element/>` or `<element></element>` | Empty string or null |
+| Unknown module | Query from module not in config | Null, not exception |
+| Unknown definition | Query definition not in config | Null, not exception |
+| Partial config | Some fields present, others missing | Only specified fields set |
+| Multiple types | Same pattern for different parent types (assembly vs field) | Both work correctly |
+
+**Example edge case test structure:**
+
+```java
+@Test
+void testMissingOptionalElement() throws IOException {
+    // Load config with element that has no optional child
+    config.load(new File("edge-cases.xml"));
+
+    // Query should return null, not throw
+    IPropertyBindingConfiguration result = config.getPropertyBindingConfiguration(definition, "missing-child");
+    assertNull(result, "Missing optional element should return null");
+}
+```
 
 ## Coverage Expansion Workflow
 

--- a/PRDs/20251224-codegen-quality/implementation-plan.md
+++ b/PRDs/20251224-codegen-quality/implementation-plan.md
@@ -95,16 +95,16 @@ This PR fixes the code generator and regenerates metaschema-testing binding clas
 
 ---
 
-## PR 2: Collection Class Override Support
+## PR 2: Collection Class Override Support ✅
 
 | Attribute | Value |
 |-----------|-------|
-| **Files Changed** | ~10 |
+| **Files Changed** | ~15 |
 | **Risk Level** | Low |
 | **Dependencies** | PR 1 |
 | **Target Branch** | develop |
-| **Status** | Pending |
-| **Pull Request** | |
+| **Status** | Completed |
+| **Pull Request** | [#584](https://github.com/metaschema-framework/metaschema-java/pull/584) |
 
 This PR extends the binding configuration to support overriding default collection implementation classes.
 
@@ -155,14 +155,29 @@ This PR extends the binding configuration to support overriding default collecti
 
 ### Acceptance Criteria
 
-- [ ] Binding configuration schema supports `<collection-class>` element
-- [ ] `DefaultBindingConfiguration` parses collection-class from XML
-- [ ] Override is applied in `getCollectionImplementationClass()`
-- [ ] Type compatibility validation (List vs Map)
-- [ ] Unit tests for collection-class parsing and application
-- [ ] `mvn checkstyle:check` passes
-- [ ] All tests pass: `mvn test`
-- [ ] Build succeeds: `mvn clean install -PCI -Prelease`
+- [x] Binding configuration schema supports `<collection-class>` element
+- [x] `DefaultBindingConfiguration` parses collection-class from XML
+- [x] Override is applied in `getCollectionImplementationClass()` (infrastructure ready)
+- [ ] Type compatibility validation (List vs Map) - deferred to PR 4
+- [x] Unit tests for collection-class parsing and application
+- [x] `mvn checkstyle:check` passes
+- [x] All tests pass: `mvn test`
+- [x] Build succeeds: `mvn clean install -PCI -Prelease`
+
+### Files Actually Modified
+
+| File | Changes |
+|------|---------|
+| `databind/src/main/metaschema/metaschema-bindings.yaml` | Added `collection-class` field and fixed `object-type` keywords |
+| `databind/src/main/java/.../config/binding/MetaschemaBindings.java` | Regenerated with `getCollectionClass()` method |
+| `databind/src/main/java/.../config/binding/MetaschemaBindingsModule.java` | Regenerated module class |
+| `databind/src/main/java/.../config/binding/package-info.java` | Regenerated package info |
+| `databind/src/main/java/.../codegen/config/DefaultBindingConfiguration.java` | Added property binding parsing |
+| `databind/src/main/java/.../codegen/config/IPropertyBindingConfiguration.java` | New interface for property bindings |
+| `databind/src/main/java/.../codegen/config/IMutablePropertyBindingConfiguration.java` | New mutable interface |
+| `databind/src/main/java/.../codegen/config/DefaultPropertyBindingConfiguration.java` | New implementation |
+| `databind/pom-bootstrap.xml` | Simplified bootstrap POM for direct generation |
+| `databind/src/test/resources/metaschema/binding-config-with-collection-class.xml` | Test configuration |
 
 ---
 
@@ -237,16 +252,74 @@ This PR creates the databind bootstrap infrastructure and regenerates the databi
 
 ---
 
+## PR 4: Parser Required Field Validation
+
+| Attribute | Value |
+|-----------|-------|
+| **Files Changed** | ~10 |
+| **Risk Level** | Medium |
+| **Dependencies** | PR 1 |
+| **Target Branch** | develop |
+| **Status** | Pending |
+| **Pull Request** | |
+
+This PR adds validation during parsing to emit meaningful errors when required fields are missing, and includes type compatibility validation for collection class overrides.
+
+### Motivation
+
+Currently, when a required field/flag is missing from input data, the generated binding classes have `@NonNull` annotations on getters but the parser doesn't actively validate and provide meaningful errors. This can result in confusing null pointer exceptions later rather than clear parse-time errors.
+
+### Files to Modify
+
+| File | Changes |
+|------|---------|
+| `databind/src/main/java/.../io/xml/DefaultXmlDeserializer.java` | Add required field validation |
+| `databind/src/main/java/.../io/json/DefaultJsonDeserializer.java` | Add required field validation |
+| `databind/src/main/java/.../codegen/typeinfo/AbstractModelInstanceTypeInfo.java` | Validate collection class type compatibility |
+
+### Implementation Approach
+
+1. **Required field validation at parse time**
+   - After parsing an object, check if all required fields (those with `@NonNull` getters) have values
+   - Emit meaningful error message with field name and source location
+   - Must be efficient - check once after parsing, not on every field access
+
+2. **Collection class type compatibility**
+   - When collection-class override is specified, validate at code generation time:
+     - For List fields: class must implement `java.util.List`
+     - For Map fields: class must implement `java.util.Map`
+   - Emit clear error if incompatible type specified
+
+3. **Performance considerations**
+   - Required field tracking should use bitsets or similar compact representation
+   - Validation should happen once per object, not per field
+   - No reflection at runtime - track requirements at class binding time
+
+### Acceptance Criteria
+
+- [ ] Parser validates required fields are present during deserialization
+- [ ] Missing required field produces clear error with field name and location
+- [ ] Collection class override validates type compatibility (List/Map)
+- [ ] Validation is efficient (no per-field overhead)
+- [ ] Unit tests for required field validation
+- [ ] Unit tests for collection class type validation
+- [ ] `mvn checkstyle:check` passes
+- [ ] All tests pass: `mvn test`
+- [ ] Build succeeds: `mvn clean install -PCI -Prelease`
+
+---
+
 ## PR Summary Table
 
 | PR | Description | Files | Risk | Dependencies | Status |
 |----|-------------|-------|------|--------------|--------|
 | 1 | Code generator improvements + metaschema-testing regeneration | 20 | Low | None | ✅ Completed ([#577](https://github.com/metaschema-framework/metaschema-java/pull/577)) |
-| 2 | Collection class override support | ~10 | Low | PR 1 | Pending |
+| 2 | Collection class override support | ~15 | Low | PR 1 | ✅ Completed |
 | 3 | Databind bootstrap setup + regeneration | ~35 | Medium | PR 1, PR 2 | Pending |
+| 4 | Parser required field validation | ~10 | Medium | PR 1 | Pending |
 
-**Total Estimated PRs**: 3
-**Total Estimated Files**: ~65
+**Total Estimated PRs**: 4
+**Total Estimated Files**: ~80
 
 ---
 

--- a/databind/pom-bootstrap.xml
+++ b/databind/pom-bootstrap.xml
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  This POM is used to regenerate the test suite binding classes.
+  This POM is used to regenerate the metaschema-bindings binding classes.
   It is NOT part of the normal build due to circular dependencies.
 
-  Usage: mvn -f metaschema-testing/pom-bootstrap.xml generate-sources
+  Usage: mvn -f databind/pom-bootstrap.xml generate-sources
 
   This will:
-  1. Delete existing generated classes in the testsuite package
+  1. Delete existing generated classes in the config/binding package
   2. Generate new binding classes directly into src/main/java
+
+  See metaschema-testing/pom-bootstrap.xml for a similar pattern.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
@@ -16,13 +18,13 @@
 		<artifactId>metaschema-framework</artifactId>
 		<version>3.0.0-SNAPSHOT</version>
 	</parent>
-	<artifactId>metaschema-testing-bootstrap</artifactId>
+	<artifactId>metaschema-databind-bootstrap</artifactId>
 	<packaging>pom</packaging>
-	<name>Metaschema Testing - Binding Class Generator</name>
-	<description>Standalone POM for regenerating test suite binding classes.</description>
+	<name>Metaschema Databind - Binding Class Generator</name>
+	<description>Standalone POM for regenerating metaschema-bindings binding classes.</description>
 
 	<properties>
-		<testsuite.package.dir>${project.basedir}/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite</testsuite.package.dir>
+		<binding.package.dir>${project.basedir}/src/main/java/gov/nist/secauto/metaschema/databind/config/binding</binding.package.dir>
 		<stale.file.dir>${project.build.directory}/metaschema</stale.file.dir>
 	</properties>
 
@@ -42,7 +44,7 @@
 							<excludeDefaultDirectories>true</excludeDefaultDirectories>
 							<filesets>
 								<fileset>
-									<directory>${testsuite.package.dir}</directory>
+									<directory>${binding.package.dir}</directory>
 									<includes>
 										<include>**/*.java</include>
 									</includes>
@@ -74,10 +76,10 @@
 							<metaschemaDir>${project.basedir}/src/main/metaschema</metaschemaDir>
 							<outputDirectory>${project.basedir}/src/main/java</outputDirectory>
 							<configs>
-								<config>${project.basedir}/src/main/metaschema-bindings/test-suite-bindings.xml</config>
+								<config>${project.basedir}/src/main/metaschema-bindings/metaschema-binding-bindings.xml</config>
 							</configs>
 							<includes>
-								<include>unit-tests.yaml</include>
+								<include>metaschema-bindings.yaml</include>
 							</includes>
 						</configuration>
 					</execution>

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/config/DefaultBindingConfiguration.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/config/DefaultBindingConfiguration.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -113,6 +114,32 @@ public class DefaultBindingConfiguration implements IBindingConfiguration {
     return config == null
         ? CollectionUtil.emptyList()
         : config.getInterfacesToImplement();
+  }
+
+  /**
+   * Get the property binding configuration for a specific property within a
+   * definition.
+   *
+   * @param definition
+   *          the containing definition
+   * @param propertyName
+   *          the name of the property
+   * @return the property binding configuration, or {@code null} if none is
+   *         configured
+   */
+  @Nullable
+  public IPropertyBindingConfiguration getPropertyBindingConfiguration(
+      @NonNull IModelDefinition definition,
+      @NonNull String propertyName) {
+    String moduleUri = ObjectUtils.notNull(definition.getContainingModule().getLocation().toASCIIString());
+    String definitionName = definition.getName();
+
+    MetaschemaBindingConfiguration metaschemaConfig = getMetaschemaBindingConfiguration(moduleUri);
+    if (metaschemaConfig == null) {
+      return null;
+    }
+
+    return metaschemaConfig.getPropertyBindingConfig(definitionName, propertyName);
   }
 
   /**
@@ -273,11 +300,7 @@ public class DefaultBindingConfiguration implements IBindingConfiguration {
   }
 
   private void processModelBindingConfig(MetaschemaBindings.ModelBinding model) {
-    URI namespaceUri = model.getNamespace();
-    if (namespaceUri == null) {
-      return;
-    }
-    String namespace = namespaceUri.toString();
+    String namespace = model.getNamespace().toString();
 
     MetaschemaBindings.ModelBinding.Java java = model.getJava();
     if (java != null) {
@@ -290,11 +313,7 @@ public class DefaultBindingConfiguration implements IBindingConfiguration {
 
   private void processMetaschemaBindingConfig(URL configResource, MetaschemaBindings.MetaschemaBinding metaschema)
       throws MalformedURLException, URISyntaxException {
-    URI hrefUri = metaschema.getHref();
-    if (hrefUri == null) {
-      return;
-    }
-    String href = hrefUri.toString();
+    String href = metaschema.getHref().toString();
     URL moduleUrl = new URL(configResource, href);
     String moduleUri = ObjectUtils.notNull(moduleUrl.toURI().normalize().toString());
 
@@ -313,6 +332,9 @@ public class DefaultBindingConfiguration implements IBindingConfiguration {
           IDefinitionBindingConfiguration config = metaschemaConfig.getAssemblyDefinitionBindingConfig(name);
           config = processDefinitionBindingConfiguration(config, assemblyBinding.getJava());
           metaschemaConfig.addAssemblyDefinitionBindingConfig(name, config);
+
+          // Process property bindings for this assembly
+          processAssemblyPropertyBindings(metaschemaConfig, name, assemblyBinding.getPropertyBindings());
         }
       }
     }
@@ -326,9 +348,112 @@ public class DefaultBindingConfiguration implements IBindingConfiguration {
           IDefinitionBindingConfiguration config = metaschemaConfig.getFieldDefinitionBindingConfig(name);
           config = processDefinitionBindingConfiguration(config, fieldBinding.getJava());
           metaschemaConfig.addFieldDefinitionBindingConfig(name, config);
+
+          // Process property bindings for this field
+          processFieldPropertyBindings(metaschemaConfig, name, fieldBinding.getPropertyBindings());
         }
       }
     }
+  }
+
+  /**
+   * Process property bindings from a definition binding element.
+   * <p>
+   * This generic helper method consolidates the common logic for processing
+   * property bindings from both assembly and field definition bindings.
+   *
+   * @param <P>
+   *          the property binding type
+   * @param <J>
+   *          the Java configuration type
+   * @param metaschemaConfig
+   *          the metaschema binding configuration to add property bindings to
+   * @param definitionName
+   *          the name of the containing definition
+   * @param propertyBindings
+   *          the list of property bindings to process
+   * @param nameAccessor
+   *          function to extract the property name from a binding
+   * @param javaAccessor
+   *          function to extract the Java config from a binding
+   * @param collectionClassAccessor
+   *          function to extract the collection class name from a Java config
+   */
+  private static <P, J> void processPropertyBindings(
+      @NonNull MetaschemaBindingConfiguration metaschemaConfig,
+      @NonNull String definitionName,
+      @Nullable List<P> propertyBindings,
+      @NonNull Function<P, String> nameAccessor,
+      @NonNull Function<P, J> javaAccessor,
+      @NonNull Function<J, String> collectionClassAccessor) {
+    if (propertyBindings == null) {
+      return;
+    }
+
+    for (P propertyBinding : propertyBindings) {
+      String propertyName = nameAccessor.apply(propertyBinding);
+      if (propertyName == null) {
+        continue;
+      }
+
+      J java = javaAccessor.apply(propertyBinding);
+      if (java == null) {
+        continue;
+      }
+
+      String collectionClassName = collectionClassAccessor.apply(java);
+      if (collectionClassName != null) {
+        IMutablePropertyBindingConfiguration config = new DefaultPropertyBindingConfiguration();
+        config.setCollectionClassName(collectionClassName);
+        metaschemaConfig.addPropertyBindingConfig(definitionName, propertyName, config);
+      }
+    }
+  }
+
+  /**
+   * Process property bindings from a define-assembly-binding element.
+   *
+   * @param metaschemaConfig
+   *          the metaschema binding configuration to add property bindings to
+   * @param definitionName
+   *          the name of the containing definition
+   * @param propertyBindings
+   *          the list of property bindings to process
+   */
+  private static void processAssemblyPropertyBindings(
+      @NonNull MetaschemaBindingConfiguration metaschemaConfig,
+      @NonNull String definitionName,
+      @Nullable List<MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.PropertyBinding> propertyBindings) {
+    processPropertyBindings(
+        metaschemaConfig,
+        definitionName,
+        propertyBindings,
+        MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.PropertyBinding::getName,
+        MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.PropertyBinding::getJava,
+        MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.PropertyBinding.Java::getCollectionClass);
+  }
+
+  /**
+   * Process property bindings from a define-field-binding element.
+   *
+   * @param metaschemaConfig
+   *          the metaschema binding configuration to add property bindings to
+   * @param definitionName
+   *          the name of the containing definition
+   * @param propertyBindings
+   *          the list of property bindings to process
+   */
+  private static void processFieldPropertyBindings(
+      @NonNull MetaschemaBindingConfiguration metaschemaConfig,
+      @NonNull String definitionName,
+      @Nullable List<MetaschemaBindings.MetaschemaBinding.DefineFieldBinding.PropertyBinding> propertyBindings) {
+    processPropertyBindings(
+        metaschemaConfig,
+        definitionName,
+        propertyBindings,
+        MetaschemaBindings.MetaschemaBinding.DefineFieldBinding.PropertyBinding::getName,
+        MetaschemaBindings.MetaschemaBinding.DefineFieldBinding.PropertyBinding::getJava,
+        MetaschemaBindings.MetaschemaBinding.DefineFieldBinding.PropertyBinding.Java::getCollectionClass);
   }
 
   @NonNull
@@ -392,6 +517,9 @@ public class DefaultBindingConfiguration implements IBindingConfiguration {
   public static final class MetaschemaBindingConfiguration {
     private final Map<String, IDefinitionBindingConfiguration> assemblyBindingConfigs = new ConcurrentHashMap<>();
     private final Map<String, IDefinitionBindingConfiguration> fieldBindingConfigs = new ConcurrentHashMap<>();
+    // Map structure: definition name -> property name -> property binding config
+    private final Map<String, Map<String, IPropertyBindingConfiguration>> propertyBindingConfigs
+        = new ConcurrentHashMap<>();
 
     private MetaschemaBindingConfiguration() {
     }
@@ -456,6 +584,48 @@ public class DefaultBindingConfiguration implements IBindingConfiguration {
     public IDefinitionBindingConfiguration addFieldDefinitionBindingConfig(@NonNull String name,
         @NonNull IDefinitionBindingConfiguration config) {
       return fieldBindingConfigs.put(name, config);
+    }
+
+    /**
+     * Get the property binding configuration for a specific property within a
+     * definition.
+     *
+     * @param definitionName
+     *          the name of the containing definition
+     * @param propertyName
+     *          the name of the property
+     * @return the property binding configuration, or {@code null} if none is
+     *         configured
+     */
+    @Nullable
+    public IPropertyBindingConfiguration getPropertyBindingConfig(
+        @NonNull String definitionName,
+        @NonNull String propertyName) {
+      Map<String, IPropertyBindingConfiguration> defProps = propertyBindingConfigs.get(definitionName);
+      return defProps == null ? null : defProps.get(propertyName);
+    }
+
+    /**
+     * Set the property binding configuration for a specific property within a
+     * definition.
+     *
+     * @param definitionName
+     *          the name of the containing definition
+     * @param propertyName
+     *          the name of the property
+     * @param config
+     *          the property binding configuration
+     * @return the old property binding configuration, or {@code null} if none was
+     *         previously configured
+     */
+    @Nullable
+    public IPropertyBindingConfiguration addPropertyBindingConfig(
+        @NonNull String definitionName,
+        @NonNull String propertyName,
+        @NonNull IPropertyBindingConfiguration config) {
+      return propertyBindingConfigs
+          .computeIfAbsent(definitionName, k -> new ConcurrentHashMap<>())
+          .put(propertyName, config);
     }
   }
 }

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/config/DefaultPropertyBindingConfiguration.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/config/DefaultPropertyBindingConfiguration.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.databind.codegen.config;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Default implementation of {@link IMutablePropertyBindingConfiguration}.
+ */
+public class DefaultPropertyBindingConfiguration implements IMutablePropertyBindingConfiguration {
+  @Nullable
+  private String collectionClassName;
+
+  /**
+   * Constructs a new empty property binding configuration.
+   */
+  public DefaultPropertyBindingConfiguration() {
+    // empty constructor
+  }
+
+  /**
+   * Constructs a new property binding configuration by copying values from an
+   * existing configuration.
+   *
+   * @param config
+   *          the configuration to copy from
+   */
+  public DefaultPropertyBindingConfiguration(@NonNull IPropertyBindingConfiguration config) {
+    this.collectionClassName = config.getCollectionClassName();
+  }
+
+  @Override
+  @Nullable
+  public String getCollectionClassName() {
+    return collectionClassName;
+  }
+
+  @Override
+  public void setCollectionClassName(@NonNull String className) {
+    this.collectionClassName = className;
+  }
+}

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/config/IMutablePropertyBindingConfiguration.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/config/IMutablePropertyBindingConfiguration.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.databind.codegen.config;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * A mutable extension of {@link IPropertyBindingConfiguration} that allows
+ * setting property binding configuration values.
+ */
+public interface IMutablePropertyBindingConfiguration extends IPropertyBindingConfiguration {
+
+  /**
+   * Set the fully qualified class name to use for collection initialization.
+   *
+   * @param className
+   *          the fully qualified class name
+   */
+  void setCollectionClassName(@NonNull String className);
+}

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/config/IPropertyBindingConfiguration.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/config/IPropertyBindingConfiguration.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.databind.codegen.config;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Provides binding configuration for a specific property (field or assembly
+ * instance) within a definition.
+ *
+ * <p>
+ * Property bindings allow fine-grained control over code generation for
+ * individual model instances, such as specifying custom collection
+ * implementation classes.
+ */
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
+public interface IPropertyBindingConfiguration {
+
+  /**
+   * Get the fully qualified class name to use for collection initialization.
+   *
+   * <p>
+   * When specified, this class will be used instead of the default
+   * {@link java.util.LinkedList} or {@link java.util.LinkedHashMap} for
+   * collection properties.
+   *
+   * @return the fully qualified class name, or {@code null} if the default
+   *         collection class should be used
+   */
+  @Nullable
+  String getCollectionClassName();
+}

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/DefaultMetaschemaClassFactory.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/DefaultMetaschemaClassFactory.java
@@ -25,6 +25,7 @@ import gov.nist.secauto.metaschema.core.model.IModelDefinition;
 import gov.nist.secauto.metaschema.core.model.IModule;
 import gov.nist.secauto.metaschema.core.util.CollectionUtil;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
+import gov.nist.secauto.metaschema.core.util.UriUtils;
 import gov.nist.secauto.metaschema.databind.IBindingContext;
 import gov.nist.secauto.metaschema.databind.codegen.IGeneratedClass;
 import gov.nist.secauto.metaschema.databind.codegen.IGeneratedDefinitionClass;
@@ -53,6 +54,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -110,6 +112,67 @@ public class DefaultMetaschemaClassFactory implements IMetaschemaClassFactory {
     return typeResolver;
   }
 
+  /**
+   * Calculates a relative path from the generated file location to the source
+   * Metaschema module.
+   *
+   * @param module
+   *          the source module
+   * @param javaPackage
+   *          the Java package of the generated file
+   * @param targetDirectory
+   *          the target directory where files are generated
+   * @return a relative path string if relativization succeeds, the module short
+   *         name if location is unavailable, or the absolute URI string if
+   *         relativization fails
+   */
+  @NonNull
+  private static String getRelativeSourcePath(
+      @NonNull IModule module,
+      @NonNull String javaPackage,
+      @NonNull Path targetDirectory) {
+    URI location = module.getLocation();
+    if (location == null) {
+      return module.getShortName();
+    }
+
+    try {
+      // Calculate the path to the generated file (targetDirectory + package path)
+      String packagePath = javaPackage.replace('.', '/');
+      Path generatedFileDir = targetDirectory.resolve(packagePath);
+      URI generatedDirUri = generatedFileDir.toUri();
+
+      // Calculate relative path from generated file directory to source file
+      return UriUtils.relativize(generatedDirUri, location, true).toString();
+    } catch (URISyntaxException ex) {
+      // Fall back to absolute URI if relativization fails
+      return location.toString();
+    }
+  }
+
+  /**
+   * Adds a file header comment indicating the file is generated from a Metaschema
+   * module.
+   *
+   * @param javaFileBuilder
+   *          the JavaFile builder to add the comment to
+   * @param module
+   *          the source module
+   * @param javaPackage
+   *          the Java package of the generated file
+   * @param targetDirectory
+   *          the target directory where the file will be generated
+   */
+  private static void addGeneratedFileComment(
+      @NonNull JavaFile.Builder javaFileBuilder,
+      @NonNull IModule module,
+      @NonNull String javaPackage,
+      @NonNull Path targetDirectory) {
+    String sourceReference = getRelativeSourcePath(module, javaPackage, targetDirectory);
+    javaFileBuilder.addFileComment("Generated from: $L\nDo not edit - changes will be lost when regenerated.",
+        sourceReference);
+  }
+
   @Override
   public IGeneratedModuleClass generateClass(
       IModule module,
@@ -120,7 +183,13 @@ public class DefaultMetaschemaClassFactory implements IMetaschemaClassFactory {
 
     TypeSpec.Builder classSpec = newClassBuilder(module, className);
 
-    JavaFile javaFile = JavaFile.builder(className.packageName(), classSpec.build()).build();
+    JavaFile.Builder javaFileBuilder = JavaFile.builder(className.packageName(), classSpec.build())
+        .skipJavaLangImports(true);
+
+    // Add file header comment indicating this is generated code
+    addGeneratedFileComment(javaFileBuilder, module, className.packageName(), targetDirectory);
+
+    JavaFile javaFile = javaFileBuilder.build();
     Path classFile = ObjectUtils.notNull(javaFile.writeToPath(targetDirectory));
 
     // now generate all related definition classes
@@ -187,7 +256,14 @@ public class DefaultMetaschemaClassFactory implements IMetaschemaClassFactory {
 
     TypeSpec.Builder classSpec = newClassBuilder(typeInfo, false);
 
-    JavaFile javaFile = JavaFile.builder(className.packageName(), classSpec.build()).build();
+    JavaFile.Builder javaFileBuilder = JavaFile.builder(className.packageName(), classSpec.build())
+        .skipJavaLangImports(true);
+
+    // Add file header comment indicating this is generated code
+    IModule module = typeInfo.getDefinition().getContainingModule();
+    addGeneratedFileComment(javaFileBuilder, module, className.packageName(), targetDirectory);
+
+    JavaFile javaFile = javaFileBuilder.build();
     Path classFile = ObjectUtils.notNull(javaFile.writeToPath(targetDirectory));
 
     return new DefaultGeneratedDefinitionClass(classFile, className, typeInfo.getDefinition());
@@ -206,6 +282,14 @@ public class DefaultMetaschemaClassFactory implements IMetaschemaClassFactory {
     try (PrintWriter writer = new PrintWriter(
         Files.newBufferedWriter(packageInfo, StandardOpenOption.CREATE, StandardOpenOption.WRITE,
             StandardOpenOption.TRUNCATE_EXISTING))) {
+      // Add file header comment indicating this is generated code
+      for (IGeneratedModuleClass moduleProduction : moduleProductions) {
+        IModule module = moduleProduction.getModule();
+        String sourceReference = getRelativeSourcePath(module, javaPackage, targetDirectory);
+        writer.format("// Generated from: %s%n", sourceReference);
+      }
+      writer.format("// Do not edit - changes will be lost when regenerated.%n");
+
       writer.format("@%1$s(moduleClass = {%n", MetaschemaPackage.class.getName());
 
       boolean first = true;
@@ -250,6 +334,15 @@ public class DefaultMetaschemaClassFactory implements IMetaschemaClassFactory {
         .addModifiers(Modifier.PUBLIC)
         .addModifiers(Modifier.FINAL);
 
+    // Add class-level Javadoc from module name and remarks
+    MarkupLine moduleName = module.getName();
+    builder.addJavadoc("$L", moduleName.toHtml());
+    MarkupMultiline moduleRemarks = module.getRemarks();
+    if (moduleRemarks != null) {
+      // toHtml() already wraps content in <p> tags, so just add a newline separator
+      builder.addJavadoc("\n$L", moduleRemarks.toHtml());
+    }
+
     builder.superclass(AbstractBoundModule.class);
     builder.addAnnotation(buildModuleAnnotation(module).build());
 
@@ -288,6 +381,11 @@ public class DefaultMetaschemaClassFactory implements IMetaschemaClassFactory {
 
     builder.addMethod(
         MethodSpec.constructorBuilder()
+            .addJavadoc("Construct a new module instance.\n\n")
+            .addJavadoc("@param importedModules\n")
+            .addJavadoc("          modules imported by this module\n")
+            .addJavadoc("@param bindingContext\n")
+            .addJavadoc("          the binding context to associate with this module\n")
             .addModifiers(Modifier.PUBLIC)
             .addParameter(
                 ParameterizedTypeName.get(ClassName.get(List.class),

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/config/binding/MetaschemaBindings.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/config/binding/MetaschemaBindings.java
@@ -2,9 +2,13 @@
  * SPDX-FileCopyrightText: none
  * SPDX-License-Identifier: CC0-1.0
  */
+// Generated from: ../../../../../../../../metaschema/metaschema-bindings.yaml
+// Do not edit - changes will be lost when regenerated.
 
 package gov.nist.secauto.metaschema.databind.config.binding;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import gov.nist.secauto.metaschema.core.datatype.adapter.TokenAdapter;
 import gov.nist.secauto.metaschema.core.datatype.adapter.UriAdapter;
 import gov.nist.secauto.metaschema.core.datatype.adapter.UriReferenceAdapter;
@@ -35,6 +39,10 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 public class MetaschemaBindings implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
+  /**
+   * Defines binding configurations that apply to a whole model described by a
+   * namespace.
+   */
   @BoundAssembly(
       formalName = "Model Binding",
       description = "Defines binding configurations that apply to a whole model described by a namespace.",
@@ -43,6 +51,9 @@ public class MetaschemaBindings implements IBoundObject {
       groupAs = @GroupAs(name = "model-bindings", inJson = JsonGroupAsBehavior.LIST))
   private List<ModelBinding> _modelBindings;
 
+  /**
+   * Defines a binding for a given metaschema identified by a relative URL.
+   */
   @BoundAssembly(
       formalName = "Metaschema Binding",
       description = "Defines a binding for a given metaschema identified by a relative URL.",
@@ -51,10 +62,23 @@ public class MetaschemaBindings implements IBoundObject {
       groupAs = @GroupAs(name = "metaschema-bindings", inJson = JsonGroupAsBehavior.LIST))
   private List<MetaschemaBinding> _metaschemaBindings;
 
+  /**
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings}
+   * instance with no metadata.
+   */
   public MetaschemaBindings() {
     this(null);
   }
 
+  /**
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings}
+   * instance with the specified metadata.
+   *
+   * @param data
+   *          the metaschema data, or {@code null} if none
+   */
   public MetaschemaBindings(IMetaschemaData data) {
     this.__metaschemaData = data;
   }
@@ -64,11 +88,34 @@ public class MetaschemaBindings implements IBoundObject {
     return __metaschemaData;
   }
 
+  /**
+   * Get the model Binding.
+   *
+   * <p>
+   * Defines binding configurations that apply to a whole model described by a
+   * namespace.
+   *
+   * @return the model-binding value
+   */
+  @NonNull
   public List<ModelBinding> getModelBindings() {
+    if (_modelBindings == null) {
+      _modelBindings = new LinkedList<>();
+    }
     return _modelBindings;
   }
 
-  public void setModelBindings(List<ModelBinding> value) {
+  /**
+   * Set the model Binding.
+   *
+   * <p>
+   * Defines binding configurations that apply to a whole model described by a
+   * namespace.
+   *
+   * @param value
+   *          the model-binding value to set
+   */
+  public void setModelBindings(@NonNull List<ModelBinding> value) {
     _modelBindings = value;
   }
 
@@ -100,11 +147,32 @@ public class MetaschemaBindings implements IBoundObject {
     return _modelBindings != null && _modelBindings.remove(value);
   }
 
+  /**
+   * Get the metaschema Binding.
+   *
+   * <p>
+   * Defines a binding for a given metaschema identified by a relative URL.
+   *
+   * @return the metaschema-binding value
+   */
+  @NonNull
   public List<MetaschemaBinding> getMetaschemaBindings() {
+    if (_metaschemaBindings == null) {
+      _metaschemaBindings = new LinkedList<>();
+    }
     return _metaschemaBindings;
   }
 
-  public void setMetaschemaBindings(List<MetaschemaBinding> value) {
+  /**
+   * Set the metaschema Binding.
+   *
+   * <p>
+   * Defines a binding for a given metaschema identified by a relative URL.
+   *
+   * @param value
+   *          the metaschema-binding value to set
+   */
+  public void setMetaschemaBindings(@NonNull List<MetaschemaBinding> value) {
     _metaschemaBindings = value;
   }
 
@@ -154,26 +222,43 @@ public class MetaschemaBindings implements IBoundObject {
     private final IMetaschemaData __metaschemaData;
 
     /**
-     * "A URI referencing the namespace of one or more related metaschema
-     * definitions."
+     * A URI referencing the namespace of one or more related metaschema
+     * definitions.
      */
     @BoundFlag(
         formalName = "Namespace",
         description = "A URI referencing the namespace of one or more related metaschema definitions.",
         name = "namespace",
+        required = true,
         typeAdapter = UriAdapter.class)
     private URI _namespace;
 
+    /**
+     * Java-specific binding configuration for a model namespace.
+     */
     @BoundAssembly(
         formalName = "Java Model Binding",
         description = "Java-specific binding configuration for a model namespace.",
         useName = "java")
     private Java _java;
 
+    /**
+     * Constructs a new
+     * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.ModelBinding}
+     * instance with no metadata.
+     */
     public ModelBinding() {
       this(null);
     }
 
+    /**
+     * Constructs a new
+     * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.ModelBinding}
+     * instance with the specified metadata.
+     *
+     * @param data
+     *          the metaschema data, or {@code null} if none
+     */
     public ModelBinding(IMetaschemaData data) {
       this.__metaschemaData = data;
     }
@@ -183,19 +268,57 @@ public class MetaschemaBindings implements IBoundObject {
       return __metaschemaData;
     }
 
+    /**
+     * Get the namespace.
+     *
+     * <p>
+     * A URI referencing the namespace of one or more related metaschema
+     * definitions.
+     *
+     * @return the namespace value
+     */
+    @NonNull
     public URI getNamespace() {
       return _namespace;
     }
 
-    public void setNamespace(URI value) {
+    /**
+     * Set the namespace.
+     *
+     * <p>
+     * A URI referencing the namespace of one or more related metaschema
+     * definitions.
+     *
+     * @param value
+     *          the namespace value to set
+     */
+    public void setNamespace(@NonNull URI value) {
       _namespace = value;
     }
 
+    /**
+     * Get the java Model Binding.
+     *
+     * <p>
+     * Java-specific binding configuration for a model namespace.
+     *
+     * @return the java value, or {@code null} if not set
+     */
+    @Nullable
     public Java getJava() {
       return _java;
     }
 
-    public void setJava(Java value) {
+    /**
+     * Set the java Model Binding.
+     *
+     * <p>
+     * Java-specific binding configuration for a model namespace.
+     *
+     * @param value
+     *          the java value to set
+     */
+    public void setJava(@Nullable Java value) {
       _java = value;
     }
 
@@ -215,6 +338,9 @@ public class MetaschemaBindings implements IBoundObject {
     public static class Java implements IBoundObject {
       private final IMetaschemaData __metaschemaData;
 
+      /**
+       * The Java package name to use for classes generated from this namespace.
+       */
       @BoundField(
           formalName = "Use Package Name",
           description = "The Java package name to use for classes generated from this namespace.",
@@ -222,10 +348,23 @@ public class MetaschemaBindings implements IBoundObject {
           typeAdapter = TokenAdapter.class)
       private String _usePackageName;
 
+      /**
+       * Constructs a new
+       * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.ModelBinding.Java}
+       * instance with no metadata.
+       */
       public Java() {
         this(null);
       }
 
+      /**
+       * Constructs a new
+       * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.ModelBinding.Java}
+       * instance with the specified metadata.
+       *
+       * @param data
+       *          the metaschema data, or {@code null} if none
+       */
       public Java(IMetaschemaData data) {
         this.__metaschemaData = data;
       }
@@ -235,11 +374,29 @@ public class MetaschemaBindings implements IBoundObject {
         return __metaschemaData;
       }
 
+      /**
+       * Get the use Package Name.
+       *
+       * <p>
+       * The Java package name to use for classes generated from this namespace.
+       *
+       * @return the use-package-name value, or {@code null} if not set
+       */
+      @Nullable
       public String getUsePackageName() {
         return _usePackageName;
       }
 
-      public void setUsePackageName(String value) {
+      /**
+       * Set the use Package Name.
+       *
+       * <p>
+       * The Java package name to use for classes generated from this namespace.
+       *
+       * @param value
+       *          the use-package-name value to set
+       */
+      public void setUsePackageName(@Nullable String value) {
         _usePackageName = value;
       }
 
@@ -262,16 +419,21 @@ public class MetaschemaBindings implements IBoundObject {
     private final IMetaschemaData __metaschemaData;
 
     /**
-     * "A URL relative to this binding configuration file, pointing to a metaschema
-     * definition."
+     * A URL relative to this binding configuration file, pointing to a metaschema
+     * definition.
      */
     @BoundFlag(
         formalName = "Href",
         description = "A URL relative to this binding configuration file, pointing to a metaschema definition.",
         name = "href",
+        required = true,
         typeAdapter = UriReferenceAdapter.class)
     private URI _href;
 
+    /**
+     * Provides binding configurations for a given defined assembly within the
+     * parent metaschema.
+     */
     @BoundAssembly(
         formalName = "Define Assembly Binding",
         description = "Provides binding configurations for a given defined assembly within the parent metaschema.",
@@ -280,6 +442,10 @@ public class MetaschemaBindings implements IBoundObject {
         groupAs = @GroupAs(name = "define-assembly-bindings", inJson = JsonGroupAsBehavior.LIST))
     private List<DefineAssemblyBinding> _defineAssemblyBindings;
 
+    /**
+     * Provides binding configurations for a given defined field within the parent
+     * metaschema.
+     */
     @BoundAssembly(
         formalName = "Define Field Binding",
         description = "Provides binding configurations for a given defined field within the parent metaschema.",
@@ -288,10 +454,23 @@ public class MetaschemaBindings implements IBoundObject {
         groupAs = @GroupAs(name = "define-field-bindings", inJson = JsonGroupAsBehavior.LIST))
     private List<DefineFieldBinding> _defineFieldBindings;
 
+    /**
+     * Constructs a new
+     * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding}
+     * instance with no metadata.
+     */
     public MetaschemaBinding() {
       this(null);
     }
 
+    /**
+     * Constructs a new
+     * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding}
+     * instance with the specified metadata.
+     *
+     * @param data
+     *          the metaschema data, or {@code null} if none
+     */
     public MetaschemaBinding(IMetaschemaData data) {
       this.__metaschemaData = data;
     }
@@ -301,19 +480,62 @@ public class MetaschemaBindings implements IBoundObject {
       return __metaschemaData;
     }
 
+    /**
+     * Get the href.
+     *
+     * <p>
+     * A URL relative to this binding configuration file, pointing to a metaschema
+     * definition.
+     *
+     * @return the href value
+     */
+    @NonNull
     public URI getHref() {
       return _href;
     }
 
-    public void setHref(URI value) {
+    /**
+     * Set the href.
+     *
+     * <p>
+     * A URL relative to this binding configuration file, pointing to a metaschema
+     * definition.
+     *
+     * @param value
+     *          the href value to set
+     */
+    public void setHref(@NonNull URI value) {
       _href = value;
     }
 
+    /**
+     * Get the define Assembly Binding.
+     *
+     * <p>
+     * Provides binding configurations for a given defined assembly within the
+     * parent metaschema.
+     *
+     * @return the define-assembly-binding value
+     */
+    @NonNull
     public List<DefineAssemblyBinding> getDefineAssemblyBindings() {
+      if (_defineAssemblyBindings == null) {
+        _defineAssemblyBindings = new LinkedList<>();
+      }
       return _defineAssemblyBindings;
     }
 
-    public void setDefineAssemblyBindings(List<DefineAssemblyBinding> value) {
+    /**
+     * Set the define Assembly Binding.
+     *
+     * <p>
+     * Provides binding configurations for a given defined assembly within the
+     * parent metaschema.
+     *
+     * @param value
+     *          the define-assembly-binding value to set
+     */
+    public void setDefineAssemblyBindings(@NonNull List<DefineAssemblyBinding> value) {
       _defineAssemblyBindings = value;
     }
 
@@ -345,11 +567,34 @@ public class MetaschemaBindings implements IBoundObject {
       return _defineAssemblyBindings != null && _defineAssemblyBindings.remove(value);
     }
 
+    /**
+     * Get the define Field Binding.
+     *
+     * <p>
+     * Provides binding configurations for a given defined field within the parent
+     * metaschema.
+     *
+     * @return the define-field-binding value
+     */
+    @NonNull
     public List<DefineFieldBinding> getDefineFieldBindings() {
+      if (_defineFieldBindings == null) {
+        _defineFieldBindings = new LinkedList<>();
+      }
       return _defineFieldBindings;
     }
 
-    public void setDefineFieldBindings(List<DefineFieldBinding> value) {
+    /**
+     * Set the define Field Binding.
+     *
+     * <p>
+     * Provides binding configurations for a given defined field within the parent
+     * metaschema.
+     *
+     * @param value
+     *          the define-field-binding value to set
+     */
+    public void setDefineFieldBindings(@NonNull List<DefineFieldBinding> value) {
       _defineFieldBindings = value;
     }
 
@@ -399,25 +644,53 @@ public class MetaschemaBindings implements IBoundObject {
       private final IMetaschemaData __metaschemaData;
 
       /**
-       * "The name of the metaschema assembly."
+       * The name of the metaschema assembly.
        */
       @BoundFlag(
           formalName = "Name",
           description = "The name of the metaschema assembly.",
           name = "name",
+          required = true,
           typeAdapter = TokenAdapter.class)
       private String _name;
 
+      /**
+       * Field and assembly binding configurations for Java bound classes.
+       */
       @BoundAssembly(
           formalName = "Java Object Definition Binding",
           description = "Field and assembly binding configurations for Java bound classes.",
           useName = "java")
       private Java _java;
 
+      /**
+       * Provides binding configurations for a property within the parent definition.
+       */
+      @BoundAssembly(
+          formalName = "Property Binding",
+          description = "Provides binding configurations for a property within the parent definition.",
+          useName = "property-binding",
+          maxOccurs = -1,
+          groupAs = @GroupAs(name = "property-bindings", inJson = JsonGroupAsBehavior.LIST))
+      private List<PropertyBinding> _propertyBindings;
+
+      /**
+       * Constructs a new
+       * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding}
+       * instance with no metadata.
+       */
       public DefineAssemblyBinding() {
         this(null);
       }
 
+      /**
+       * Constructs a new
+       * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding}
+       * instance with the specified metadata.
+       *
+       * @param data
+       *          the metaschema data, or {@code null} if none
+       */
       public DefineAssemblyBinding(IMetaschemaData data) {
         this.__metaschemaData = data;
       }
@@ -427,20 +700,113 @@ public class MetaschemaBindings implements IBoundObject {
         return __metaschemaData;
       }
 
+      /**
+       * Get the name.
+       *
+       * <p>
+       * The name of the metaschema assembly.
+       *
+       * @return the name value
+       */
+      @NonNull
       public String getName() {
         return _name;
       }
 
-      public void setName(String value) {
+      /**
+       * Set the name.
+       *
+       * <p>
+       * The name of the metaschema assembly.
+       *
+       * @param value
+       *          the name value to set
+       */
+      public void setName(@NonNull String value) {
         _name = value;
       }
 
+      /**
+       * Get the java Object Definition Binding.
+       *
+       * <p>
+       * Field and assembly binding configurations for Java bound classes.
+       *
+       * @return the java value, or {@code null} if not set
+       */
+      @Nullable
       public Java getJava() {
         return _java;
       }
 
-      public void setJava(Java value) {
+      /**
+       * Set the java Object Definition Binding.
+       *
+       * <p>
+       * Field and assembly binding configurations for Java bound classes.
+       *
+       * @param value
+       *          the java value to set
+       */
+      public void setJava(@Nullable Java value) {
         _java = value;
+      }
+
+      /**
+       * Get the property Binding.
+       *
+       * <p>
+       * Provides binding configurations for a property within the parent definition.
+       *
+       * @return the property-binding value
+       */
+      @NonNull
+      public List<PropertyBinding> getPropertyBindings() {
+        if (_propertyBindings == null) {
+          _propertyBindings = new LinkedList<>();
+        }
+        return _propertyBindings;
+      }
+
+      /**
+       * Set the property Binding.
+       *
+       * <p>
+       * Provides binding configurations for a property within the parent definition.
+       *
+       * @param value
+       *          the property-binding value to set
+       */
+      public void setPropertyBindings(@NonNull List<PropertyBinding> value) {
+        _propertyBindings = value;
+      }
+
+      /**
+       * Add a new {@link PropertyBinding} item to the underlying collection.
+       *
+       * @param item
+       *          the item to add
+       * @return {@code true}
+       */
+      public boolean addPropertyBinding(PropertyBinding item) {
+        PropertyBinding value = ObjectUtils.requireNonNull(item, "item cannot be null");
+        if (_propertyBindings == null) {
+          _propertyBindings = new LinkedList<>();
+        }
+        return _propertyBindings.add(value);
+      }
+
+      /**
+       * Remove the first matching {@link PropertyBinding} item from the underlying
+       * collection.
+       *
+       * @param item
+       *          the item to remove
+       * @return {@code true} if the item was removed or {@code false} otherwise
+       */
+      public boolean removePropertyBinding(PropertyBinding item) {
+        PropertyBinding value = ObjectUtils.requireNonNull(item, "item cannot be null");
+        return _propertyBindings != null && _propertyBindings.remove(value);
       }
 
       @Override
@@ -459,6 +825,9 @@ public class MetaschemaBindings implements IBoundObject {
       public static class Java implements IBoundObject {
         private final IMetaschemaData __metaschemaData;
 
+        /**
+         * The Java class name to use for the generated class.
+         */
         @BoundField(
             formalName = "Use Class Name",
             description = "The Java class name to use for the generated class.",
@@ -466,6 +835,10 @@ public class MetaschemaBindings implements IBoundObject {
             typeAdapter = TokenAdapter.class)
         private String _useClassName;
 
+        /**
+         * A fully qualified Java interface name that the generated class should
+         * implement.
+         */
         @BoundField(
             formalName = "Implement Interface",
             description = "A fully qualified Java interface name that the generated class should implement.",
@@ -475,6 +848,9 @@ public class MetaschemaBindings implements IBoundObject {
             typeAdapter = TokenAdapter.class)
         private List<String> _implementInterfaces;
 
+        /**
+         * A fully qualified Java class name that the generated class should extend.
+         */
         @BoundField(
             formalName = "Extend Base Class",
             description = "A fully qualified Java class name that the generated class should extend.",
@@ -482,10 +858,33 @@ public class MetaschemaBindings implements IBoundObject {
             typeAdapter = TokenAdapter.class)
         private String _extendBaseClass;
 
+        /**
+         * A fully qualified Java collection class name to use instead of the default.
+         */
+        @BoundField(
+            formalName = "Collection Class",
+            description = "A fully qualified Java collection class name to use instead of the default.",
+            useName = "collection-class",
+            typeAdapter = TokenAdapter.class)
+        private String _collectionClass;
+
+        /**
+         * Constructs a new
+         * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.Java}
+         * instance with no metadata.
+         */
         public Java() {
           this(null);
         }
 
+        /**
+         * Constructs a new
+         * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.Java}
+         * instance with the specified metadata.
+         *
+         * @param data
+         *          the metaschema data, or {@code null} if none
+         */
         public Java(IMetaschemaData data) {
           this.__metaschemaData = data;
         }
@@ -495,19 +894,60 @@ public class MetaschemaBindings implements IBoundObject {
           return __metaschemaData;
         }
 
+        /**
+         * Get the use Class Name.
+         *
+         * <p>
+         * The Java class name to use for the generated class.
+         *
+         * @return the use-class-name value, or {@code null} if not set
+         */
+        @Nullable
         public String getUseClassName() {
           return _useClassName;
         }
 
-        public void setUseClassName(String value) {
+        /**
+         * Set the use Class Name.
+         *
+         * <p>
+         * The Java class name to use for the generated class.
+         *
+         * @param value
+         *          the use-class-name value to set
+         */
+        public void setUseClassName(@Nullable String value) {
           _useClassName = value;
         }
 
+        /**
+         * Get the implement Interface.
+         *
+         * <p>
+         * A fully qualified Java interface name that the generated class should
+         * implement.
+         *
+         * @return the implement-interface value
+         */
+        @NonNull
         public List<String> getImplementInterfaces() {
+          if (_implementInterfaces == null) {
+            _implementInterfaces = new LinkedList<>();
+          }
           return _implementInterfaces;
         }
 
-        public void setImplementInterfaces(List<String> value) {
+        /**
+         * Set the implement Interface.
+         *
+         * <p>
+         * A fully qualified Java interface name that the generated class should
+         * implement.
+         *
+         * @param value
+         *          the implement-interface value to set
+         */
+        public void setImplementInterfaces(@NonNull List<String> value) {
           _implementInterfaces = value;
         }
 
@@ -538,17 +978,255 @@ public class MetaschemaBindings implements IBoundObject {
           return _implementInterfaces != null && _implementInterfaces.remove(value);
         }
 
+        /**
+         * Get the extend Base Class.
+         *
+         * <p>
+         * A fully qualified Java class name that the generated class should extend.
+         *
+         * @return the extend-base-class value, or {@code null} if not set
+         */
+        @Nullable
         public String getExtendBaseClass() {
           return _extendBaseClass;
         }
 
-        public void setExtendBaseClass(String value) {
+        /**
+         * Set the extend Base Class.
+         *
+         * <p>
+         * A fully qualified Java class name that the generated class should extend.
+         *
+         * @param value
+         *          the extend-base-class value to set
+         */
+        public void setExtendBaseClass(@Nullable String value) {
           _extendBaseClass = value;
+        }
+
+        /**
+         * Get the collection Class.
+         *
+         * <p>
+         * A fully qualified Java collection class name to use instead of the default.
+         *
+         * @return the collection-class value, or {@code null} if not set
+         */
+        @Nullable
+        public String getCollectionClass() {
+          return _collectionClass;
+        }
+
+        /**
+         * Set the collection Class.
+         *
+         * <p>
+         * A fully qualified Java collection class name to use instead of the default.
+         *
+         * @param value
+         *          the collection-class value to set
+         */
+        public void setCollectionClass(@Nullable String value) {
+          _collectionClass = value;
         }
 
         @Override
         public String toString() {
           return new ReflectionToStringBuilder(this, ToStringStyle.MULTI_LINE_STYLE).toString();
+        }
+      }
+
+      /**
+       * Provides binding configurations for a property within the parent definition.
+       */
+      @MetaschemaAssembly(
+          formalName = "Property Binding",
+          description = "Provides binding configurations for a property within the parent definition.",
+          name = "property-binding",
+          moduleClass = MetaschemaBindingsModule.class)
+      public static class PropertyBinding implements IBoundObject {
+        private final IMetaschemaData __metaschemaData;
+
+        /**
+         * The name of the property within the parent definition.
+         */
+        @BoundFlag(
+            formalName = "Name",
+            description = "The name of the property within the parent definition.",
+            name = "name",
+            required = true,
+            typeAdapter = TokenAdapter.class)
+        private String _name;
+
+        /**
+         * Java-specific binding configuration for a property.
+         */
+        @BoundAssembly(
+            formalName = "Java Property Binding",
+            description = "Java-specific binding configuration for a property.",
+            useName = "java")
+        private Java _java;
+
+        /**
+         * Constructs a new
+         * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.PropertyBinding}
+         * instance with no metadata.
+         */
+        public PropertyBinding() {
+          this(null);
+        }
+
+        /**
+         * Constructs a new
+         * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.PropertyBinding}
+         * instance with the specified metadata.
+         *
+         * @param data
+         *          the metaschema data, or {@code null} if none
+         */
+        public PropertyBinding(IMetaschemaData data) {
+          this.__metaschemaData = data;
+        }
+
+        @Override
+        public IMetaschemaData getMetaschemaData() {
+          return __metaschemaData;
+        }
+
+        /**
+         * Get the name.
+         *
+         * <p>
+         * The name of the property within the parent definition.
+         *
+         * @return the name value
+         */
+        @NonNull
+        public String getName() {
+          return _name;
+        }
+
+        /**
+         * Set the name.
+         *
+         * <p>
+         * The name of the property within the parent definition.
+         *
+         * @param value
+         *          the name value to set
+         */
+        public void setName(@NonNull String value) {
+          _name = value;
+        }
+
+        /**
+         * Get the java Property Binding.
+         *
+         * <p>
+         * Java-specific binding configuration for a property.
+         *
+         * @return the java value, or {@code null} if not set
+         */
+        @Nullable
+        public Java getJava() {
+          return _java;
+        }
+
+        /**
+         * Set the java Property Binding.
+         *
+         * <p>
+         * Java-specific binding configuration for a property.
+         *
+         * @param value
+         *          the java value to set
+         */
+        public void setJava(@Nullable Java value) {
+          _java = value;
+        }
+
+        @Override
+        public String toString() {
+          return new ReflectionToStringBuilder(this, ToStringStyle.MULTI_LINE_STYLE).toString();
+        }
+
+        /**
+         * Java-specific binding configuration for a property.
+         */
+        @MetaschemaAssembly(
+            formalName = "Java Property Binding",
+            description = "Java-specific binding configuration for a property.",
+            name = "java",
+            moduleClass = MetaschemaBindingsModule.class)
+        public static class Java implements IBoundObject {
+          private final IMetaschemaData __metaschemaData;
+
+          /**
+           * A fully qualified Java collection class name to use instead of the default.
+           */
+          @BoundField(
+              formalName = "Collection Class",
+              description = "A fully qualified Java collection class name to use instead of the default.",
+              useName = "collection-class",
+              typeAdapter = TokenAdapter.class)
+          private String _collectionClass;
+
+          /**
+           * Constructs a new
+           * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.PropertyBinding.Java}
+           * instance with no metadata.
+           */
+          public Java() {
+            this(null);
+          }
+
+          /**
+           * Constructs a new
+           * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.PropertyBinding.Java}
+           * instance with the specified metadata.
+           *
+           * @param data
+           *          the metaschema data, or {@code null} if none
+           */
+          public Java(IMetaschemaData data) {
+            this.__metaschemaData = data;
+          }
+
+          @Override
+          public IMetaschemaData getMetaschemaData() {
+            return __metaschemaData;
+          }
+
+          /**
+           * Get the collection Class.
+           *
+           * <p>
+           * A fully qualified Java collection class name to use instead of the default.
+           *
+           * @return the collection-class value, or {@code null} if not set
+           */
+          @Nullable
+          public String getCollectionClass() {
+            return _collectionClass;
+          }
+
+          /**
+           * Set the collection Class.
+           *
+           * <p>
+           * A fully qualified Java collection class name to use instead of the default.
+           *
+           * @param value
+           *          the collection-class value to set
+           */
+          public void setCollectionClass(@Nullable String value) {
+            _collectionClass = value;
+          }
+
+          @Override
+          public String toString() {
+            return new ReflectionToStringBuilder(this, ToStringStyle.MULTI_LINE_STYLE).toString();
+          }
         }
       }
     }
@@ -566,25 +1244,53 @@ public class MetaschemaBindings implements IBoundObject {
       private final IMetaschemaData __metaschemaData;
 
       /**
-       * "The name of the metaschema field."
+       * The name of the metaschema field.
        */
       @BoundFlag(
           formalName = "Name",
           description = "The name of the metaschema field.",
           name = "name",
+          required = true,
           typeAdapter = TokenAdapter.class)
       private String _name;
 
+      /**
+       * Field and assembly binding configurations for Java bound classes.
+       */
       @BoundAssembly(
           formalName = "Java Object Definition Binding",
           description = "Field and assembly binding configurations for Java bound classes.",
           useName = "java")
       private Java _java;
 
+      /**
+       * Provides binding configurations for a property within the parent definition.
+       */
+      @BoundAssembly(
+          formalName = "Property Binding",
+          description = "Provides binding configurations for a property within the parent definition.",
+          useName = "property-binding",
+          maxOccurs = -1,
+          groupAs = @GroupAs(name = "property-bindings", inJson = JsonGroupAsBehavior.LIST))
+      private List<PropertyBinding> _propertyBindings;
+
+      /**
+       * Constructs a new
+       * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineFieldBinding}
+       * instance with no metadata.
+       */
       public DefineFieldBinding() {
         this(null);
       }
 
+      /**
+       * Constructs a new
+       * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineFieldBinding}
+       * instance with the specified metadata.
+       *
+       * @param data
+       *          the metaschema data, or {@code null} if none
+       */
       public DefineFieldBinding(IMetaschemaData data) {
         this.__metaschemaData = data;
       }
@@ -594,20 +1300,113 @@ public class MetaschemaBindings implements IBoundObject {
         return __metaschemaData;
       }
 
+      /**
+       * Get the name.
+       *
+       * <p>
+       * The name of the metaschema field.
+       *
+       * @return the name value
+       */
+      @NonNull
       public String getName() {
         return _name;
       }
 
-      public void setName(String value) {
+      /**
+       * Set the name.
+       *
+       * <p>
+       * The name of the metaschema field.
+       *
+       * @param value
+       *          the name value to set
+       */
+      public void setName(@NonNull String value) {
         _name = value;
       }
 
+      /**
+       * Get the java Object Definition Binding.
+       *
+       * <p>
+       * Field and assembly binding configurations for Java bound classes.
+       *
+       * @return the java value, or {@code null} if not set
+       */
+      @Nullable
       public Java getJava() {
         return _java;
       }
 
-      public void setJava(Java value) {
+      /**
+       * Set the java Object Definition Binding.
+       *
+       * <p>
+       * Field and assembly binding configurations for Java bound classes.
+       *
+       * @param value
+       *          the java value to set
+       */
+      public void setJava(@Nullable Java value) {
         _java = value;
+      }
+
+      /**
+       * Get the property Binding.
+       *
+       * <p>
+       * Provides binding configurations for a property within the parent definition.
+       *
+       * @return the property-binding value
+       */
+      @NonNull
+      public List<PropertyBinding> getPropertyBindings() {
+        if (_propertyBindings == null) {
+          _propertyBindings = new LinkedList<>();
+        }
+        return _propertyBindings;
+      }
+
+      /**
+       * Set the property Binding.
+       *
+       * <p>
+       * Provides binding configurations for a property within the parent definition.
+       *
+       * @param value
+       *          the property-binding value to set
+       */
+      public void setPropertyBindings(@NonNull List<PropertyBinding> value) {
+        _propertyBindings = value;
+      }
+
+      /**
+       * Add a new {@link PropertyBinding} item to the underlying collection.
+       *
+       * @param item
+       *          the item to add
+       * @return {@code true}
+       */
+      public boolean addPropertyBinding(PropertyBinding item) {
+        PropertyBinding value = ObjectUtils.requireNonNull(item, "item cannot be null");
+        if (_propertyBindings == null) {
+          _propertyBindings = new LinkedList<>();
+        }
+        return _propertyBindings.add(value);
+      }
+
+      /**
+       * Remove the first matching {@link PropertyBinding} item from the underlying
+       * collection.
+       *
+       * @param item
+       *          the item to remove
+       * @return {@code true} if the item was removed or {@code false} otherwise
+       */
+      public boolean removePropertyBinding(PropertyBinding item) {
+        PropertyBinding value = ObjectUtils.requireNonNull(item, "item cannot be null");
+        return _propertyBindings != null && _propertyBindings.remove(value);
       }
 
       @Override
@@ -626,6 +1425,9 @@ public class MetaschemaBindings implements IBoundObject {
       public static class Java implements IBoundObject {
         private final IMetaschemaData __metaschemaData;
 
+        /**
+         * The Java class name to use for the generated class.
+         */
         @BoundField(
             formalName = "Use Class Name",
             description = "The Java class name to use for the generated class.",
@@ -633,6 +1435,10 @@ public class MetaschemaBindings implements IBoundObject {
             typeAdapter = TokenAdapter.class)
         private String _useClassName;
 
+        /**
+         * A fully qualified Java interface name that the generated class should
+         * implement.
+         */
         @BoundField(
             formalName = "Implement Interface",
             description = "A fully qualified Java interface name that the generated class should implement.",
@@ -642,6 +1448,9 @@ public class MetaschemaBindings implements IBoundObject {
             typeAdapter = TokenAdapter.class)
         private List<String> _implementInterfaces;
 
+        /**
+         * A fully qualified Java class name that the generated class should extend.
+         */
         @BoundField(
             formalName = "Extend Base Class",
             description = "A fully qualified Java class name that the generated class should extend.",
@@ -649,10 +1458,33 @@ public class MetaschemaBindings implements IBoundObject {
             typeAdapter = TokenAdapter.class)
         private String _extendBaseClass;
 
+        /**
+         * A fully qualified Java collection class name to use instead of the default.
+         */
+        @BoundField(
+            formalName = "Collection Class",
+            description = "A fully qualified Java collection class name to use instead of the default.",
+            useName = "collection-class",
+            typeAdapter = TokenAdapter.class)
+        private String _collectionClass;
+
+        /**
+         * Constructs a new
+         * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineFieldBinding.Java}
+         * instance with no metadata.
+         */
         public Java() {
           this(null);
         }
 
+        /**
+         * Constructs a new
+         * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineFieldBinding.Java}
+         * instance with the specified metadata.
+         *
+         * @param data
+         *          the metaschema data, or {@code null} if none
+         */
         public Java(IMetaschemaData data) {
           this.__metaschemaData = data;
         }
@@ -662,19 +1494,60 @@ public class MetaschemaBindings implements IBoundObject {
           return __metaschemaData;
         }
 
+        /**
+         * Get the use Class Name.
+         *
+         * <p>
+         * The Java class name to use for the generated class.
+         *
+         * @return the use-class-name value, or {@code null} if not set
+         */
+        @Nullable
         public String getUseClassName() {
           return _useClassName;
         }
 
-        public void setUseClassName(String value) {
+        /**
+         * Set the use Class Name.
+         *
+         * <p>
+         * The Java class name to use for the generated class.
+         *
+         * @param value
+         *          the use-class-name value to set
+         */
+        public void setUseClassName(@Nullable String value) {
           _useClassName = value;
         }
 
+        /**
+         * Get the implement Interface.
+         *
+         * <p>
+         * A fully qualified Java interface name that the generated class should
+         * implement.
+         *
+         * @return the implement-interface value
+         */
+        @NonNull
         public List<String> getImplementInterfaces() {
+          if (_implementInterfaces == null) {
+            _implementInterfaces = new LinkedList<>();
+          }
           return _implementInterfaces;
         }
 
-        public void setImplementInterfaces(List<String> value) {
+        /**
+         * Set the implement Interface.
+         *
+         * <p>
+         * A fully qualified Java interface name that the generated class should
+         * implement.
+         *
+         * @param value
+         *          the implement-interface value to set
+         */
+        public void setImplementInterfaces(@NonNull List<String> value) {
           _implementInterfaces = value;
         }
 
@@ -705,17 +1578,255 @@ public class MetaschemaBindings implements IBoundObject {
           return _implementInterfaces != null && _implementInterfaces.remove(value);
         }
 
+        /**
+         * Get the extend Base Class.
+         *
+         * <p>
+         * A fully qualified Java class name that the generated class should extend.
+         *
+         * @return the extend-base-class value, or {@code null} if not set
+         */
+        @Nullable
         public String getExtendBaseClass() {
           return _extendBaseClass;
         }
 
-        public void setExtendBaseClass(String value) {
+        /**
+         * Set the extend Base Class.
+         *
+         * <p>
+         * A fully qualified Java class name that the generated class should extend.
+         *
+         * @param value
+         *          the extend-base-class value to set
+         */
+        public void setExtendBaseClass(@Nullable String value) {
           _extendBaseClass = value;
+        }
+
+        /**
+         * Get the collection Class.
+         *
+         * <p>
+         * A fully qualified Java collection class name to use instead of the default.
+         *
+         * @return the collection-class value, or {@code null} if not set
+         */
+        @Nullable
+        public String getCollectionClass() {
+          return _collectionClass;
+        }
+
+        /**
+         * Set the collection Class.
+         *
+         * <p>
+         * A fully qualified Java collection class name to use instead of the default.
+         *
+         * @param value
+         *          the collection-class value to set
+         */
+        public void setCollectionClass(@Nullable String value) {
+          _collectionClass = value;
         }
 
         @Override
         public String toString() {
           return new ReflectionToStringBuilder(this, ToStringStyle.MULTI_LINE_STYLE).toString();
+        }
+      }
+
+      /**
+       * Provides binding configurations for a property within the parent definition.
+       */
+      @MetaschemaAssembly(
+          formalName = "Property Binding",
+          description = "Provides binding configurations for a property within the parent definition.",
+          name = "property-binding",
+          moduleClass = MetaschemaBindingsModule.class)
+      public static class PropertyBinding implements IBoundObject {
+        private final IMetaschemaData __metaschemaData;
+
+        /**
+         * The name of the property within the parent definition.
+         */
+        @BoundFlag(
+            formalName = "Name",
+            description = "The name of the property within the parent definition.",
+            name = "name",
+            required = true,
+            typeAdapter = TokenAdapter.class)
+        private String _name;
+
+        /**
+         * Java-specific binding configuration for a property.
+         */
+        @BoundAssembly(
+            formalName = "Java Property Binding",
+            description = "Java-specific binding configuration for a property.",
+            useName = "java")
+        private Java _java;
+
+        /**
+         * Constructs a new
+         * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineFieldBinding.PropertyBinding}
+         * instance with no metadata.
+         */
+        public PropertyBinding() {
+          this(null);
+        }
+
+        /**
+         * Constructs a new
+         * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineFieldBinding.PropertyBinding}
+         * instance with the specified metadata.
+         *
+         * @param data
+         *          the metaschema data, or {@code null} if none
+         */
+        public PropertyBinding(IMetaschemaData data) {
+          this.__metaschemaData = data;
+        }
+
+        @Override
+        public IMetaschemaData getMetaschemaData() {
+          return __metaschemaData;
+        }
+
+        /**
+         * Get the name.
+         *
+         * <p>
+         * The name of the property within the parent definition.
+         *
+         * @return the name value
+         */
+        @NonNull
+        public String getName() {
+          return _name;
+        }
+
+        /**
+         * Set the name.
+         *
+         * <p>
+         * The name of the property within the parent definition.
+         *
+         * @param value
+         *          the name value to set
+         */
+        public void setName(@NonNull String value) {
+          _name = value;
+        }
+
+        /**
+         * Get the java Property Binding.
+         *
+         * <p>
+         * Java-specific binding configuration for a property.
+         *
+         * @return the java value, or {@code null} if not set
+         */
+        @Nullable
+        public Java getJava() {
+          return _java;
+        }
+
+        /**
+         * Set the java Property Binding.
+         *
+         * <p>
+         * Java-specific binding configuration for a property.
+         *
+         * @param value
+         *          the java value to set
+         */
+        public void setJava(@Nullable Java value) {
+          _java = value;
+        }
+
+        @Override
+        public String toString() {
+          return new ReflectionToStringBuilder(this, ToStringStyle.MULTI_LINE_STYLE).toString();
+        }
+
+        /**
+         * Java-specific binding configuration for a property.
+         */
+        @MetaschemaAssembly(
+            formalName = "Java Property Binding",
+            description = "Java-specific binding configuration for a property.",
+            name = "java",
+            moduleClass = MetaschemaBindingsModule.class)
+        public static class Java implements IBoundObject {
+          private final IMetaschemaData __metaschemaData;
+
+          /**
+           * A fully qualified Java collection class name to use instead of the default.
+           */
+          @BoundField(
+              formalName = "Collection Class",
+              description = "A fully qualified Java collection class name to use instead of the default.",
+              useName = "collection-class",
+              typeAdapter = TokenAdapter.class)
+          private String _collectionClass;
+
+          /**
+           * Constructs a new
+           * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineFieldBinding.PropertyBinding.Java}
+           * instance with no metadata.
+           */
+          public Java() {
+            this(null);
+          }
+
+          /**
+           * Constructs a new
+           * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineFieldBinding.PropertyBinding.Java}
+           * instance with the specified metadata.
+           *
+           * @param data
+           *          the metaschema data, or {@code null} if none
+           */
+          public Java(IMetaschemaData data) {
+            this.__metaschemaData = data;
+          }
+
+          @Override
+          public IMetaschemaData getMetaschemaData() {
+            return __metaschemaData;
+          }
+
+          /**
+           * Get the collection Class.
+           *
+           * <p>
+           * A fully qualified Java collection class name to use instead of the default.
+           *
+           * @return the collection-class value, or {@code null} if not set
+           */
+          @Nullable
+          public String getCollectionClass() {
+            return _collectionClass;
+          }
+
+          /**
+           * Set the collection Class.
+           *
+           * <p>
+           * A fully qualified Java collection class name to use instead of the default.
+           *
+           * @param value
+           *          the collection-class value to set
+           */
+          public void setCollectionClass(@Nullable String value) {
+            _collectionClass = value;
+          }
+
+          @Override
+          public String toString() {
+            return new ReflectionToStringBuilder(this, ToStringStyle.MULTI_LINE_STYLE).toString();
+          }
         }
       }
     }

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/config/binding/MetaschemaBindingsModule.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/config/binding/MetaschemaBindingsModule.java
@@ -2,6 +2,8 @@
  * SPDX-FileCopyrightText: none
  * SPDX-License-Identifier: CC0-1.0
  */
+// Generated from: ../../../../../../../../metaschema/metaschema-bindings.yaml
+// Do not edit - changes will be lost when regenerated.
 
 package gov.nist.secauto.metaschema.databind.config.binding;
 
@@ -15,13 +17,20 @@ import java.net.URI;
 import java.util.List;
 
 /**
- * A bound module that provides the Metaschema binding configuration model.
+ * Metaschema Binding Configuration
  * <p>
- * This module enables parsing of binding configuration files that define how
- * Metaschema modules map to Java packages and classes.
+ * This module defines the binding configuration format used to customize Java
+ * code generation from Metaschema modules. It allows specifying package names,
+ * class names, interface implementations, base classes, and collection types
+ * for generated binding classes.
+ * </p>
  */
 @MetaschemaModule(
-    assemblies = MetaschemaBindings.class)
+    assemblies = MetaschemaBindings.class,
+    remarks = "This module defines the binding configuration format used to customize\n"
+        + "Java code generation from Metaschema modules. It allows specifying\n"
+        + "package names, class names, interface implementations, base classes,\n"
+        + "and collection types for generated binding classes.")
 public final class MetaschemaBindingsModule
     extends AbstractBoundModule {
   private static final MarkupLine NAME = MarkupLine.fromMarkdown("Metaschema Binding Configuration");
@@ -34,13 +43,19 @@ public final class MetaschemaBindingsModule
 
   private static final URI JSON_BASE_URI = URI.create("https://csrc.nist.gov/ns/metaschema-binding/1.0");
 
+  private static final MarkupMultiline REMARKS
+      = MarkupMultiline.fromMarkdown("This module defines the binding configuration format used to customize\n"
+          + "Java code generation from Metaschema modules. It allows specifying\n"
+          + "package names, class names, interface implementations, base classes,\n"
+          + "and collection types for generated binding classes.");
+
   /**
-   * Constructs a new binding configuration module.
+   * Construct a new module instance.
    *
    * @param importedModules
-   *          the list of modules imported by this module
+   *          modules imported by this module
    * @param bindingContext
-   *          the binding context for this module
+   *          the binding context to associate with this module
    */
   public MetaschemaBindingsModule(List<? extends IBoundModule> importedModules,
       IBindingContext bindingContext) {
@@ -74,6 +89,6 @@ public final class MetaschemaBindingsModule
 
   @Override
   public MarkupMultiline getRemarks() {
-    return null;
+    return REMARKS;
   }
 }

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/config/binding/package-info.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/config/binding/package-info.java
@@ -3,24 +3,8 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-/**
- * Contains pre-generated Metaschema binding classes for the binding
- * configuration model.
- * <p>
- * These classes are bootstrapped (pre-generated and committed to source
- * control) because the databind module cannot use the metaschema-maven-plugin
- * to generate them during build (circular dependency). When the binding
- * configuration schema changes, regenerate using:
- *
- * <pre>
- * java -jar metaschema-cli/target/metaschema-cli-*-metaschema-cli.jar \
- *     generate-java --output-dir /tmp/binding-classes \
- *     databind/src/main/metaschema/metaschema-bindings.yaml
- * </pre>
- *
- * Then copy the generated classes to this package.
- */
-
+// Generated from: ../../../../../../../../metaschema/metaschema-bindings.yaml
+// Do not edit - changes will be lost when regenerated.
 @gov.nist.secauto.metaschema.databind.model.annotations.MetaschemaPackage(moduleClass = {
     gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindingsModule.class })
 @gov.nist.secauto.metaschema.databind.model.annotations.XmlSchema(

--- a/databind/src/main/metaschema-bindings/metaschema-binding-bindings.xml
+++ b/databind/src/main/metaschema-bindings/metaschema-binding-bindings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metaschema-bindings
+    xmlns="https://csrc.nist.gov/ns/metaschema-binding/1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://csrc.nist.gov/ns/metaschema-binding/1.0 ../xsd/metaschema-binding.xsd">
+    <model-binding namespace="https://csrc.nist.gov/ns/metaschema-binding/1.0">
+        <java>
+            <use-package-name>gov.nist.secauto.metaschema.databind.config.binding</use-package-name>
+        </java>
+    </model-binding>
+</metaschema-bindings>

--- a/databind/src/main/metaschema/metaschema-bindings.yaml
+++ b/databind/src/main/metaschema/metaschema-bindings.yaml
@@ -5,149 +5,213 @@ METASCHEMA:
   namespace: https://csrc.nist.gov/ns/metaschema-binding/1.0
   json-base-uri: https://csrc.nist.gov/ns/metaschema-binding/1.0
   schema-version: 1.0.0
+  remarks:
+    remark: |
+      This module defines the binding configuration format used to customize
+      Java code generation from Metaschema modules. It allows specifying
+      package names, class names, interface implementations, base classes,
+      and collection types for generated binding classes.
   definitions:
-  - object-type: define-assembly
+  - object-type: assembly
     name: metaschema-bindings
     formal-name: Metaschema Bindings
     description: The root element for a set of metaschema binding customizations.
-    root-name: metaschema-bindings
+    root-name:
+      name: metaschema-bindings
     model:
       instances:
       - object-type: assembly
-        ref: model-binding
+        name: model-binding
+        formal-name: Model Binding
+        description: Defines binding configurations that apply to a whole model described by a namespace.
         max-occurs: unbounded
         group-as:
           name: model-bindings
           in-json: ARRAY
+        flags:
+        - object-type: flag
+          name: namespace
+          formal-name: Namespace
+          description: A URI referencing the namespace of one or more related metaschema definitions.
+          as-type: uri
+          required: "yes"
+        model:
+          instances:
+          - object-type: assembly
+            name: java
+            formal-name: Java Model Binding
+            description: Java-specific binding configuration for a model namespace.
+            model:
+              instances:
+              - object-type: field
+                name: use-package-name
+                formal-name: Use Package Name
+                description: The Java package name to use for classes generated from this namespace.
+                as-type: token
       - object-type: assembly
-        ref: metaschema-binding
+        name: metaschema-binding
+        formal-name: Metaschema Binding
+        description: Defines a binding for a given metaschema identified by a relative URL.
         max-occurs: unbounded
         group-as:
           name: metaschema-bindings
           in-json: ARRAY
-
-  - object-type: define-assembly
-    name: model-binding
-    formal-name: Model Binding
-    description: Defines binding configurations that apply to a whole model described by a namespace.
-    flags:
-    - object-type: define-flag
-      name: namespace
-      formal-name: Namespace
-      description: A URI referencing the namespace of one or more related metaschema definitions.
-      as-type: uri
-      required: "yes"
-    model:
-      instances:
-      - object-type: assembly
-        ref: java-model-binding
-
-  - object-type: define-assembly
-    name: java-model-binding
-    formal-name: Java Model Binding
-    description: Java-specific binding configuration for a model namespace.
-    use-name: java
-    model:
-      instances:
-      - object-type: field
-        ref: use-package-name
-
-  - object-type: define-field
-    name: use-package-name
-    formal-name: Use Package Name
-    description: The Java package name to use for classes generated from this namespace.
-    as-type: token
-
-  - object-type: define-assembly
-    name: metaschema-binding
-    formal-name: Metaschema Binding
-    description: Defines a binding for a given metaschema identified by a relative URL.
-    flags:
-    - object-type: define-flag
-      name: href
-      formal-name: Href
-      description: A URL relative to this binding configuration file, pointing to a metaschema definition.
-      as-type: uri-reference
-      required: "yes"
-    model:
-      instances:
-      - object-type: assembly
-        ref: define-assembly-binding
-        max-occurs: unbounded
-        group-as:
-          name: define-assembly-bindings
-          in-json: ARRAY
-      - object-type: assembly
-        ref: define-field-binding
-        max-occurs: unbounded
-        group-as:
-          name: define-field-bindings
-          in-json: ARRAY
-
-  - object-type: define-assembly
-    name: define-assembly-binding
-    formal-name: Define Assembly Binding
-    description: Provides binding configurations for a given defined assembly within the parent metaschema.
-    flags:
-    - object-type: define-flag
-      name: name
-      formal-name: Name
-      description: The name of the metaschema assembly.
-      as-type: token
-      required: "yes"
-    model:
-      instances:
-      - object-type: assembly
-        ref: java-object-definition-binding
-
-  - object-type: define-assembly
-    name: define-field-binding
-    formal-name: Define Field Binding
-    description: Provides binding configurations for a given defined field within the parent metaschema.
-    flags:
-    - object-type: define-flag
-      name: name
-      formal-name: Name
-      description: The name of the metaschema field.
-      as-type: token
-      required: "yes"
-    model:
-      instances:
-      - object-type: assembly
-        ref: java-object-definition-binding
-
-  - object-type: define-assembly
-    name: java-object-definition-binding
-    formal-name: Java Object Definition Binding
-    description: Field and assembly binding configurations for Java bound classes.
-    use-name: java
-    model:
-      instances:
-      - object-type: field
-        ref: use-class-name
-      - object-type: field
-        ref: implement-interface
-        max-occurs: unbounded
-        group-as:
-          name: implement-interfaces
-          in-json: ARRAY
-      - object-type: field
-        ref: extend-base-class
-
-  - object-type: define-field
-    name: use-class-name
-    formal-name: Use Class Name
-    description: The Java class name to use for the generated class.
-    as-type: token
-
-  - object-type: define-field
-    name: implement-interface
-    formal-name: Implement Interface
-    description: A fully qualified Java interface name that the generated class should implement.
-    as-type: token
-
-  - object-type: define-field
-    name: extend-base-class
-    formal-name: Extend Base Class
-    description: A fully qualified Java class name that the generated class should extend.
-    as-type: token
+        flags:
+        - object-type: flag
+          name: href
+          formal-name: Href
+          description: A URL relative to this binding configuration file, pointing to a metaschema definition.
+          as-type: uri-reference
+          required: "yes"
+        model:
+          instances:
+          - object-type: assembly
+            name: define-assembly-binding
+            formal-name: Define Assembly Binding
+            description: Provides binding configurations for a given defined assembly within the parent metaschema.
+            max-occurs: unbounded
+            group-as:
+              name: define-assembly-bindings
+              in-json: ARRAY
+            flags:
+            - object-type: flag
+              name: name
+              formal-name: Name
+              description: The name of the metaschema assembly.
+              as-type: token
+              required: "yes"
+            model:
+              instances:
+              - object-type: assembly
+                name: java
+                formal-name: Java Object Definition Binding
+                description: Field and assembly binding configurations for Java bound classes.
+                model:
+                  instances:
+                  - object-type: field
+                    name: use-class-name
+                    formal-name: Use Class Name
+                    description: The Java class name to use for the generated class.
+                    as-type: token
+                  - object-type: field
+                    name: implement-interface
+                    formal-name: Implement Interface
+                    description: A fully qualified Java interface name that the generated class should implement.
+                    as-type: token
+                    max-occurs: unbounded
+                    group-as:
+                      name: implement-interfaces
+                      in-json: ARRAY
+                  - object-type: field
+                    name: extend-base-class
+                    formal-name: Extend Base Class
+                    description: A fully qualified Java class name that the generated class should extend.
+                    as-type: token
+                  - object-type: field
+                    name: collection-class
+                    formal-name: Collection Class
+                    description: A fully qualified Java collection class name to use instead of the default.
+                    as-type: token
+              - object-type: assembly
+                name: property-binding
+                formal-name: Property Binding
+                description: Provides binding configurations for a property within the parent definition.
+                max-occurs: unbounded
+                group-as:
+                  name: property-bindings
+                  in-json: ARRAY
+                flags:
+                - object-type: flag
+                  name: name
+                  formal-name: Name
+                  description: The name of the property within the parent definition.
+                  as-type: token
+                  required: "yes"
+                model:
+                  instances:
+                  - object-type: assembly
+                    name: java
+                    formal-name: Java Property Binding
+                    description: Java-specific binding configuration for a property.
+                    model:
+                      instances:
+                      - object-type: field
+                        name: collection-class
+                        formal-name: Collection Class
+                        description: A fully qualified Java collection class name to use instead of the default.
+                        as-type: token
+          - object-type: assembly
+            name: define-field-binding
+            formal-name: Define Field Binding
+            description: Provides binding configurations for a given defined field within the parent metaschema.
+            max-occurs: unbounded
+            group-as:
+              name: define-field-bindings
+              in-json: ARRAY
+            flags:
+            - object-type: flag
+              name: name
+              formal-name: Name
+              description: The name of the metaschema field.
+              as-type: token
+              required: "yes"
+            model:
+              instances:
+              - object-type: assembly
+                name: java
+                formal-name: Java Object Definition Binding
+                description: Field and assembly binding configurations for Java bound classes.
+                model:
+                  instances:
+                  - object-type: field
+                    name: use-class-name
+                    formal-name: Use Class Name
+                    description: The Java class name to use for the generated class.
+                    as-type: token
+                  - object-type: field
+                    name: implement-interface
+                    formal-name: Implement Interface
+                    description: A fully qualified Java interface name that the generated class should implement.
+                    as-type: token
+                    max-occurs: unbounded
+                    group-as:
+                      name: implement-interfaces
+                      in-json: ARRAY
+                  - object-type: field
+                    name: extend-base-class
+                    formal-name: Extend Base Class
+                    description: A fully qualified Java class name that the generated class should extend.
+                    as-type: token
+                  - object-type: field
+                    name: collection-class
+                    formal-name: Collection Class
+                    description: A fully qualified Java collection class name to use instead of the default.
+                    as-type: token
+              - object-type: assembly
+                name: property-binding
+                formal-name: Property Binding
+                description: Provides binding configurations for a property within the parent definition.
+                max-occurs: unbounded
+                group-as:
+                  name: property-bindings
+                  in-json: ARRAY
+                flags:
+                - object-type: flag
+                  name: name
+                  formal-name: Name
+                  description: The name of the property within the parent definition.
+                  as-type: token
+                  required: "yes"
+                model:
+                  instances:
+                  - object-type: assembly
+                    name: java
+                    formal-name: Java Property Binding
+                    description: Java-specific binding configuration for a property.
+                    model:
+                      instances:
+                      - object-type: field
+                        name: collection-class
+                        formal-name: Collection Class
+                        description: A fully qualified Java collection class name to use instead of the default.
+                        as-type: token

--- a/databind/src/test/java/gov/nist/secauto/metaschema/databind/codegen/config/DefaultBindingConfigurationTest.java
+++ b/databind/src/test/java/gov/nist/secauto/metaschema/databind/codegen/config/DefaultBindingConfigurationTest.java
@@ -7,9 +7,12 @@ package gov.nist.secauto.metaschema.databind.codegen.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
+import gov.nist.secauto.metaschema.core.model.IAssemblyDefinition;
 import gov.nist.secauto.metaschema.core.model.IModelDefinition;
 import gov.nist.secauto.metaschema.core.model.IModule;
+import gov.nist.secauto.metaschema.core.model.INamedModelInstanceAbsolute;
 import gov.nist.secauto.metaschema.core.model.ModelType;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 
@@ -23,6 +26,9 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 class DefaultBindingConfigurationTest {
   private static final URI METASCHEMA_LOCATION
@@ -66,6 +72,226 @@ class DefaultBindingConfigurationTest {
         ObjectUtils.notNull(definition));
     assertNotNull(defConfig);
     assertEquals(DEFINITION__CLASS_NAME, defConfig.getClassName());
+  }
+
+  @Test
+  void testCollectionClassOverride() throws IOException {
+    // Test loading binding configuration with collection-class overrides
+    File bindingConfigFile = new File("src/test/resources/metaschema/binding-config-with-collection-class.xml");
+    URI assemblyMetaschemaLocation = new File("src/test/resources/metaschema/assembly/metaschema.xml")
+        .getAbsoluteFile().toURI();
+
+    DefaultBindingConfiguration config = new DefaultBindingConfiguration();
+    config.load(bindingConfigFile);
+
+    // Create mock for the top-level assembly definition
+    IAssemblyDefinition topLevelDefinition = context.mock(IAssemblyDefinition.class, "topLevel");
+    IModule assemblyModule = context.mock(IModule.class, "assemblyModule");
+    INamedModelInstanceAbsolute childrenInstance = context.mock(INamedModelInstanceAbsolute.class, "childrenInstance");
+
+    context.checking(new Expectations() {
+      {
+        // Module expectations
+        allowing(assemblyModule).getLocation();
+        will(returnValue(assemblyMetaschemaLocation));
+
+        // Definition expectations
+        allowing(topLevelDefinition).getContainingModule();
+        will(returnValue(assemblyModule));
+        allowing(topLevelDefinition).getModelType();
+        will(returnValue(ModelType.ASSEMBLY));
+        allowing(topLevelDefinition).getName();
+        will(returnValue("top-level"));
+
+        // Instance expectations
+        allowing(childrenInstance).getContainingDefinition();
+        will(returnValue(topLevelDefinition));
+        allowing(childrenInstance).getName();
+        will(returnValue("children"));
+      }
+    });
+
+    // Get the property binding configuration
+    IPropertyBindingConfiguration propertyConfig = config.getPropertyBindingConfiguration(
+        ObjectUtils.notNull(topLevelDefinition),
+        "children");
+
+    // Verify collection class override is available
+    assertNotNull(propertyConfig, "Property binding configuration should exist for 'children'");
+    assertEquals(ArrayList.class.getName(), propertyConfig.getCollectionClassName(),
+        "Collection class should be ArrayList");
+
+    // Test grandchild's fields property
+    IAssemblyDefinition grandchildDefinition = context.mock(IAssemblyDefinition.class, "grandchild");
+
+    context.checking(new Expectations() {
+      {
+        allowing(grandchildDefinition).getContainingModule();
+        will(returnValue(assemblyModule));
+        allowing(grandchildDefinition).getModelType();
+        will(returnValue(ModelType.ASSEMBLY));
+        allowing(grandchildDefinition).getName();
+        will(returnValue("grandchild"));
+      }
+    });
+
+    IPropertyBindingConfiguration fieldsPropertyConfig = config.getPropertyBindingConfiguration(
+        ObjectUtils.notNull(grandchildDefinition),
+        "fields");
+
+    assertNotNull(fieldsPropertyConfig, "Property binding configuration should exist for 'fields'");
+    assertEquals(CopyOnWriteArrayList.class.getName(), fieldsPropertyConfig.getCollectionClassName(),
+        "Collection class should be CopyOnWriteArrayList");
+
+    // Test that unconfigured property returns null
+    IPropertyBindingConfiguration unconfiguredProperty = config.getPropertyBindingConfiguration(
+        ObjectUtils.notNull(topLevelDefinition),
+        "nonexistent");
+    assertNull(unconfiguredProperty, "Unconfigured property should return null");
+  }
+
+  @Test
+  void testPropertyBindingWithoutJavaElement() throws IOException {
+    // Test property-binding element that has no <java> child
+    File bindingConfigFile = new File("src/test/resources/metaschema/binding-config-edge-cases.xml");
+    URI assemblyMetaschemaLocation = new File("src/test/resources/metaschema/assembly/metaschema.xml")
+        .getAbsoluteFile().toURI();
+
+    DefaultBindingConfiguration config = new DefaultBindingConfiguration();
+    config.load(bindingConfigFile);
+
+    IAssemblyDefinition testDefinition = context.mock(IAssemblyDefinition.class, "testDef");
+    IModule testModule = context.mock(IModule.class, "testModule");
+
+    context.checking(new Expectations() {
+      {
+        allowing(testModule).getLocation();
+        will(returnValue(assemblyMetaschemaLocation));
+        allowing(testDefinition).getContainingModule();
+        will(returnValue(testModule));
+        allowing(testDefinition).getModelType();
+        will(returnValue(ModelType.ASSEMBLY));
+        allowing(testDefinition).getName();
+        will(returnValue("edge-case-assembly"));
+      }
+    });
+
+    // Property with no <java> element should return null
+    IPropertyBindingConfiguration noJavaConfig = config.getPropertyBindingConfiguration(
+        ObjectUtils.notNull(testDefinition),
+        "no-java-element");
+    assertNull(noJavaConfig, "Property binding without <java> element should return null");
+
+    // Property with <java> but no <collection-class> should return null
+    IPropertyBindingConfiguration noCollectionClassConfig = config.getPropertyBindingConfiguration(
+        ObjectUtils.notNull(testDefinition),
+        "no-collection-class");
+    assertNull(noCollectionClassConfig, "Property binding without <collection-class> should return null");
+  }
+
+  @Test
+  void testDefinitionNotInBindingConfig() throws IOException {
+    // Test querying a definition from a module that has no binding config
+    File bindingConfigFile = new File("src/test/resources/metaschema/binding-config-with-collection-class.xml");
+    URI unknownModuleLocation = new File("src/test/resources/metaschema/unknown-module.xml")
+        .getAbsoluteFile().toURI();
+
+    DefaultBindingConfiguration config = new DefaultBindingConfiguration();
+    config.load(bindingConfigFile);
+
+    IAssemblyDefinition unknownDefinition = context.mock(IAssemblyDefinition.class, "unknownDef");
+    IModule unknownModule = context.mock(IModule.class, "unknownModule");
+
+    context.checking(new Expectations() {
+      {
+        allowing(unknownModule).getLocation();
+        will(returnValue(unknownModuleLocation));
+        allowing(unknownDefinition).getContainingModule();
+        will(returnValue(unknownModule));
+        allowing(unknownDefinition).getModelType();
+        will(returnValue(ModelType.ASSEMBLY));
+        allowing(unknownDefinition).getName();
+        will(returnValue("unknown-definition"));
+      }
+    });
+
+    // Definition from unknown module should return null
+    IPropertyBindingConfiguration unknownConfig = config.getPropertyBindingConfiguration(
+        ObjectUtils.notNull(unknownDefinition),
+        "some-property");
+    assertNull(unknownConfig, "Property from unknown module should return null");
+  }
+
+  @Test
+  void testFieldDefinitionPropertyBinding() throws IOException {
+    // Test property binding on a field definition (not just assembly)
+    File bindingConfigFile = new File("src/test/resources/metaschema/binding-config-edge-cases.xml");
+    URI assemblyMetaschemaLocation = new File("src/test/resources/metaschema/assembly/metaschema.xml")
+        .getAbsoluteFile().toURI();
+
+    DefaultBindingConfiguration config = new DefaultBindingConfiguration();
+    config.load(bindingConfigFile);
+
+    IModelDefinition fieldDefinition = context.mock(IModelDefinition.class, "fieldDef");
+    IModule fieldModule = context.mock(IModule.class, "fieldModule");
+
+    context.checking(new Expectations() {
+      {
+        allowing(fieldModule).getLocation();
+        will(returnValue(assemblyMetaschemaLocation));
+        allowing(fieldDefinition).getContainingModule();
+        will(returnValue(fieldModule));
+        allowing(fieldDefinition).getModelType();
+        will(returnValue(ModelType.FIELD));
+        allowing(fieldDefinition).getName();
+        will(returnValue("test-field"));
+      }
+    });
+
+    // Field definition property binding should work
+    IPropertyBindingConfiguration fieldPropertyConfig = config.getPropertyBindingConfiguration(
+        ObjectUtils.notNull(fieldDefinition),
+        "field-items");
+    assertNotNull(fieldPropertyConfig, "Property binding should exist for field definition");
+    assertEquals("java.util.LinkedHashSet", fieldPropertyConfig.getCollectionClassName(),
+        "Collection class should be LinkedHashSet");
+  }
+
+  @Test
+  void testDuplicatePropertyBindingLastWins() throws IOException {
+    // Test that duplicate property bindings use last-wins semantics
+    File bindingConfigFile = new File("src/test/resources/metaschema/binding-config-edge-cases.xml");
+    URI assemblyMetaschemaLocation = new File("src/test/resources/metaschema/assembly/metaschema.xml")
+        .getAbsoluteFile().toURI();
+
+    DefaultBindingConfiguration config = new DefaultBindingConfiguration();
+    config.load(bindingConfigFile);
+
+    IAssemblyDefinition duplicateDefinition = context.mock(IAssemblyDefinition.class, "duplicateDef");
+    IModule duplicateModule = context.mock(IModule.class, "duplicateModule");
+
+    context.checking(new Expectations() {
+      {
+        allowing(duplicateModule).getLocation();
+        will(returnValue(assemblyMetaschemaLocation));
+        allowing(duplicateDefinition).getContainingModule();
+        will(returnValue(duplicateModule));
+        allowing(duplicateDefinition).getModelType();
+        will(returnValue(ModelType.ASSEMBLY));
+        allowing(duplicateDefinition).getName();
+        will(returnValue("edge-case-assembly"));
+      }
+    });
+
+    // When duplicate property bindings exist, the last one should win
+    // The config has ArrayList first, then LinkedList - LinkedList should be
+    // returned
+    IPropertyBindingConfiguration duplicateConfig = config.getPropertyBindingConfiguration(
+        ObjectUtils.notNull(duplicateDefinition),
+        "duplicate-property");
+    assertNotNull(duplicateConfig, "Duplicate property binding should return a configuration");
+    assertEquals(LinkedList.class.getName(), duplicateConfig.getCollectionClassName(),
+        "Duplicate property bindings should use last-wins semantics");
   }
 
 }

--- a/databind/src/test/resources/metaschema/binding-config-edge-cases.xml
+++ b/databind/src/test/resources/metaschema/binding-config-edge-cases.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metaschema-bindings
+	xmlns="https://csrc.nist.gov/ns/metaschema-binding/1.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<metaschema-binding href="./assembly/metaschema.xml">
+		<!-- Assembly with various edge cases for property bindings -->
+		<define-assembly-binding name="edge-case-assembly">
+			<!-- Property binding without java element -->
+			<property-binding name="no-java-element"/>
+			<!-- Property binding with java but no collection-class -->
+			<property-binding name="no-collection-class">
+				<java/>
+			</property-binding>
+			<!-- Duplicate property bindings - last wins behavior -->
+			<property-binding name="duplicate-property">
+				<java>
+					<collection-class>java.util.ArrayList</collection-class>
+				</java>
+			</property-binding>
+			<property-binding name="duplicate-property">
+				<java>
+					<collection-class>java.util.LinkedList</collection-class>
+				</java>
+			</property-binding>
+		</define-assembly-binding>
+		<!-- Field definition with property binding -->
+		<define-field-binding name="test-field">
+			<property-binding name="field-items">
+				<java>
+					<collection-class>java.util.LinkedHashSet</collection-class>
+				</java>
+			</property-binding>
+		</define-field-binding>
+	</metaschema-binding>
+</metaschema-bindings>

--- a/databind/src/test/resources/metaschema/binding-config-with-collection-class.xml
+++ b/databind/src/test/resources/metaschema/binding-config-with-collection-class.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metaschema-bindings
+	xmlns="https://csrc.nist.gov/ns/metaschema-binding/1.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<metaschema-binding href="./assembly/metaschema.xml">
+		<define-assembly-binding name="top-level">
+			<property-binding name="children">
+				<java>
+					<collection-class>java.util.ArrayList</collection-class>
+				</java>
+			</property-binding>
+		</define-assembly-binding>
+		<define-assembly-binding name="grandchild">
+			<property-binding name="fields">
+				<java>
+					<collection-class>java.util.concurrent.CopyOnWriteArrayList</collection-class>
+				</java>
+			</property-binding>
+		</define-assembly-binding>
+	</metaschema-binding>
+</metaschema-bindings>

--- a/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/GenerateSchema.java
+++ b/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/GenerateSchema.java
@@ -2,6 +2,8 @@
  * SPDX-FileCopyrightText: none
  * SPDX-License-Identifier: CC0-1.0
  */
+// Generated from: ../../../../../../../../metaschema/unit-tests.yaml
+// Do not edit - changes will be lost when regenerated.
 
 package gov.nist.secauto.metaschema.model.testing.testsuite;
 
@@ -20,8 +22,6 @@ import gov.nist.secauto.metaschema.databind.model.annotations.BoundFlag;
 import gov.nist.secauto.metaschema.databind.model.annotations.GroupAs;
 import gov.nist.secauto.metaschema.databind.model.annotations.MetaschemaAssembly;
 import gov.nist.secauto.metaschema.databind.model.annotations.ValueConstraints;
-import java.lang.Override;
-import java.lang.String;
 import java.util.LinkedList;
 import java.util.List;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;

--- a/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/GenerationCase.java
+++ b/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/GenerationCase.java
@@ -2,6 +2,8 @@
  * SPDX-FileCopyrightText: none
  * SPDX-License-Identifier: CC0-1.0
  */
+// Generated from: ../../../../../../../../metaschema/unit-tests.yaml
+// Do not edit - changes will be lost when regenerated.
 
 package gov.nist.secauto.metaschema.model.testing.testsuite;
 
@@ -17,8 +19,6 @@ import gov.nist.secauto.metaschema.databind.model.annotations.AllowedValues;
 import gov.nist.secauto.metaschema.databind.model.annotations.BoundFlag;
 import gov.nist.secauto.metaschema.databind.model.annotations.MetaschemaAssembly;
 import gov.nist.secauto.metaschema.databind.model.annotations.ValueConstraints;
-import java.lang.Override;
-import java.lang.String;
 import java.net.URI;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;

--- a/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/Metaschema.java
+++ b/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/Metaschema.java
@@ -2,6 +2,8 @@
  * SPDX-FileCopyrightText: none
  * SPDX-License-Identifier: CC0-1.0
  */
+// Generated from: ../../../../../../../../metaschema/unit-tests.yaml
+// Do not edit - changes will be lost when regenerated.
 
 package gov.nist.secauto.metaschema.model.testing.testsuite;
 
@@ -11,8 +13,6 @@ import gov.nist.secauto.metaschema.core.model.IBoundObject;
 import gov.nist.secauto.metaschema.core.model.IMetaschemaData;
 import gov.nist.secauto.metaschema.databind.model.annotations.BoundFlag;
 import gov.nist.secauto.metaschema.databind.model.annotations.MetaschemaAssembly;
-import java.lang.Override;
-import java.lang.String;
 import java.net.URI;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;

--- a/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/MetaschemaTestSuiteModule.java
+++ b/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/MetaschemaTestSuiteModule.java
@@ -2,6 +2,8 @@
  * SPDX-FileCopyrightText: none
  * SPDX-License-Identifier: CC0-1.0
  */
+// Generated from: ../../../../../../../../metaschema/unit-tests.yaml
+// Do not edit - changes will be lost when regenerated.
 
 package gov.nist.secauto.metaschema.model.testing.testsuite;
 
@@ -11,11 +13,12 @@ import gov.nist.secauto.metaschema.databind.IBindingContext;
 import gov.nist.secauto.metaschema.databind.model.AbstractBoundModule;
 import gov.nist.secauto.metaschema.databind.model.IBoundModule;
 import gov.nist.secauto.metaschema.databind.model.annotations.MetaschemaModule;
-import java.lang.Override;
-import java.lang.String;
 import java.net.URI;
 import java.util.List;
 
+/**
+ * Metaschema Test Suite
+ */
 @MetaschemaModule(
     assemblies = {
         TestSuite.class,
@@ -38,6 +41,14 @@ public final class MetaschemaTestSuiteModule
 
   private static final URI JSON_BASE_URI = URI.create("http://csrc.nist.gov/ns/metaschema/test-suite/1.0");
 
+  /**
+   * Construct a new module instance.
+   *
+   * @param importedModules
+   *          modules imported by this module
+   * @param bindingContext
+   *          the binding context to associate with this module
+   */
   public MetaschemaTestSuiteModule(List<? extends IBoundModule> importedModules,
       IBindingContext bindingContext) {
     super(importedModules, bindingContext);

--- a/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/TestCollection.java
+++ b/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/TestCollection.java
@@ -2,6 +2,8 @@
  * SPDX-FileCopyrightText: none
  * SPDX-License-Identifier: CC0-1.0
  */
+// Generated from: ../../../../../../../../metaschema/unit-tests.yaml
+// Do not edit - changes will be lost when regenerated.
 
 package gov.nist.secauto.metaschema.model.testing.testsuite;
 
@@ -16,8 +18,6 @@ import gov.nist.secauto.metaschema.databind.model.annotations.BoundAssembly;
 import gov.nist.secauto.metaschema.databind.model.annotations.BoundFlag;
 import gov.nist.secauto.metaschema.databind.model.annotations.GroupAs;
 import gov.nist.secauto.metaschema.databind.model.annotations.MetaschemaAssembly;
-import java.lang.Override;
-import java.lang.String;
 import java.net.URI;
 import java.util.LinkedList;
 import java.util.List;

--- a/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/TestScenario.java
+++ b/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/TestScenario.java
@@ -2,6 +2,8 @@
  * SPDX-FileCopyrightText: none
  * SPDX-License-Identifier: CC0-1.0
  */
+// Generated from: ../../../../../../../../metaschema/unit-tests.yaml
+// Do not edit - changes will be lost when regenerated.
 
 package gov.nist.secauto.metaschema.model.testing.testsuite;
 
@@ -16,8 +18,6 @@ import gov.nist.secauto.metaschema.databind.model.annotations.BoundAssembly;
 import gov.nist.secauto.metaschema.databind.model.annotations.BoundFlag;
 import gov.nist.secauto.metaschema.databind.model.annotations.GroupAs;
 import gov.nist.secauto.metaschema.databind.model.annotations.MetaschemaAssembly;
-import java.lang.Override;
-import java.lang.String;
 import java.util.LinkedList;
 import java.util.List;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;

--- a/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/TestSuite.java
+++ b/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/TestSuite.java
@@ -2,6 +2,8 @@
  * SPDX-FileCopyrightText: none
  * SPDX-License-Identifier: CC0-1.0
  */
+// Generated from: ../../../../../../../../metaschema/unit-tests.yaml
+// Do not edit - changes will be lost when regenerated.
 
 package gov.nist.secauto.metaschema.model.testing.testsuite;
 
@@ -13,8 +15,6 @@ import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import gov.nist.secauto.metaschema.databind.model.annotations.BoundAssembly;
 import gov.nist.secauto.metaschema.databind.model.annotations.GroupAs;
 import gov.nist.secauto.metaschema.databind.model.annotations.MetaschemaAssembly;
-import java.lang.Override;
-import java.lang.String;
 import java.util.LinkedList;
 import java.util.List;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;

--- a/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/ValidationCase.java
+++ b/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/ValidationCase.java
@@ -2,6 +2,8 @@
  * SPDX-FileCopyrightText: none
  * SPDX-License-Identifier: CC0-1.0
  */
+// Generated from: ../../../../../../../../metaschema/unit-tests.yaml
+// Do not edit - changes will be lost when regenerated.
 
 package gov.nist.secauto.metaschema.model.testing.testsuite;
 
@@ -17,8 +19,6 @@ import gov.nist.secauto.metaschema.databind.model.annotations.AllowedValues;
 import gov.nist.secauto.metaschema.databind.model.annotations.BoundFlag;
 import gov.nist.secauto.metaschema.databind.model.annotations.MetaschemaAssembly;
 import gov.nist.secauto.metaschema.databind.model.annotations.ValueConstraints;
-import java.lang.Override;
-import java.lang.String;
 import java.net.URI;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;

--- a/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/package-info.java
+++ b/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/package-info.java
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
+// Generated from: ../../../../../../../../metaschema/unit-tests.yaml
+// Do not edit - changes will be lost when regenerated.
 @gov.nist.secauto.metaschema.databind.model.annotations.MetaschemaPackage(moduleClass = {
     gov.nist.secauto.metaschema.model.testing.testsuite.MetaschemaTestSuiteModule.class })
 @gov.nist.secauto.metaschema.databind.model.annotations.XmlSchema(


### PR DESCRIPTION
## Summary

This PR adds support for overriding the default collection implementation class in binding configurations, enabling alternative Java collection types (e.g., ArrayList, LinkedHashSet) for generated model classes. It also improves code generator output quality.

### Changes

**Collection Class Override Support**
- Add `collection-class` field to `metaschema-bindings.yaml` schema
- Create `IPropertyBindingConfiguration` interface for property-level bindings  
- Extend `DefaultBindingConfiguration` to parse property binding elements
- Add comprehensive edge case tests for configuration parsing

**Code Generator Improvements**
- Add module-level Javadoc from `remarks` field in source Metaschema modules
- Add file header comments showing relative path to source Metaschema file
- Add generated comments to `package-info.java` files
- Calculate relative paths from actual generated file location (including package path)

**Infrastructure**
- Regenerate `MetaschemaBindings` and test suite bindings with new comments
- Add bootstrap POM for databind binding class regeneration
- Update `.claude` documentation with edge case testing guidance

### Example Usage

```xml
<metaschema-bindings xmlns="https://csrc.nist.gov/ns/metaschema-binding/1.0">
  <metaschema-binding href="./assembly/metaschema.xml">
    <define-assembly-binding name="top-level">
      <property-binding name="children">
        <java>
          <collection-class>java.util.ArrayList</collection-class>
        </java>
      </property-binding>
    </define-assembly-binding>
  </metaschema-binding>
</metaschema-bindings>
```

### Generated Code Example

Generated files now include:
```java
// Generated from: ../../../../../../../../metaschema/metaschema-bindings.yaml
// Do not edit - changes will be lost when regenerated.
package gov.nist.secauto.metaschema.databind.config.binding;

/**
 * Metaschema Binding Configuration
 * <p>This module defines the binding configuration format used to customize
 * Java code generation from Metaschema modules...</p>
 */
@MetaschemaModule(...)
public final class MetaschemaBindingsModule extends AbstractBoundModule {
```

## Test Plan

- [x] Run `DefaultBindingConfigurationTest` - all 5 tests pass
- [x] Tests cover collection class parsing from binding config
- [x] Tests cover edge cases: missing java element, missing collection-class, unknown module, field definitions
- [x] Verify generated file comments with correct relative paths
- [x] Verify module-level Javadoc generation from remarks
- [x] Build passes: `mvn clean install -PCI -Prelease`

Resolves parts of #572

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Property-level binding support: specify collection-class overrides for individual properties.

* **Documentation**
  * Mandatory debugging workflow and stricter unit-testing policy (100% pass blocking).
  * Expanded metaschema authoring and code-generation guidance, including nested vs. separate class guidance.

* **Tests**
  * Added tests and test fixtures for binding edge cases and collection-class override behavior.

* **Chores**
  * Added bootstrap regeneration support and generated-file headers to improve binding regeneration and provenance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->