### PR TITLE
fix: skip container build for fork PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,6 +112,8 @@ jobs:
         path: ./metaschema-cli/target/*metaschema-cli.zip
   build-container:
     name: Container
+    # Skip container build for fork PRs (no write access to org container registry)
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary

Fork PRs do not have write access to the organization's container registry (`ghcr.io/metaschema-framework/`), causing container build failures with:

```
ERROR: failed to push ghcr.io/metaschema-framework/metaschema-cli:pr-XXX: denied: installation not allowed to Write organization package
```

This change adds a condition to skip the container build job when the PR originates from a forked repository.

## Changes

- Added `if` condition to `build-container` job to skip when:
  - Event is `pull_request` AND
  - PR head repository is a fork

## Test Plan

- [ ] Verify existing PRs from forks no longer fail on container build
- [ ] Verify push events to develop/release branches still build containers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow to optimize container build operations for internal processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->