### PR TITLE
feat(databind): add parser validation for required fields and collection types

### DIFF
--- a/.claude/skills/metaschema-java-library.md
+++ b/.claude/skills/metaschema-java-library.md
@@ -37,6 +37,76 @@ metaschema-framework (parent)
 | `gov.nist.secauto.metaschema.core.model.constraint` | Constraint validation |
 | `gov.nist.secauto.metaschema.databind` | Data binding context |
 | `gov.nist.secauto.metaschema.databind.io` | Serialization/deserialization |
+| `gov.nist.secauto.metaschema.databind.model.annotations` | Binding annotations (`@BoundField`, `@BoundChoice`, etc.) |
+| `gov.nist.secauto.metaschema.databind.codegen` | Code generation from Metaschema modules |
+
+## Annotation-Based Binding Model
+
+The databind module provides annotation-based bindings that map Java classes to Metaschema definitions.
+
+### Core Binding Annotations
+
+| Annotation | Purpose |
+|------------|---------|
+| `@MetaschemaAssembly` | Marks a class as a bound assembly definition |
+| `@MetaschemaField` | Marks a class as a bound field definition |
+| `@BoundAssembly` | Marks a field as a bound assembly instance |
+| `@BoundField` | Marks a field as a bound field instance |
+| `@BoundFlag` | Marks a field as a bound flag instance |
+| `@BoundChoice` | Marks a field as part of a mutually exclusive choice |
+| `@BoundChoiceGroup` | Marks a field as a polymorphic collection with discriminator |
+
+### Choice Support
+
+**Choice (`@BoundChoice`)**: Mutually exclusive alternatives at the same position in the model.
+
+```java
+@MetaschemaAssembly(name = "my-assembly", moduleClass = MyModule.class)
+public class MyAssembly implements IBoundObject {
+  @BoundField(useName = "option-a")
+  @BoundChoice(choiceId = "choice-1")
+  private String optionA;
+
+  @BoundField(useName = "option-b")
+  @BoundChoice(choiceId = "choice-1")
+  private String optionB;
+}
+```
+
+**Adjacency requirement**: All fields with the same `choiceId` must be declared consecutively.
+
+**Choice Groups (`@BoundChoiceGroup`)**: Polymorphic collections with type discriminators.
+
+```java
+@BoundChoiceGroup(
+    maxOccurs = -1,
+    assemblies = {
+        @BoundGroupedAssembly(useName = "child-a", binding = ChildA.class),
+        @BoundGroupedAssembly(useName = "child-b", binding = ChildB.class)
+    },
+    groupAs = @GroupAs(name = "children", inJson = JsonGroupAsBehavior.LIST))
+private List<Object> children;
+```
+
+### Choice Instance Interface
+
+The `IChoiceInstance` interface represents a choice in the model:
+
+```java
+IChoiceInstance choice = ...;
+
+// Check cardinality
+int minOccurs = choice.getMinOccurs();  // 0 = optional, ≥1 = required
+int maxOccurs = choice.getMaxOccurs();  // -1 = unbounded
+
+// Get alternatives
+Collection<INamedModelInstanceAbsolute> alternatives = choice.getNamedModelInstances();
+
+// Get parent
+IAssemblyDefinition parent = choice.getContainingDefinition();
+```
+
+For annotation-based bindings, choices are optional by default (`minOccurs = 0`).
 
 ## Loading Metaschema Modules
 
@@ -107,6 +177,86 @@ DynamicContext dynamicContext = new DynamicContext(staticContext);
 dynamicContext.setDocumentLoader(loader);
 ```
 
+## Binding Configuration (Code Generation)
+
+Binding configuration files customize how Java classes are generated from Metaschema modules.
+
+### Configuration File Location
+
+Binding configurations are XML files in `{module}/src/main/metaschema-bindings/`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<metaschema-bindings xmlns="https://csrc.nist.gov/ns/metaschema-binding/1.0">
+  <metaschema-binding href="../metaschema/my-module.yaml">
+    <define-assembly-binding name="my-assembly">
+      <java>
+        <use-class-name>MyCustomClassName</use-class-name>
+        <implement-interface>com.example.MyInterface</implement-interface>
+        <extend-base-class>com.example.BaseClass</extend-base-class>
+      </java>
+    </define-assembly-binding>
+  </metaschema-binding>
+</metaschema-bindings>
+```
+
+### Configuration Options
+
+| Element | Purpose |
+|---------|---------|
+| `use-class-name` | Override generated class name |
+| `implement-interface` | Add interface to implements clause (repeatable) |
+| `extend-base-class` | Set base class for generated class |
+| `collection-class` | Override default collection type (e.g., `java.util.LinkedList`) |
+
+### Typed Choice Group Collections
+
+By default, choice group fields use `List<Object>`. Use binding configuration to specify a common interface:
+
+```xml
+<define-assembly-binding name="parent-assembly">
+  <choice-group-binding name="children">
+    <item-type use-wildcard="true">com.example.IChildItem</item-type>
+  </choice-group-binding>
+</define-assembly-binding>
+```
+
+This generates:
+
+```java
+// With use-wildcard="true" (default)
+private List<? extends IChildItem> children;
+
+// With use-wildcard="false"
+private List<IChildItem> children;
+```
+
+### Property-Level Collection Override
+
+Override collection type for specific properties:
+
+```xml
+<define-assembly-binding name="my-assembly">
+  <property-binding name="items">
+    <java>
+      <collection-class>java.util.LinkedHashSet</collection-class>
+    </java>
+  </property-binding>
+</define-assembly-binding>
+```
+
+### Targeting Inline Definitions
+
+Use `target` attribute with Metapath expressions to configure inline definitions:
+
+```xml
+<define-assembly-binding target="//define-assembly[@name='inline-def']">
+  <java>
+    <implement-interface>com.example.InlineInterface</implement-interface>
+  </java>
+</define-assembly-binding>
+```
+
 ## Serialization and Deserialization
 
 ### Deserializing Content
@@ -144,6 +294,38 @@ serializer.serialize(object, outputStream);
 | `Format.XML` | XML serialization |
 | `Format.JSON` | JSON serialization |
 | `Format.YAML` | YAML serialization |
+
+### Deserialization Features
+
+Control deserialization behavior with `DeserializationFeature`:
+
+```java
+IDeserializer<MyClass> deserializer = bindingContext.newDeserializer(Format.JSON, MyClass.class);
+
+// Enable/disable features
+deserializer.enableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
+deserializer.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
+```
+
+| Feature | Default | Description |
+|---------|---------|-------------|
+| `DESERIALIZE_VALIDATE_REQUIRED_FIELDS` | enabled | Validate that required fields (`minOccurs >= 1`) are present |
+| `DESERIALIZE_XML_ALLOW_ENTITY_RESOLUTION` | disabled | Allow XML entity resolution (security consideration) |
+
+### Required Field Validation
+
+When `DESERIALIZE_VALIDATE_REQUIRED_FIELDS` is enabled:
+
+- Fields with `minOccurs >= 1` must be provided in the input
+- Default values are applied for missing optional fields
+- Choice groups are validated correctly:
+  - If any alternative is provided, the choice is satisfied
+  - If no alternative is provided, `minOccurs` on the choice determines validity
+
+```java
+// Throws IOException if required fields are missing
+MyClass obj = deserializer.deserialize(inputStream);
+```
 
 ## Constraint Validation
 
@@ -424,6 +606,45 @@ void testWithDocument() {
   // assertions
 }
 ```
+
+## Generated Code Quality
+
+### Null-Safety Annotations
+
+Generated binding classes include SpotBugs null-safety annotations:
+
+```java
+// Field annotations
+@Nullable
+private String optionalField;
+
+@NonNull
+private String requiredField;
+
+// Getter annotations
+@Nullable
+public String getOptionalField() { ... }
+
+@NonNull
+public String getRequiredField() { ... }
+
+// Setter annotations
+public void setRequiredField(@NonNull String value) { ... }
+```
+
+**Rules for generated code:**
+- Fields with `minOccurs = 0` → `@Nullable`
+- Fields with `minOccurs >= 1` → `@NonNull`
+- Getters follow field nullability
+- Required field setters have `@NonNull` parameters
+
+### Javadoc Generation
+
+Generated classes include comprehensive Javadoc:
+
+- Class-level documentation describes the Metaschema definition
+- Field documentation includes formal name and description
+- Getter/setter methods reference the underlying property
 
 ## References
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,9 +198,36 @@ Checkstyle enforces these rules (configured in [oss-maven checkstyle.xml](https:
 - `AtclauseOrder` - tags must follow order: `@param`, `@return`, `@throws`, `@deprecated`
 
 Exceptions (no Javadoc required):
-- `@Override` methods (inherit documentation)
+- `@Override` methods (inherit documentation from interface/superclass)
 - `@Test` methods (use descriptive names)
 - Generated code (`*.antlr` packages)
+
+When adding implementation-specific behavior to `@Override` methods, use `{@inheritDoc}` with additional notes:
+
+```java
+/**
+ * {@inheritDoc}
+ * <p>
+ * Implementation note: delegates to the model container.
+ */
+@Override
+public List<IChoiceInstance> getChoiceInstances() {
+  return getModelContainer().getChoiceInstances();
+}
+```
+
+### Addressing Automated Review Feedback
+
+When automated reviewers (e.g., CodeRabbit) flag Javadoc issues:
+
+1. **Critical/blocking issues**: Address immediately per project conventions
+2. **@Override method flags**: Use `{@inheritDoc}` if adding implementation notes, otherwise explain the project exception
+3. **Missing `@throws` tags**: Add for declared exceptions
+4. **Nitpick suggestions**: Address if in scope, defer otherwise with explanation
+
+After addressing review comments:
+- Reply explaining what was fixed or why the comment doesn't apply
+- Close resolved conversation threads
 
 ```bash
 # Check Javadoc compliance

--- a/PRDs/20251224-codegen-quality/implementation-plan.md
+++ b/PRDs/20251224-codegen-quality/implementation-plan.md
@@ -436,3 +436,5 @@ mvn -pl metaschema-testing test
 | #572 | Interface patterns + collection class override | PR 2, PR 3 |
 | #573 | Bootstrap standardization | PR 3 |
 | #575 | Consolidated improvements | ✅ PR 1 |
+| #594 | Choice instance support for annotation-based bindings | PR 5 |
+| #595 | Format-appropriate names in validation error messages | Future |

--- a/PRDs/20251224-codegen-quality/implementation-plan.md
+++ b/PRDs/20251224-codegen-quality/implementation-plan.md
@@ -249,16 +249,16 @@ This PR creates the databind bootstrap infrastructure and regenerates the databi
 
 ---
 
-## PR 4: Parser Required Field Validation
+## PR 4: Parser Required Field Validation ✅
 
 | Attribute | Value |
 |-----------|-------|
-| **Files Changed** | ~10 |
+| **Files Changed** | ~25 |
 | **Risk Level** | Medium |
 | **Dependencies** | PR 1 |
 | **Target Branch** | develop |
-| **Status** | Pending |
-| **Pull Request** | |
+| **Status** | Completed |
+| **Pull Request** | [#593](https://github.com/metaschema-framework/metaschema-java/pull/593) |
 
 This PR adds validation during parsing to emit meaningful errors when required fields are missing, and includes type compatibility validation for collection class overrides.
 
@@ -294,15 +294,18 @@ Currently, when a required field/flag is missing from input data, the generated 
 
 ### Acceptance Criteria
 
-- [ ] Parser validates required fields are present during deserialization
-- [ ] Missing required field produces clear error with field name and location
-- [ ] Collection class override validates type compatibility (List/Map)
-- [ ] Validation is efficient (no per-field overhead)
-- [ ] Unit tests for required field validation
-- [ ] Unit tests for collection class type validation
-- [ ] `mvn checkstyle:check` passes
-- [ ] All tests pass: `mvn test`
-- [ ] Build succeeds: `mvn clean install -PCI -Prelease`
+- [x] Parser validates required fields are present during deserialization
+- [x] Missing required field produces clear error with field name and location
+- [x] Collection class override validates type compatibility (Collection/Map)
+- [x] Validation is efficient (no per-field overhead)
+- [x] Choice group support - only error if ALL options in choice are missing
+- [x] Unit tests for required field validation
+- [x] Unit tests for collection class type validation
+- [x] Required field validation enabled by default
+- [x] CLI validators disable required field validation (schema handles it)
+- [x] `mvn checkstyle:check` passes
+- [x] All tests pass: `mvn test`
+- [x] Build succeeds: `mvn clean install -PCI -Prelease`
 
 ---
 
@@ -313,7 +316,7 @@ Currently, when a required field/flag is missing from input data, the generated 
 | 1 | Code generator improvements + metaschema-testing regeneration | 20 | Low | None | ✅ Completed ([#577](https://github.com/metaschema-framework/metaschema-java/pull/577)) |
 | 2 | Collection class override support | ~15 | Low | PR 1 | ✅ Completed ([#584](https://github.com/metaschema-framework/metaschema-java/pull/584)) |
 | 3 | Databind bootstrap setup + regeneration | ~55 | Medium | PR 1, PR 2 | ✅ Completed (combined with PR 2) |
-| 4 | Parser required field validation | ~10 | Medium | PR 1 | Pending |
+| 4 | Parser required field validation | ~25 | Medium | PR 1 | ✅ Completed ([#593](https://github.com/metaschema-framework/metaschema-java/pull/593)) |
 
 **Total Estimated PRs**: 4 (3 actual - PR 2 and PR 3 combined)
 **Total Estimated Files**: ~100

--- a/PRDs/20251224-codegen-quality/implementation-plan.md
+++ b/PRDs/20251224-codegen-quality/implementation-plan.md
@@ -309,6 +309,91 @@ Currently, when a required field/flag is missing from input data, the generated 
 
 ---
 
+## PR 5: Choice Instance Support for Annotation-Based Bindings
+
+| Attribute | Value |
+|-----------|-------|
+| **Files Changed** | ~10 |
+| **Risk Level** | Medium |
+| **Dependencies** | PR 4 |
+| **Target Branch** | develop |
+| **Status** | Pending |
+| **Issue** | [#594](https://github.com/metaschema-framework/metaschema-java/issues/594), [#262](https://github.com/metaschema-framework/metaschema-java/issues/262) |
+
+This PR adds full choice instance support to annotation-based bindings, enabling required field validation to work correctly for dynamically compiled modules.
+
+### Background
+
+Metaschema has two related but distinct concepts:
+
+| Concept | Interface | Purpose | Current Support |
+|---------|-----------|---------|-----------------|
+| **Choice** | `IChoiceInstance` | Mutually exclusive alternatives | ❌ Not supported |
+| **Choice Group** | `IChoiceGroupInstance` | Polymorphic collection with discriminator | ✅ `@BoundChoiceGroup` |
+
+PR 4 added required field validation with choice group support, but only for `DefinitionAssemblyGlobal` (Metaschema-loaded modules). Dynamically compiled modules use `DefinitionAssembly` which returns an empty list for `getChoiceInstances()`.
+
+### Files to Create
+
+| File | Purpose |
+|------|---------|
+| `databind/.../annotations/BoundChoice.java` | Annotation to mark fields in a choice |
+| `databind/.../model/impl/InstanceModelChoice.java` | `IChoiceInstance` implementation for bindings |
+
+### Files to Modify
+
+| File | Changes |
+|------|---------|
+| `databind/.../model/impl/AssemblyModelGenerator.java` | Group `@BoundChoice` fields, create choice instances |
+| `databind/.../codegen/typeinfo/AbstractModelInstanceTypeInfo.java` | Emit `@BoundChoice` for fields in choices |
+| Bootstrap binding classes | Regenerate with new annotations |
+
+### Implementation Approach
+
+1. **New `@BoundChoice` annotation**
+   - `choiceId` attribute to group mutually exclusive fields
+   - Applied to fields within Metaschema `<choice>` elements
+
+2. **New `InstanceModelChoice` class**
+   - Implements `IChoiceInstance`
+   - Wraps a list of `IBoundInstanceModelNamed<?>` instances
+   - Provides `getNamedModelInstances()` for validation
+
+3. **Update `AssemblyModelGenerator`**
+   - Collect fields annotated with `@BoundChoice`
+   - Group by `choiceId`
+   - Create `InstanceModelChoice` for each group
+   - Call `builder.append(choiceInstance)`
+
+4. **Update code generator**
+   - Track choice context during model traversal
+   - Emit `@BoundChoice(choiceId = "choice-N")` on fields within choices
+
+5. **Adjacency validation**
+   - Choice fields must be adjacent in the model (same position in serialization order)
+   - Validate at binding initialization that all fields with same `choiceId` are consecutive
+   - Throw `IllegalStateException` if non-adjacent choice fields detected
+   - Catches code generator bugs, manual edits, and inheritance issues
+
+### Acceptance Criteria
+
+- [ ] New `@BoundChoice` annotation created with `choiceId` attribute
+- [ ] `InstanceModelChoice` implements `IChoiceInstance` correctly
+- [ ] `AssemblyModelGenerator` groups fields by choice and creates instances
+- [ ] Adjacency validation - verify choice fields are consecutive at initialization
+- [ ] Code generator emits `@BoundChoice` for fields in Metaschema choices
+- [ ] `DefinitionAssembly.getChoiceInstances()` returns proper choice instances
+- [ ] Required field validation works for dynamically compiled modules
+- [ ] Remove workarounds added in PR 4 for choice group limitation
+- [ ] Bootstrap binding classes regenerated with new annotations
+- [ ] Unit tests for choice instance creation and validation
+- [ ] Unit tests for adjacency validation (positive and negative cases)
+- [ ] `mvn checkstyle:check` passes
+- [ ] All tests pass: `mvn test`
+- [ ] Build succeeds: `mvn clean install -PCI -Prelease`
+
+---
+
 ## PR Summary Table
 
 | PR | Description | Files | Risk | Dependencies | Status |
@@ -317,9 +402,10 @@ Currently, when a required field/flag is missing from input data, the generated 
 | 2 | Collection class override support | ~15 | Low | PR 1 | ✅ Completed ([#584](https://github.com/metaschema-framework/metaschema-java/pull/584)) |
 | 3 | Databind bootstrap setup + regeneration | ~55 | Medium | PR 1, PR 2 | ✅ Completed (combined with PR 2) |
 | 4 | Parser required field validation | ~25 | Medium | PR 1 | ✅ Completed ([#593](https://github.com/metaschema-framework/metaschema-java/pull/593)) |
+| 5 | Choice instance support for bindings | ~10 | Medium | PR 4 | Pending ([#594](https://github.com/metaschema-framework/metaschema-java/issues/594)) |
 
-**Total Estimated PRs**: 4 (3 actual - PR 2 and PR 3 combined)
-**Total Estimated Files**: ~100
+**Total Estimated PRs**: 5 (4 actual - PR 2 and PR 3 combined)
+**Total Estimated Files**: ~110
 
 ---
 

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/IBindingContext.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/IBindingContext.java
@@ -447,6 +447,8 @@ public interface IBindingContext {
       @Nullable IConfiguration<ValidationFeature<?>> config) {
     IBoundLoader loader = newBoundLoader();
     loader.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_CONSTRAINTS);
+    // Disable required field validation since schema validation handles this
+    loader.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
 
     DynamicContext context = new DynamicContext();
     context.setDocumentLoader(loader);
@@ -570,6 +572,8 @@ public interface IBindingContext {
       throws IOException, ConstraintValidationException {
     IBoundLoader loader = newBoundLoader();
     loader.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_CONSTRAINTS);
+    // Disable required field validation since schema validation handles this
+    loader.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
     IDocumentNodeItem nodeItem = loader.loadAsNodeItem(target);
 
     return validate(nodeItem, loader, config);

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/config/DefaultBindingConfiguration.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/config/DefaultBindingConfiguration.java
@@ -15,6 +15,7 @@ import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import gov.nist.secauto.metaschema.databind.IBindingContext;
 import gov.nist.secauto.metaschema.databind.codegen.ClassUtils;
 import gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings;
+import gov.nist.secauto.metaschema.databind.io.BindingException;
 import gov.nist.secauto.metaschema.databind.io.Format;
 import gov.nist.secauto.metaschema.databind.io.IDeserializer;
 
@@ -25,6 +26,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -295,8 +297,10 @@ public class DefaultBindingConfiguration implements IBindingConfiguration {
    *          the configuration resource
    * @throws IOException
    *           if an error occurred while reading the {@code file}
+   * @throws BindingException
+   *           if an error occurred while processing the binding configuration
    */
-  public void load(Path file) throws IOException {
+  public void load(Path file) throws IOException, BindingException {
     URL resource = file.toAbsolutePath().normalize().toUri().toURL();
     load(resource);
   }
@@ -308,8 +312,10 @@ public class DefaultBindingConfiguration implements IBindingConfiguration {
    *          the configuration resource
    * @throws IOException
    *           if an error occurred while reading the {@code file}
+   * @throws BindingException
+   *           if an error occurred while processing the binding configuration
    */
-  public void load(File file) throws IOException {
+  public void load(File file) throws IOException, BindingException {
     load(file.toPath());
   }
 
@@ -320,8 +326,10 @@ public class DefaultBindingConfiguration implements IBindingConfiguration {
    *          the configuration resource
    * @throws IOException
    *           if an error occurred while reading the {@code resource}
+   * @throws BindingException
+   *           if an error occurred while processing the binding configuration
    */
-  public void load(URL resource) throws IOException {
+  public void load(URL resource) throws IOException, BindingException {
     IBindingContext context = IBindingContext.newInstance();
     IDeserializer<MetaschemaBindings> deserializer = context.newDeserializer(Format.XML, MetaschemaBindings.class);
 
@@ -364,7 +372,7 @@ public class DefaultBindingConfiguration implements IBindingConfiguration {
   }
 
   private void processMetaschemaBindingConfig(URL configResource, MetaschemaBindings.MetaschemaBinding metaschema)
-      throws MalformedURLException, URISyntaxException {
+      throws MalformedURLException, URISyntaxException, BindingException {
     String href = metaschema.getHref().toString();
     URL moduleUrl = new URL(configResource, href);
     String moduleUri = ObjectUtils.notNull(moduleUrl.toURI().normalize().toString());
@@ -441,6 +449,8 @@ public class DefaultBindingConfiguration implements IBindingConfiguration {
    *          function to extract the Java config from a binding
    * @param collectionClassAccessor
    *          function to extract the collection class name from a Java config
+   * @throws BindingException
+   *           if the collection class is invalid or cannot be found
    */
   private static <P, J> void processPropertyBindings(
       @NonNull MetaschemaBindingConfiguration metaschemaConfig,
@@ -448,7 +458,7 @@ public class DefaultBindingConfiguration implements IBindingConfiguration {
       @Nullable List<P> propertyBindings,
       @NonNull Function<P, String> nameAccessor,
       @NonNull Function<P, J> javaAccessor,
-      @NonNull Function<J, String> collectionClassAccessor) {
+      @NonNull Function<J, String> collectionClassAccessor) throws BindingException {
     if (propertyBindings == null) {
       return;
     }
@@ -466,10 +476,49 @@ public class DefaultBindingConfiguration implements IBindingConfiguration {
 
       String collectionClassName = collectionClassAccessor.apply(java);
       if (collectionClassName != null) {
+        // Validate the collection class
+        validateCollectionClass(collectionClassName, definitionName, propertyName);
+
         IMutablePropertyBindingConfiguration config = new DefaultPropertyBindingConfiguration();
         config.setCollectionClassName(collectionClassName);
         metaschemaConfig.addPropertyBindingConfig(definitionName, propertyName, config);
       }
+    }
+  }
+
+  /**
+   * Validate that the specified collection class exists and implements a
+   * supported collection interface (Collection or Map).
+   *
+   * @param collectionClassName
+   *          the fully qualified class name to validate
+   * @param definitionName
+   *          the name of the containing definition (for error messages)
+   * @param propertyName
+   *          the name of the property (for error messages)
+   * @throws BindingException
+   *           if the class cannot be found or does not implement a supported
+   *           collection interface
+   */
+  private static void validateCollectionClass(
+      @NonNull String collectionClassName,
+      @NonNull String definitionName,
+      @NonNull String propertyName) throws BindingException {
+    Class<?> collectionClass;
+    try {
+      collectionClass = Class.forName(collectionClassName);
+    } catch (ClassNotFoundException ex) {
+      throw new BindingException(String.format(
+          "Collection class '%s' for property '%s' in definition '%s' could not be found",
+          collectionClassName, propertyName, definitionName), ex);
+    }
+
+    // Check if the class implements Collection or Map
+    if (!Collection.class.isAssignableFrom(collectionClass) && !Map.class.isAssignableFrom(collectionClass)) {
+      throw new BindingException(String.format(
+          "Collection class '%s' for property '%s' in definition '%s' must implement "
+              + "java.util.Collection or java.util.Map",
+          collectionClassName, propertyName, definitionName));
     }
   }
 
@@ -482,11 +531,14 @@ public class DefaultBindingConfiguration implements IBindingConfiguration {
    *          the name of the containing definition
    * @param propertyBindings
    *          the list of property bindings to process
+   * @throws BindingException
+   *           if the collection class is invalid or cannot be found
    */
   private static void processAssemblyPropertyBindings(
       @NonNull MetaschemaBindingConfiguration metaschemaConfig,
       @NonNull String definitionName,
-      @Nullable List<MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.PropertyBinding> propertyBindings) {
+      @Nullable List<MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.PropertyBinding> propertyBindings)
+      throws BindingException {
     processPropertyBindings(
         metaschemaConfig,
         definitionName,
@@ -505,11 +557,14 @@ public class DefaultBindingConfiguration implements IBindingConfiguration {
    *          the name of the containing definition
    * @param propertyBindings
    *          the list of property bindings to process
+   * @throws BindingException
+   *           if the collection class is invalid or cannot be found
    */
   private static void processFieldPropertyBindings(
       @NonNull MetaschemaBindingConfiguration metaschemaConfig,
       @NonNull String definitionName,
-      @Nullable List<MetaschemaBindings.MetaschemaBinding.DefineFieldBinding.PropertyBinding> propertyBindings) {
+      @Nullable List<MetaschemaBindings.MetaschemaBinding.DefineFieldBinding.PropertyBinding> propertyBindings)
+      throws BindingException {
     processPropertyBindings(
         metaschemaConfig,
         definitionName,

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/AbstractNamedModelInstanceTypeInfo.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/AbstractNamedModelInstanceTypeInfo.java
@@ -23,6 +23,7 @@ import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import gov.nist.secauto.metaschema.databind.codegen.ClassUtils;
 import gov.nist.secauto.metaschema.databind.codegen.typeinfo.def.IAssemblyDefinitionTypeInfo;
 import gov.nist.secauto.metaschema.databind.codegen.typeinfo.def.IModelDefinitionTypeInfo;
+import gov.nist.secauto.metaschema.databind.model.annotations.BoundChoice;
 
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -32,14 +33,42 @@ import java.util.Set;
 import javax.lang.model.element.Modifier;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 abstract class AbstractNamedModelInstanceTypeInfo<INSTANCE extends INamedModelInstanceAbsolute>
     extends AbstractModelInstanceTypeInfo<INSTANCE>
     implements INamedModelInstanceTypeInfo {
+
+  @Nullable
+  private String choiceId;
+
   public AbstractNamedModelInstanceTypeInfo(
       @NonNull INSTANCE instance,
       @NonNull IAssemblyDefinitionTypeInfo parentDefinition) {
     super(instance, parentDefinition);
+  }
+
+  /**
+   * Get the choice ID if this instance is part of a choice.
+   *
+   * @return the choice ID, or {@code null} if not part of a choice
+   */
+  @Nullable
+  public String getChoiceId() {
+    return choiceId;
+  }
+
+  /**
+   * Set the choice ID for this instance.
+   * <p>
+   * This should be called when the instance is part of a Metaschema choice to
+   * associate it with its choice group.
+   *
+   * @param choiceId
+   *          the choice ID to set
+   */
+  public void setChoiceId(@Nullable String choiceId) {
+    this.choiceId = choiceId;
   }
 
   @Override
@@ -85,6 +114,14 @@ abstract class AbstractNamedModelInstanceTypeInfo<INSTANCE extends INamedModelIn
       TypeSpec.Builder typeBuilder,
       FieldSpec.Builder fieldBuilder) {
     Set<IModelDefinition> retval = super.buildField(typeBuilder, fieldBuilder);
+
+    // Add @BoundChoice annotation if this instance is part of a choice
+    String choiceIdValue = getChoiceId();
+    if (choiceIdValue != null) {
+      AnnotationSpec.Builder choiceAnnotation = AnnotationSpec.builder(BoundChoice.class);
+      choiceAnnotation.addMember("choiceId", "$S", choiceIdValue);
+      fieldBuilder.addAnnotation(choiceAnnotation.build());
+    }
 
     IModelDefinition definition = getInstance().getDefinition();
     if (definition.isInline() && (definition.hasChildren() || definition instanceof IAssemblyDefinition)) {

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/AbstractNamedModelInstanceTypeInfo.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/AbstractNamedModelInstanceTypeInfo.java
@@ -67,6 +67,7 @@ abstract class AbstractNamedModelInstanceTypeInfo<INSTANCE extends INamedModelIn
    * @param choiceId
    *          the choice ID to set
    */
+  @Override
   public void setChoiceId(@Nullable String choiceId) {
     this.choiceId = choiceId;
   }

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/INamedModelInstanceTypeInfo.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/INamedModelInstanceTypeInfo.java
@@ -13,10 +13,22 @@ import gov.nist.secauto.metaschema.core.datatype.markup.MarkupLine;
 import gov.nist.secauto.metaschema.core.model.INamedModelInstanceAbsolute;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 public interface INamedModelInstanceTypeInfo extends IModelInstanceTypeInfo {
   @Override
   INamedModelInstanceAbsolute getInstance();
+
+  /**
+   * Set the choice ID for this instance.
+   * <p>
+   * This should be called when the instance is part of a Metaschema choice to
+   * associate it with its choice group.
+   *
+   * @param choiceId
+   *          the choice ID to set, or {@code null} to clear it
+   */
+  void setChoiceId(@Nullable String choiceId);
 
   /**
    * Generate annotation values that are common to all named model instances.

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/def/AssemblyDefinitionTypeInfoImpl.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/def/AssemblyDefinitionTypeInfoImpl.java
@@ -16,6 +16,7 @@ import gov.nist.secauto.metaschema.core.util.CustomCollectors;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import gov.nist.secauto.metaschema.databind.codegen.typeinfo.IInstanceTypeInfo;
 import gov.nist.secauto.metaschema.databind.codegen.typeinfo.IModelInstanceTypeInfo;
+import gov.nist.secauto.metaschema.databind.codegen.typeinfo.INamedModelInstanceTypeInfo;
 import gov.nist.secauto.metaschema.databind.codegen.typeinfo.IPropertyTypeInfo;
 import gov.nist.secauto.metaschema.databind.codegen.typeinfo.ITypeResolver;
 
@@ -40,6 +41,8 @@ class AssemblyDefinitionTypeInfoImpl
   private final Lazy<Map<String, IPropertyTypeInfo>> propertyNameToTypeInfoMap;
   @NonNull
   private final Lazy<Map<IInstance, IInstanceTypeInfo>> instanceToTypeInfoMap;
+
+  private int choiceCounter;
 
   public AssemblyDefinitionTypeInfoImpl(@NonNull IAssemblyDefinition definition, @NonNull ITypeResolver typeResolver) {
     super(definition, typeResolver);
@@ -76,6 +79,23 @@ class AssemblyDefinitionTypeInfoImpl
 
   private Stream<? extends IModelInstanceTypeInfo> processModel(
       @NonNull IContainerModelAbsolute model) {
+    return processModel(model, null);
+  }
+
+  /**
+   * Process a model container, optionally associating named instances with a
+   * choice ID.
+   *
+   * @param model
+   *          the model to process
+   * @param choiceId
+   *          the choice ID to associate with named instances, or {@code null}
+   * @return a stream of model instance type info objects
+   */
+  @NonNull
+  private Stream<? extends IModelInstanceTypeInfo> processModel(
+      @NonNull IContainerModelAbsolute model,
+      @edu.umd.cs.findbugs.annotations.Nullable String choiceId) {
     Stream<IModelInstanceTypeInfo> modelInstances = Stream.empty();
     // create model instances for the model
     for (IModelInstanceAbsolute instance : model.getModelInstances()) {
@@ -86,14 +106,24 @@ class AssemblyDefinitionTypeInfoImpl
             modelInstances,
             Stream.of(getTypeResolver().getTypeInfo((IChoiceGroupInstance) instance, this)));
       } else if (instance instanceof IChoiceInstance) {
+        // Generate a unique choice ID for this choice instance
+        String newChoiceId = "choice-" + (++choiceCounter);
         modelInstances = Stream.concat(
             modelInstances,
-            processModel((IChoiceInstance) instance));
+            processModel((IChoiceInstance) instance, newChoiceId));
       } else if (instance instanceof INamedModelInstanceAbsolute) {
         // else the instance is an object model instance with a name
+        INamedModelInstanceTypeInfo typeInfo = getTypeResolver()
+            .getTypeInfo((INamedModelInstanceAbsolute) instance, this);
+
+        // Set the choice ID if this instance is part of a choice
+        if (choiceId != null) {
+          typeInfo.setChoiceId(choiceId);
+        }
+
         modelInstances = Stream.concat(
             modelInstances,
-            Stream.of(getTypeResolver().getTypeInfo((INamedModelInstanceAbsolute) instance, this)));
+            Stream.of(typeInfo));
       }
     }
     return modelInstances;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/AbstractProblemHandler.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/AbstractProblemHandler.java
@@ -156,21 +156,26 @@ public abstract class AbstractProblemHandler implements IProblemHandler {
   }
 
   /**
-   * Check if a choice is satisfied (at least one option was provided).
+   * Check if a choice is satisfied.
    * <p>
-   * Note: This method assumes the choice has at least one named model instance,
-   * which is guaranteed by valid Metaschema definitions.
+   * A choice is satisfied if:
+   * <ul>
+   * <li>At least one alternative was provided, OR</li>
+   * <li>The choice is optional (minOccurs = 0) and no alternative is required
+   * </li>
+   * </ul>
    *
    * @param choice
    *          the choice to check
    * @param unhandledNames
    *          the set of instance names that were NOT provided
-   * @return {@code true} if at least one option in the choice was provided,
-   *         {@code false} if all options are missing
+   * @return {@code true} if the choice requirements are satisfied, {@code false}
+   *         if a required alternative is missing
    */
   private static boolean isChoiceSatisfied(
       @NonNull IChoiceInstance choice,
       @NonNull Set<String> unhandledNames) {
+    // Check if any alternative was provided
     for (INamedModelInstanceAbsolute modelInstance : choice.getNamedModelInstances()) {
       String name = modelInstance.getJsonName();
       if (!unhandledNames.contains(name)) {
@@ -178,8 +183,10 @@ public abstract class AbstractProblemHandler implements IProblemHandler {
         return true;
       }
     }
-    // All siblings are in the unhandled list - choice is not satisfied
-    return false;
+
+    // All siblings are in the unhandled list - check if choice is optional
+    // If choice.getMinOccurs() == 0, having no selection is valid
+    return choice.getMinOccurs() == 0;
   }
 
   /**

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/AbstractProblemHandler.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/AbstractProblemHandler.java
@@ -157,6 +157,9 @@ public abstract class AbstractProblemHandler implements IProblemHandler {
 
   /**
    * Check if a choice is satisfied (at least one option was provided).
+   * <p>
+   * Note: This method assumes the choice has at least one named model instance,
+   * which is guaranteed by valid Metaschema definitions.
    *
    * @param choice
    *          the choice to check

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/AbstractProblemHandler.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/AbstractProblemHandler.java
@@ -6,22 +6,215 @@
 package gov.nist.secauto.metaschema.databind.io;
 
 import gov.nist.secauto.metaschema.core.model.IBoundObject;
+import gov.nist.secauto.metaschema.core.model.IChoiceInstance;
+import gov.nist.secauto.metaschema.core.model.IFlagInstance;
+import gov.nist.secauto.metaschema.core.model.IModelInstance;
+import gov.nist.secauto.metaschema.core.model.INamedModelInstanceAbsolute;
+import gov.nist.secauto.metaschema.databind.model.IBoundDefinitionModelAssembly;
 import gov.nist.secauto.metaschema.databind.model.IBoundDefinitionModelComplex;
 import gov.nist.secauto.metaschema.databind.model.IBoundProperty;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Abstract base class for problem handlers that can validate required fields
+ * during deserialization.
+ */
 public abstract class AbstractProblemHandler implements IProblemHandler {
+  private final boolean validateRequiredFields;
+
+  /**
+   * Construct a new problem handler with default settings.
+   * <p>
+   * Required field validation is enabled by default.
+   */
+  protected AbstractProblemHandler() {
+    this(true);
+  }
+
+  /**
+   * Construct a new problem handler with the specified validation setting.
+   *
+   * @param validateRequiredFields
+   *          {@code true} to validate that required fields are present,
+   *          {@code false} to skip validation
+   */
+  protected AbstractProblemHandler(boolean validateRequiredFields) {
+    this.validateRequiredFields = validateRequiredFields;
+  }
+
+  /**
+   * Determine if required field validation is enabled.
+   *
+   * @return {@code true} if required fields should be validated, {@code false}
+   *         otherwise
+   */
+  protected boolean isValidateRequiredFields() {
+    return validateRequiredFields;
+  }
 
   @Override
   public void handleMissingInstances(
       IBoundDefinitionModelComplex parentDefinition,
       IBoundObject targetObject,
       Collection<? extends IBoundProperty<?>> unhandledInstances) throws IOException {
+    if (isValidateRequiredFields()) {
+      validateRequiredFields(parentDefinition, unhandledInstances);
+    }
     applyDefaults(targetObject, unhandledInstances);
+  }
+
+  /**
+   * Validate that all required fields have values or defaults.
+   * <p>
+   * This method handles choice groups correctly: if an instance belongs to a
+   * choice and at least one sibling in that choice was provided, the instance is
+   * not considered missing.
+   *
+   * @param parentDefinition
+   *          the definition containing the unhandled instances
+   * @param unhandledInstances
+   *          the collection of unhandled instances to validate
+   * @throws IOException
+   *           if a required field is missing and has no default value
+   */
+  protected void validateRequiredFields(
+      @NonNull IBoundDefinitionModelComplex parentDefinition,
+      @NonNull Collection<? extends IBoundProperty<?>> unhandledInstances) throws IOException {
+
+    // Build a set of unhandled instance names for quick lookup
+    Set<String> unhandledNames = new HashSet<>();
+    for (IBoundProperty<?> instance : unhandledInstances) {
+      unhandledNames.add(getInstanceName(instance));
+    }
+
+    // Build a map from instance name to its choice group (if any)
+    Map<String, IChoiceInstance> instanceToChoice = buildInstanceToChoiceMap(parentDefinition);
+
+    List<String> missingRequired = new ArrayList<>();
+
+    for (IBoundProperty<?> instance : unhandledInstances) {
+      if (isRequiredAndMissingDefault(instance)) {
+        String instanceName = getInstanceName(instance);
+        IChoiceInstance choice = instanceToChoice.get(instanceName);
+
+        if (choice != null) {
+          // Instance belongs to a choice group - check if any sibling was provided
+          if (!isChoiceSatisfied(choice, unhandledNames)) {
+            // All siblings in the choice are missing - report this as an error
+            missingRequired.add(instanceName);
+          }
+          // else: at least one sibling was provided, choice is satisfied
+        } else {
+          // Not in a choice group - normal required field check
+          missingRequired.add(instanceName);
+        }
+      }
+    }
+
+    if (!missingRequired.isEmpty()) {
+      throw new IOException(String.format(
+          "Missing required %s in %s: %s",
+          missingRequired.size() == 1 ? "property" : "properties",
+          parentDefinition.getName(),
+          String.join(", ", missingRequired)));
+    }
+  }
+
+  /**
+   * Build a map from instance name to its containing choice instance.
+   *
+   * @param parentDefinition
+   *          the parent definition to examine
+   * @return a map of instance names to their choice groups, empty if no choices
+   */
+  @NonNull
+  private static Map<String, IChoiceInstance> buildInstanceToChoiceMap(
+      @NonNull IBoundDefinitionModelComplex parentDefinition) {
+    Map<String, IChoiceInstance> result = new HashMap<>();
+
+    if (parentDefinition instanceof IBoundDefinitionModelAssembly) {
+      IBoundDefinitionModelAssembly assembly = (IBoundDefinitionModelAssembly) parentDefinition;
+      for (IChoiceInstance choice : assembly.getChoiceInstances()) {
+        for (INamedModelInstanceAbsolute modelInstance : choice.getNamedModelInstances()) {
+          // Use the JSON name for consistency with how we track instances
+          result.put(modelInstance.getJsonName(), choice);
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Check if a choice is satisfied (at least one option was provided).
+   *
+   * @param choice
+   *          the choice to check
+   * @param unhandledNames
+   *          the set of instance names that were NOT provided
+   * @return {@code true} if at least one option in the choice was provided,
+   *         {@code false} if all options are missing
+   */
+  private static boolean isChoiceSatisfied(
+      @NonNull IChoiceInstance choice,
+      @NonNull Set<String> unhandledNames) {
+    for (INamedModelInstanceAbsolute modelInstance : choice.getNamedModelInstances()) {
+      String name = modelInstance.getJsonName();
+      if (!unhandledNames.contains(name)) {
+        // This sibling was provided (not in unhandled list)
+        return true;
+      }
+    }
+    // All siblings are in the unhandled list - choice is not satisfied
+    return false;
+  }
+
+  /**
+   * Determine if the given instance is required and has no default value.
+   *
+   * @param instance
+   *          the instance to check
+   * @return {@code true} if the instance is required and has no default value
+   */
+  private static boolean isRequiredAndMissingDefault(@NonNull IBoundProperty<?> instance) {
+    // Check if the instance has a default value
+    Object defaultValue = instance.getResolvedDefaultValue();
+    if (defaultValue != null) {
+      // Has a default value, so it's not "missing"
+      return false;
+    }
+
+    // Check if the instance is required
+    if (instance instanceof IFlagInstance) {
+      return ((IFlagInstance) instance).isRequired();
+    } else if (instance instanceof IModelInstance) {
+      return ((IModelInstance) instance).getMinOccurs() > 0;
+    }
+
+    // Unknown instance type, don't require it
+    return false;
+  }
+
+  /**
+   * Get a human-readable name for the instance.
+   *
+   * @param instance
+   *          the instance to get the name for
+   * @return the instance name
+   */
+  @NonNull
+  private static String getInstanceName(@NonNull IBoundProperty<?> instance) {
+    return instance.getJsonName();
   }
 
   /**

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/DeserializationFeature.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/DeserializationFeature.java
@@ -55,6 +55,22 @@ public final class DeserializationFeature<V>
   public static final DeserializationFeature<Integer> FORMAT_DETECTION_LOOKAHEAD_LIMIT
       = new DeserializationFeature<>("format-detection-lookahead-limit", Integer.class, FORMAT_DETECTION_LOOKAHEAD);
 
+  /**
+   * If enabled, validate that required fields are present during deserialization.
+   * When a required field is missing and has no default value, an error will be
+   * thrown with a descriptive message.
+   * <p>
+   * Choice groups are handled correctly: if an instance belongs to a choice and
+   * at least one sibling in that choice was provided, the instance is not
+   * considered missing.
+   * <p>
+   * When using schema validation via CLI commands, this feature is automatically
+   * disabled since the schema already validates required fields.
+   */
+  @NonNull
+  public static final DeserializationFeature<Boolean> DESERIALIZE_VALIDATE_REQUIRED_FIELDS
+      = new DeserializationFeature<>("validate-required-fields", Boolean.class, true);
+
   private DeserializationFeature(
       @NonNull String name,
       @NonNull Class<V> valueClass,

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/json/DefaultJsonDeserializer.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/json/DefaultJsonDeserializer.java
@@ -103,12 +103,35 @@ public class DefaultJsonDeserializer<CLASS extends IBoundObject>
     return ObjectUtils.notNull(getJsonFactory().createParser(reader));
   }
 
+  /**
+   * Create a new JSON reader with the appropriate problem handler based on the
+   * current configuration.
+   *
+   * @param jsonParser
+   *          the JSON parser to use
+   * @param documentUri
+   *          the URI of the document being parsed
+   * @return the new reader
+   * @throws IOException
+   *           if an error occurred creating the reader
+   */
+  @NonNull
+  private MetaschemaJsonReader newMetaschemaJsonReader(
+      @NonNull JsonParser jsonParser,
+      @NonNull URI documentUri) throws IOException {
+    boolean validateRequired = isFeatureEnabled(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
+    return new MetaschemaJsonReader(
+        jsonParser,
+        documentUri,
+        new DefaultJsonProblemHandler(validateRequired));
+  }
+
   @Override
   protected INodeItem deserializeToNodeItemInternal(@NonNull Reader reader, @NonNull URI documentUri)
       throws IOException {
     INodeItem retval;
     try (JsonParser jsonParser = newJsonParser(reader)) {
-      MetaschemaJsonReader parser = new MetaschemaJsonReader(jsonParser, documentUri);
+      MetaschemaJsonReader parser = newMetaschemaJsonReader(jsonParser, documentUri);
       IBoundDefinitionModelAssembly definition = getDefinition();
       IConfiguration<DeserializationFeature<?>> configuration = getConfiguration();
 
@@ -133,7 +156,7 @@ public class DefaultJsonDeserializer<CLASS extends IBoundObject>
   @Override
   public CLASS deserializeToValueInternal(@NonNull Reader reader, @NonNull URI documentUri) throws IOException {
     try (JsonParser jsonParser = newJsonParser(reader)) {
-      MetaschemaJsonReader parser = new MetaschemaJsonReader(jsonParser, documentUri);
+      MetaschemaJsonReader parser = newMetaschemaJsonReader(jsonParser, documentUri);
       IBoundDefinitionModelAssembly definition = getDefinition();
       IConfiguration<DeserializationFeature<?>> configuration = getConfiguration();
 

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/json/DefaultJsonProblemHandler.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/json/DefaultJsonProblemHandler.java
@@ -29,6 +29,24 @@ public class DefaultJsonProblemHandler
     IGNORED_FIELD_NAMES.add(JSON_SCHEMA_FIELD_NAME);
   }
 
+  /**
+   * Construct a new problem handler with required field validation enabled.
+   */
+  public DefaultJsonProblemHandler() {
+    super();
+  }
+
+  /**
+   * Construct a new problem handler with the specified validation setting.
+   *
+   * @param validateRequiredFields
+   *          {@code true} to validate that required fields are present,
+   *          {@code false} to skip validation
+   */
+  public DefaultJsonProblemHandler(boolean validateRequiredFields) {
+    super(validateRequiredFields);
+  }
+
   @Override
   public boolean handleUnknownProperty(
       IBoundDefinitionModelComplex classBinding,

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/xml/DefaultXmlDeserializer.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/xml/DefaultXmlDeserializer.java
@@ -162,8 +162,11 @@ public class DefaultXmlDeserializer<CLASS extends IBoundObject>
   @NonNull
   private CLASS parseXmlInternal(@NonNull XMLEventReader2 reader, @NonNull URI resource)
       throws IOException {
-
-    MetaschemaXmlReader parser = new MetaschemaXmlReader(reader, resource, new DefaultXmlProblemHandler());
+    boolean validateRequired = isFeatureEnabled(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
+    MetaschemaXmlReader parser = new MetaschemaXmlReader(
+        reader,
+        resource,
+        new DefaultXmlProblemHandler(validateRequired));
 
     try {
       return parser.read(rootDefinition);

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/xml/DefaultXmlProblemHandler.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/io/xml/DefaultXmlProblemHandler.java
@@ -32,6 +32,24 @@ public class DefaultXmlProblemHandler
     implements IXmlProblemHandler {
   private static final Logger LOGGER = LogManager.getLogger(DefaultXmlProblemHandler.class);
 
+  /**
+   * Construct a new problem handler with required field validation enabled.
+   */
+  public DefaultXmlProblemHandler() {
+    super();
+  }
+
+  /**
+   * Construct a new problem handler with the specified validation setting.
+   *
+   * @param validateRequiredFields
+   *          {@code true} to validate that required fields are present,
+   *          {@code false} to skip validation
+   */
+  public DefaultXmlProblemHandler(boolean validateRequiredFields) {
+    super(validateRequiredFields);
+  }
+
   private static final IEnhancedQName XSI_SCHEMA_LOCATION
       = IEnhancedQName.of("http://www.w3.org/2001/XMLSchema-instance", "schemaLocation");
   private static final Set<IEnhancedQName> IGNORED_QNAMES;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/IBoundDefinitionModelAssembly.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/IBoundDefinitionModelAssembly.java
@@ -62,13 +62,6 @@ public interface IBoundDefinitionModelAssembly
 
   @Override
   @NonNull
-  default List<IChoiceInstance> getChoiceInstances() {
-    // not supported
-    return CollectionUtil.emptyList();
-  }
-
-  @Override
-  @NonNull
   default Map<String, IBoundProperty<?>> getJsonProperties(@Nullable Predicate<IBoundInstanceFlag> flagFilter) {
     Stream<? extends IBoundInstanceFlag> flagStream = getFlagInstances().stream();
 

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/annotations/BoundChoice.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/annotations/BoundChoice.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.databind.model.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Identifies that the annotation target is a bound property that participates
+ * in a Metaschema choice.
+ * <p>
+ * A choice represents mutually exclusive alternatives in a Metaschema model.
+ * Fields with the same {@link #choiceId()} are part of the same choice and
+ * exactly one of them must be provided when the choice is required.
+ * <p>
+ * This is distinct from {@link BoundChoiceGroup}, which represents a
+ * polymorphic collection with a type discriminator.
+ * <p>
+ * <strong>Adjacency requirement:</strong> All fields with the same
+ * {@code choiceId} must be declared consecutively in the class, reflecting the
+ * Metaschema model where choice alternatives occupy the same position in the
+ * serialization order.
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({ FIELD, METHOD })
+public @interface BoundChoice {
+  /**
+   * Identifies which choice this field belongs to.
+   * <p>
+   * Fields with the same choiceId are mutually exclusive alternatives. The
+   * choiceId must be unique within the containing assembly and consistent across
+   * all alternatives in the choice.
+   *
+   * @return the choice identifier
+   */
+  @NonNull
+  String choiceId();
+}

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/impl/AssemblyModelGenerator.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/impl/AssemblyModelGenerator.java
@@ -17,22 +17,78 @@ import gov.nist.secauto.metaschema.databind.model.IBoundInstanceModelChoiceGroup
 import gov.nist.secauto.metaschema.databind.model.IBoundInstanceModelField;
 import gov.nist.secauto.metaschema.databind.model.IBoundInstanceModelNamed;
 import gov.nist.secauto.metaschema.databind.model.annotations.BoundAssembly;
+import gov.nist.secauto.metaschema.databind.model.annotations.BoundChoice;
 import gov.nist.secauto.metaschema.databind.model.annotations.BoundChoiceGroup;
 import gov.nist.secauto.metaschema.databind.model.annotations.BoundField;
 import gov.nist.secauto.metaschema.databind.model.annotations.Ignore;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * Generates assembly model containers for annotation-based bindings.
+ */
 final class AssemblyModelGenerator {
 
-  @SuppressWarnings("PMD.ShortMethodName")
+  /**
+   * A custom builder that allows adding choice instances without adding them to
+   * the model instances list.
+   * <p>
+   * For annotation-based bindings, the choice alternatives (fields/assemblies)
+   * are already in the model instances list with their {@code @BoundChoice}
+   * annotations. The {@link BoundInstanceModelChoice} wrapper is metadata that
+   * groups them, but should not be iterated during reading.
+   *
+   * @param <MI>
+   *          the model instance type
+   * @param <NMI>
+   *          the named model instance type
+   * @param <FI>
+   *          the field instance type
+   * @param <AI>
+   *          the assembly instance type
+   * @param <CI>
+   *          the choice instance type
+   * @param <CGI>
+   *          the choice group instance type
+   */
+  private static final class BoundAssemblyModelBuilder<
+      MI extends IBoundInstanceModel<?>,
+      NMI extends IBoundInstanceModelNamed<?>,
+      FI extends IBoundInstanceModelField<?>,
+      AI extends IBoundInstanceModelAssembly,
+      CI extends IChoiceInstance,
+      CGI extends IBoundInstanceModelChoiceGroup>
+      extends DefaultAssemblyModelBuilder<MI, NMI, FI, AI, CI, CGI> {
+
+    /**
+     * Append a choice instance to the choice instances list only, without adding it
+     * to the model instances list.
+     * <p>
+     * This is used for annotation-based bindings where choice alternatives are
+     * already in the model instances list as regular field/assembly instances.
+     *
+     * @param instance
+     *          the choice instance to append
+     */
+    void appendChoiceOnly(@NonNull CI instance) {
+      getChoiceInstances().add(instance);
+    }
+  }
+
+  @SuppressWarnings({
+      "PMD.ShortMethodName",
+      "PMD.CyclomaticComplexity" // reasonable for model building logic
+  })
   @NonNull
   public static IContainerModelAssemblySupport<
       IBoundInstanceModel<?>,
@@ -41,16 +97,32 @@ final class AssemblyModelGenerator {
       IBoundInstanceModelAssembly,
       IChoiceInstance,
       IBoundInstanceModelChoiceGroup> of(@NonNull DefinitionAssembly containingDefinition) {
-    DefaultAssemblyModelBuilder<IBoundInstanceModel<?>,
+    BoundAssemblyModelBuilder<IBoundInstanceModel<?>,
         IBoundInstanceModelNamed<?>,
         IBoundInstanceModelField<?>,
         IBoundInstanceModelAssembly,
         IChoiceInstance,
-        IBoundInstanceModelChoiceGroup> builder = new DefaultAssemblyModelBuilder<>();
+        IBoundInstanceModelChoiceGroup> builder = new BoundAssemblyModelBuilder<>();
 
     List<IBoundInstanceModel<?>> modelInstances = CollectionUtil.unmodifiableList(ObjectUtils.notNull(
         getModelInstanceStream(containingDefinition, containingDefinition.getBoundClass())
             .collect(Collectors.toUnmodifiableList())));
+
+    // Group named instances by @BoundChoice annotation
+    Map<String, List<ChoiceInstanceEntry>> choiceGroups = groupByChoiceId(modelInstances);
+
+    // Validate that choice instances are adjacent
+    validateChoiceAdjacency(choiceGroups, containingDefinition.getBoundClass());
+
+    // Create choice instances
+    Map<String, BoundInstanceModelChoice> choiceInstances = new LinkedHashMap<>();
+    for (Map.Entry<String, List<ChoiceInstanceEntry>> entry : choiceGroups.entrySet()) {
+      String choiceId = entry.getKey();
+      List<IBoundInstanceModelNamed<?>> instances = entry.getValue().stream()
+          .map(ChoiceInstanceEntry::getInstance)
+          .collect(Collectors.toList());
+      choiceInstances.put(choiceId, new BoundInstanceModelChoice(choiceId, containingDefinition, instances));
+    }
 
     for (IBoundInstanceModel<?> instance : modelInstances) {
       if (instance instanceof IBoundInstanceModelNamed) {
@@ -65,7 +137,102 @@ final class AssemblyModelGenerator {
         builder.append(choiceGroup);
       }
     }
+
+    // Append choice instances to the builder (only to choice list, not model
+    // instances)
+    for (BoundInstanceModelChoice choice : choiceInstances.values()) {
+      builder.appendChoiceOnly(choice);
+    }
+
     return builder.buildAssembly();
+  }
+
+  /**
+   * Groups named model instances by their {@code @BoundChoice} choiceId.
+   *
+   * @param modelInstances
+   *          the list of model instances
+   * @return a map of choiceId to list of instances with their positions
+   */
+  @NonNull
+  private static Map<String, List<ChoiceInstanceEntry>> groupByChoiceId(
+      @NonNull List<IBoundInstanceModel<?>> modelInstances) {
+    Map<String, List<ChoiceInstanceEntry>> choiceGroups = new LinkedHashMap<>();
+
+    int index = 0;
+    for (IBoundInstanceModel<?> instance : modelInstances) {
+      if (instance instanceof IBoundInstanceModelNamed) {
+        IBoundInstanceModelNamed<?> named = (IBoundInstanceModelNamed<?>) instance;
+        Field field = named.getField();
+        BoundChoice annotation = field.getAnnotation(BoundChoice.class);
+        if (annotation != null) {
+          choiceGroups
+              .computeIfAbsent(annotation.choiceId(), k -> new ArrayList<>())
+              .add(new ChoiceInstanceEntry(index, named));
+        }
+      }
+      index++;
+    }
+
+    return choiceGroups;
+  }
+
+  /**
+   * Validates that all fields with the same choiceId are adjacent (consecutive)
+   * in the class declaration.
+   *
+   * @param choiceGroups
+   *          the grouped choice instances
+   * @param boundClass
+   *          the class being validated (for error messages)
+   * @throws IllegalStateException
+   *           if choice fields are not adjacent
+   */
+  private static void validateChoiceAdjacency(
+      @NonNull Map<String, List<ChoiceInstanceEntry>> choiceGroups,
+      @NonNull Class<?> boundClass) {
+    for (Map.Entry<String, List<ChoiceInstanceEntry>> entry : choiceGroups.entrySet()) {
+      String choiceId = entry.getKey();
+      List<ChoiceInstanceEntry> instances = entry.getValue();
+
+      if (instances.size() > 1) {
+        // Check that indices are consecutive
+        for (int i = 1; i < instances.size(); i++) {
+          int prevIndex = instances.get(i - 1).getIndex();
+          int currIndex = instances.get(i).getIndex();
+          if (currIndex != prevIndex + 1) {
+            throw new IllegalStateException(String.format(
+                "Choice fields with choiceId '%s' are not adjacent in class '%s'. "
+                    + "All fields in a choice must be declared consecutively.",
+                choiceId,
+                boundClass.getName()));
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * An entry representing a named model instance with its position in the model.
+   */
+  private static final class ChoiceInstanceEntry {
+    private final int index;
+    @NonNull
+    private final IBoundInstanceModelNamed<?> instance;
+
+    ChoiceInstanceEntry(int index, @NonNull IBoundInstanceModelNamed<?> instance) {
+      this.index = index;
+      this.instance = instance;
+    }
+
+    int getIndex() {
+      return index;
+    }
+
+    @NonNull
+    IBoundInstanceModelNamed<?> getInstance() {
+      return instance;
+    }
   }
 
   private static IBoundInstanceModel<?> newBoundModelInstance(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/impl/BoundInstanceModelChoice.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/impl/BoundInstanceModelChoice.java
@@ -1,0 +1,139 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.databind.model.impl;
+
+import gov.nist.secauto.metaschema.core.datatype.markup.MarkupMultiline;
+import gov.nist.secauto.metaschema.core.model.AbstractChoiceInstance;
+import gov.nist.secauto.metaschema.core.model.DefaultChoiceModelBuilder;
+import gov.nist.secauto.metaschema.core.model.IAssemblyInstanceAbsolute;
+import gov.nist.secauto.metaschema.core.model.IContainerModelSupport;
+import gov.nist.secauto.metaschema.core.model.IFieldInstanceAbsolute;
+import gov.nist.secauto.metaschema.core.model.IModelInstanceAbsolute;
+import gov.nist.secauto.metaschema.core.model.IModule;
+import gov.nist.secauto.metaschema.core.model.INamedModelInstanceAbsolute;
+import gov.nist.secauto.metaschema.databind.model.IBoundDefinitionModelAssembly;
+import gov.nist.secauto.metaschema.databind.model.IBoundInstanceModelAssembly;
+import gov.nist.secauto.metaschema.databind.model.IBoundInstanceModelField;
+import gov.nist.secauto.metaschema.databind.model.IBoundInstanceModelNamed;
+
+import java.util.List;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Represents a choice instance for annotation-based bound definitions.
+ * <p>
+ * A choice contains mutually exclusive model instance alternatives. This class
+ * is used for annotation-based bindings (classes with {@code @BoundChoice}
+ * annotations).
+ */
+public final class BoundInstanceModelChoice
+    extends AbstractChoiceInstance<
+        IBoundDefinitionModelAssembly,
+        IModelInstanceAbsolute,
+        INamedModelInstanceAbsolute,
+        IFieldInstanceAbsolute,
+        IAssemblyInstanceAbsolute> {
+
+  @NonNull
+  private final String choiceId;
+  @NonNull
+  private final IContainerModelSupport<
+      IModelInstanceAbsolute,
+      INamedModelInstanceAbsolute,
+      IFieldInstanceAbsolute,
+      IAssemblyInstanceAbsolute> modelContainer;
+
+  /**
+   * Construct a new choice instance from a list of named model instances.
+   *
+   * @param choiceId
+   *          the identifier for this choice
+   * @param parent
+   *          the containing assembly definition
+   * @param instances
+   *          the list of named model instances that are alternatives in this
+   *          choice
+   */
+  public BoundInstanceModelChoice(
+      @NonNull String choiceId,
+      @NonNull IBoundDefinitionModelAssembly parent,
+      @NonNull List<IBoundInstanceModelNamed<?>> instances) {
+    super(parent);
+    this.choiceId = choiceId;
+    this.modelContainer = buildModelContainer(instances);
+  }
+
+  @NonNull
+  private static IContainerModelSupport<
+      IModelInstanceAbsolute,
+      INamedModelInstanceAbsolute,
+      IFieldInstanceAbsolute,
+      IAssemblyInstanceAbsolute> buildModelContainer(
+          @NonNull List<IBoundInstanceModelNamed<?>> instances) {
+    if (instances.isEmpty()) {
+      return IContainerModelSupport.empty();
+    }
+
+    DefaultChoiceModelBuilder<
+        IModelInstanceAbsolute,
+        INamedModelInstanceAbsolute,
+        IFieldInstanceAbsolute,
+        IAssemblyInstanceAbsolute> builder = new DefaultChoiceModelBuilder<>();
+
+    for (IBoundInstanceModelNamed<?> instance : instances) {
+      if (instance instanceof IBoundInstanceModelField) {
+        builder.append((IFieldInstanceAbsolute) instance);
+      } else if (instance instanceof IBoundInstanceModelAssembly) {
+        builder.append((IAssemblyInstanceAbsolute) instance);
+      }
+    }
+
+    return builder.buildChoice();
+  }
+
+  /**
+   * Get the choice identifier for this choice instance.
+   *
+   * @return the choice identifier
+   */
+  @NonNull
+  public String getChoiceId() {
+    return choiceId;
+  }
+
+  @Override
+  public IContainerModelSupport<
+      IModelInstanceAbsolute,
+      INamedModelInstanceAbsolute,
+      IFieldInstanceAbsolute,
+      IAssemblyInstanceAbsolute> getModelContainer() {
+    return modelContainer;
+  }
+
+  /**
+   * {@inheritDoc}
+   * <p>
+   * For annotation-based bindings, choices are optional by default (minOccurs =
+   * 0). The individual alternatives have their own minOccurs constraints that
+   * apply when that alternative is selected.
+   */
+  @Override
+  public int getMinOccurs() {
+    return 0;
+  }
+
+  @Override
+  public IModule getContainingModule() {
+    return getContainingDefinition().getContainingModule();
+  }
+
+  @Override
+  public MarkupMultiline getRemarks() {
+    // no remarks for annotation-based bindings
+    return null;
+  }
+}

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/impl/BoundInstanceModelChoice.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/impl/BoundInstanceModelChoice.java
@@ -22,6 +22,7 @@ import gov.nist.secauto.metaschema.databind.model.IBoundInstanceModelNamed;
 import java.util.List;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * Represents a choice instance for annotation-based bound definitions.
@@ -132,6 +133,7 @@ public final class BoundInstanceModelChoice
   }
 
   @Override
+  @Nullable
   public MarkupMultiline getRemarks() {
     // no remarks for annotation-based bindings
     return null;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/BindingModuleLoader.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/BindingModuleLoader.java
@@ -62,7 +62,14 @@ public class BindingModuleLoader
   public BindingModuleLoader(
       @NonNull IBindingContext bindingContext,
       @NonNull ModuleLoadingPostProcessor postProcessor) {
-    this.loader = Lazy.of(bindingContext::newBoundLoader);
+    this.loader = Lazy.of(() -> {
+      IBoundLoader boundLoader = bindingContext.newBoundLoader();
+      // Disable required field validation during module loading since:
+      // 1. Metaschema modules have their own schema validation
+      // 2. Module parsing is an internal operation with trusted input
+      boundLoader.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
+      return boundLoader;
+    });
     this.postProcessor = postProcessor;
   }
 

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/BindingModuleLoader.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/BindingModuleLoader.java
@@ -62,14 +62,7 @@ public class BindingModuleLoader
   public BindingModuleLoader(
       @NonNull IBindingContext bindingContext,
       @NonNull ModuleLoadingPostProcessor postProcessor) {
-    this.loader = Lazy.of(() -> {
-      IBoundLoader boundLoader = bindingContext.newBoundLoader();
-      // Disable required field validation because pre-generated binding classes
-      // (METASCHEMA) don't preserve choice group information. See issue #594.
-      // TODO: Remove this workaround when #594 is implemented.
-      boundLoader.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
-      return boundLoader;
-    });
+    this.loader = Lazy.of(() -> bindingContext.newBoundLoader());
     this.postProcessor = postProcessor;
   }
 

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/BindingModuleLoader.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/BindingModuleLoader.java
@@ -64,9 +64,9 @@ public class BindingModuleLoader
       @NonNull ModuleLoadingPostProcessor postProcessor) {
     this.loader = Lazy.of(() -> {
       IBoundLoader boundLoader = bindingContext.newBoundLoader();
-      // Disable required field validation during module loading since:
-      // 1. Metaschema modules have their own schema validation
-      // 2. Module parsing is an internal operation with trusted input
+      // Disable required field validation because pre-generated binding classes
+      // (METASCHEMA) don't preserve choice group information. See issue #594.
+      // TODO: Remove this workaround when #594 is implemented.
       boundLoader.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
       return boundLoader;
     });

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/AssemblyModel.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/AssemblyModel.java
@@ -23,6 +23,7 @@ import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import gov.nist.secauto.metaschema.databind.model.annotations.AllowedValue;
 import gov.nist.secauto.metaschema.databind.model.annotations.AllowedValues;
 import gov.nist.secauto.metaschema.databind.model.annotations.BoundAssembly;
+import gov.nist.secauto.metaschema.databind.model.annotations.BoundChoice;
 import gov.nist.secauto.metaschema.databind.model.annotations.BoundChoiceGroup;
 import gov.nist.secauto.metaschema.databind.model.annotations.BoundField;
 import gov.nist.secauto.metaschema.databind.model.annotations.BoundFlag;
@@ -1863,11 +1864,15 @@ public class AssemblyModel implements IBoundObject {
           formalName = "Field Value JSON Property Name",
           useName = "json-value-key",
           typeAdapter = TokenAdapter.class)
+      @BoundChoice(
+          choiceId = "choice-1")
       private String _jsonValueKey;
 
       @BoundAssembly(
           formalName = "Flag Used as the Field Value's JSON Property Name",
           useName = "json-value-key-flag")
+      @BoundChoice(
+          choiceId = "choice-1")
       private JsonValueKeyFlag _jsonValueKeyFlag;
 
       @BoundChoiceGroup(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/InlineDefineField.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/InlineDefineField.java
@@ -23,6 +23,7 @@ import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import gov.nist.secauto.metaschema.databind.model.annotations.AllowedValue;
 import gov.nist.secauto.metaschema.databind.model.annotations.AllowedValues;
 import gov.nist.secauto.metaschema.databind.model.annotations.BoundAssembly;
+import gov.nist.secauto.metaschema.databind.model.annotations.BoundChoice;
 import gov.nist.secauto.metaschema.databind.model.annotations.BoundChoiceGroup;
 import gov.nist.secauto.metaschema.databind.model.annotations.BoundField;
 import gov.nist.secauto.metaschema.databind.model.annotations.BoundFlag;
@@ -212,11 +213,15 @@ public class InlineDefineField implements IBoundObject {
       formalName = "Field Value JSON Property Name",
       useName = "json-value-key",
       typeAdapter = TokenAdapter.class)
+  @BoundChoice(
+      choiceId = "choice-1")
   private String _jsonValueKey;
 
   @BoundAssembly(
       formalName = "Flag Used as the Field Value's JSON Property Name",
       useName = "json-value-key-flag")
+  @BoundChoice(
+      choiceId = "choice-1")
   private JsonValueKeyFlag _jsonValueKeyFlag;
 
   @BoundAssembly(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/METASCHEMA.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/METASCHEMA.java
@@ -25,6 +25,7 @@ import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import gov.nist.secauto.metaschema.databind.model.annotations.AllowedValue;
 import gov.nist.secauto.metaschema.databind.model.annotations.AllowedValues;
 import gov.nist.secauto.metaschema.databind.model.annotations.BoundAssembly;
+import gov.nist.secauto.metaschema.databind.model.annotations.BoundChoice;
 import gov.nist.secauto.metaschema.databind.model.annotations.BoundChoiceGroup;
 import gov.nist.secauto.metaschema.databind.model.annotations.BoundField;
 import gov.nist.secauto.metaschema.databind.model.annotations.BoundFieldValue;
@@ -769,6 +770,8 @@ public class METASCHEMA implements IBoundObject {
         formalName = "Use Name",
         description = "Allows the name of the definition to be overridden.",
         useName = "use-name")
+    @BoundChoice(
+        choiceId = "choice-1")
     private UseName _useName;
 
     /**
@@ -780,6 +783,8 @@ public class METASCHEMA implements IBoundObject {
         description = "Provides a root name, for when the definition is used as the root of a node hierarchy.",
         useName = "root-name",
         minOccurs = 1)
+    @BoundChoice(
+        choiceId = "choice-1")
     private RootName _rootName;
 
     /**
@@ -1533,11 +1538,15 @@ public class METASCHEMA implements IBoundObject {
         formalName = "Field Value JSON Property Name",
         useName = "json-value-key",
         typeAdapter = TokenAdapter.class)
+    @BoundChoice(
+        choiceId = "choice-1")
     private String _jsonValueKey;
 
     @BoundAssembly(
         formalName = "Flag Used as the Field Value's JSON Property Name",
         useName = "json-value-key-flag")
+    @BoundChoice(
+        choiceId = "choice-1")
     private JsonValueKeyFlag _jsonValueKeyFlag;
 
     @BoundChoiceGroup(

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/DefinitionAssemblyGlobal.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/DefinitionAssemblyGlobal.java
@@ -33,6 +33,7 @@ import gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyCon
 import gov.nist.secauto.metaschema.databind.model.metaschema.binding.JsonKey;
 import gov.nist.secauto.metaschema.databind.model.metaschema.binding.METASCHEMA;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -145,6 +146,11 @@ public class DefinitionAssemblyGlobal
       IChoiceInstance,
       IChoiceGroupInstance> getModelContainer() {
     return ObjectUtils.notNull(modelContainer.get());
+  }
+
+  @Override
+  public List<IChoiceInstance> getChoiceInstances() {
+    return getModelContainer().getChoiceInstances();
   }
 
   @Override

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/DefinitionAssemblyGlobal.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/impl/DefinitionAssemblyGlobal.java
@@ -148,6 +148,11 @@ public class DefinitionAssemblyGlobal
     return ObjectUtils.notNull(modelContainer.get());
   }
 
+  /**
+   * {@inheritDoc}
+   * <p>
+   * Returns choice instances from the model container.
+   */
   @Override
   public List<IChoiceInstance> getChoiceInstances() {
     return getModelContainer().getChoiceInstances();

--- a/databind/src/test/java/gov/nist/secauto/metaschema/databind/codegen/AbstractMetaschemaTest.java
+++ b/databind/src/test/java/gov/nist/secauto/metaschema/databind/codegen/AbstractMetaschemaTest.java
@@ -15,6 +15,7 @@ import gov.nist.secauto.metaschema.core.util.CollectionUtil;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import gov.nist.secauto.metaschema.databind.IBindingContext;
 import gov.nist.secauto.metaschema.databind.codegen.config.DefaultBindingConfiguration;
+import gov.nist.secauto.metaschema.databind.io.BindingException;
 import gov.nist.secauto.metaschema.databind.io.Format;
 import gov.nist.secauto.metaschema.databind.io.IDeserializer;
 
@@ -64,7 +65,7 @@ public abstract class AbstractMetaschemaTest {
       @Nullable Path bindingFile,
       @NonNull String rootClassName,
       @NonNull Path classDir)
-      throws IOException, ClassNotFoundException, MetaschemaException {
+      throws IOException, ClassNotFoundException, MetaschemaException, BindingException {
     IModule module = newBindingContext().loadMetaschema(moduleFile);
 
     DefaultBindingConfiguration bindingConfiguration = new DefaultBindingConfiguration();
@@ -109,7 +110,7 @@ public abstract class AbstractMetaschemaTest {
   }
 
   public void runTests(@NonNull String testPath, @NonNull String rootClassName, @NonNull Path classDir)
-      throws ClassNotFoundException, IOException, MetaschemaException {
+      throws ClassNotFoundException, IOException, MetaschemaException, BindingException {
     runTests(testPath, rootClassName, classDir, null);
   }
 
@@ -118,7 +119,7 @@ public abstract class AbstractMetaschemaTest {
       @NonNull String rootClassName,
       @NonNull Path classDir,
       java.util.function.Consumer<Object> assertions)
-      throws ClassNotFoundException, IOException, MetaschemaException {
+      throws ClassNotFoundException, IOException, MetaschemaException, BindingException {
     runTests(
         ObjectUtils.notNull(Paths.get(String.format("src/test/resources/metaschema/%s/metaschema.xml", testPath))),
         ObjectUtils.notNull(Paths.get(String.format("src/test/resources/metaschema/%s/binding.xml", testPath))),
@@ -135,7 +136,7 @@ public abstract class AbstractMetaschemaTest {
       @NonNull String rootClassName,
       @NonNull Path classDir,
       java.util.function.Consumer<Object> assertions)
-      throws ClassNotFoundException, IOException, MetaschemaException {
+      throws ClassNotFoundException, IOException, MetaschemaException, BindingException {
 
     Class<? extends IBoundObject> rootClass = compileModule(
         metaschemaPath,

--- a/databind/src/test/java/gov/nist/secauto/metaschema/databind/codegen/BasicMetaschemaTest.java
+++ b/databind/src/test/java/gov/nist/secauto/metaschema/databind/codegen/BasicMetaschemaTest.java
@@ -23,6 +23,7 @@ import gov.nist.secauto.metaschema.core.model.constraint.IConstraintSet;
 import gov.nist.secauto.metaschema.core.qname.IEnhancedQName;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import gov.nist.secauto.metaschema.databind.IBindingContext;
+import gov.nist.secauto.metaschema.databind.io.BindingException;
 import gov.nist.secauto.metaschema.databind.model.metaschema.IBindingMetaschemaModule;
 
 import org.junit.jupiter.api.Test;
@@ -46,7 +47,7 @@ class BasicMetaschemaTest
     extends AbstractMetaschemaTest {
 
   @Test
-  void testSimpleMetaschema() throws MetaschemaException, IOException, ClassNotFoundException {
+  void testSimpleMetaschema() throws MetaschemaException, IOException, ClassNotFoundException, BindingException {
     runTests("simple", "gov.nist.csrc.ns.metaschema.testing.simple.TopLevel", ObjectUtils.notNull(generationDir));
     // runTests("simple", "gov.nist.csrc.ns.metaschema.testing.simple.TopLevel",
     // generationDir, (obj) ->
@@ -61,7 +62,7 @@ class BasicMetaschemaTest
 
   @Test
   void testSimpleUuidMetaschema()
-      throws MetaschemaException, IOException, ClassNotFoundException {
+      throws MetaschemaException, IOException, ClassNotFoundException, BindingException {
     runTests(
         "simple_with_uuid",
         "gov.nist.csrc.ns.metaschema.testing.simple.with.uuid.TopLevel",
@@ -77,7 +78,7 @@ class BasicMetaschemaTest
 
   @Test
   void testSimpleWithFieldMetaschema()
-      throws MetaschemaException, IOException, ClassNotFoundException {
+      throws MetaschemaException, IOException, ClassNotFoundException, BindingException {
     runTests(
         "simple_with_field",
         "gov.nist.csrc.ns.metaschema.testing.simple.with.field.TopLevel",
@@ -90,7 +91,7 @@ class BasicMetaschemaTest
 
   @Test
   void testFieldsWithFlagMetaschema()
-      throws MetaschemaException, IOException, ClassNotFoundException {
+      throws MetaschemaException, IOException, ClassNotFoundException, BindingException {
     runTests(
         "fields_with_flags",
         "gov.nist.csrc.ns.metaschema.testing.fields.with.flags.TopLevel",
@@ -161,7 +162,7 @@ class BasicMetaschemaTest
 
   @Test
   void testAssemblyMetaschema()
-      throws MetaschemaException, IOException, ClassNotFoundException {
+      throws MetaschemaException, IOException, ClassNotFoundException, BindingException {
     runTests(
         "assembly",
         "gov.nist.itl.metaschema.codegen.xml.example.assembly.TopLevel",
@@ -177,7 +178,7 @@ class BasicMetaschemaTest
 
   @Test
   void testLocalDefinitionsMetaschema()
-      throws MetaschemaException, IOException, ClassNotFoundException {
+      throws MetaschemaException, IOException, ClassNotFoundException, BindingException {
     runTests(
         "local-definitions",
         "gov.nist.csrc.ns.metaschema.testing.local.definitions.TopLevel",

--- a/databind/src/test/java/gov/nist/secauto/metaschema/databind/codegen/BasicMetaschemaTest.java
+++ b/databind/src/test/java/gov/nist/secauto/metaschema/databind/codegen/BasicMetaschemaTest.java
@@ -27,14 +27,11 @@ import gov.nist.secauto.metaschema.databind.io.BindingException;
 import gov.nist.secauto.metaschema.databind.model.metaschema.IBindingMetaschemaModule;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.platform.commons.util.ReflectionUtils;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
-import java.net.URL;
 import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.List;
@@ -186,12 +183,13 @@ class BasicMetaschemaTest
   }
 
   @Test
-  @Timeout(value = 180, unit = TimeUnit.SECONDS) // Network-dependent test needs extended timeout
   void testExistsWithVariable() throws IOException, MetaschemaException {
     IBindingContext bindingContext = newBindingContext();
 
-    IBindingMetaschemaModule module = bindingContext.loadMetaschema(
-        new URL("https://raw.githubusercontent.com/usnistgov/OSCAL/main/src/metaschema/oscal_complete_metaschema.xml"));
+    // Use local test resources instead of remote OSCAL metaschema to avoid network
+    // flakiness
+    IBindingMetaschemaModule module = bindingContext.loadMetaschema(ObjectUtils.notNull(
+        Paths.get("src/test/resources/metaschema/recursive-imports/parent.xml")));
 
     IDocumentNodeItem moduleItem = ObjectUtils.requireNonNull(module.getSourceNodeItem());
     // METASCHEMA moduleData =

--- a/databind/src/test/java/gov/nist/secauto/metaschema/databind/codegen/config/BindingConfigurationLoaderTest.java
+++ b/databind/src/test/java/gov/nist/secauto/metaschema/databind/codegen/config/BindingConfigurationLoaderTest.java
@@ -54,7 +54,7 @@ class BindingConfigurationLoaderTest {
   }
 
   @Test
-  void test() throws MalformedURLException, IOException, BindingException {
+  void testLoadOscalBindingConfiguration() throws MalformedURLException, IOException, BindingException {
     File configFile = new File("src/main/metaschema-bindings/oscal-metaschema-bindings.xml");
     DefaultBindingConfiguration config = new DefaultBindingConfiguration();
     config.load(configFile);

--- a/databind/src/test/java/gov/nist/secauto/metaschema/databind/codegen/config/BindingConfigurationLoaderTest.java
+++ b/databind/src/test/java/gov/nist/secauto/metaschema/databind/codegen/config/BindingConfigurationLoaderTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
+import gov.nist.secauto.metaschema.databind.io.BindingException;
 
 import org.junit.jupiter.api.Test;
 
@@ -53,7 +54,7 @@ class BindingConfigurationLoaderTest {
   }
 
   @Test
-  void test() throws MalformedURLException, IOException {
+  void test() throws MalformedURLException, IOException, BindingException {
     File configFile = new File("src/main/metaschema-bindings/oscal-metaschema-bindings.xml");
     DefaultBindingConfiguration config = new DefaultBindingConfiguration();
     config.load(configFile);

--- a/databind/src/test/java/gov/nist/secauto/metaschema/databind/codegen/config/DefaultBindingConfigurationTest.java
+++ b/databind/src/test/java/gov/nist/secauto/metaschema/databind/codegen/config/DefaultBindingConfigurationTest.java
@@ -8,6 +8,8 @@ package gov.nist.secauto.metaschema.databind.codegen.config;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import gov.nist.secauto.metaschema.core.model.IAssemblyDefinition;
 import gov.nist.secauto.metaschema.core.model.IModelDefinition;
@@ -408,12 +410,12 @@ class DefaultBindingConfigurationTest {
 
     DefaultBindingConfiguration config = new DefaultBindingConfiguration();
 
-    BindingException exception = org.junit.jupiter.api.Assertions.assertThrows(
+    BindingException exception = assertThrows(
         BindingException.class,
         () -> config.load(bindingConfigFile));
 
     String message = exception.getMessage();
-    org.junit.jupiter.api.Assertions.assertTrue(
+    assertTrue(
         message != null && (message.contains("Collection") || message.contains("collection")),
         "Error message should indicate type incompatibility: " + message);
   }
@@ -425,12 +427,12 @@ class DefaultBindingConfigurationTest {
 
     DefaultBindingConfiguration config = new DefaultBindingConfiguration();
 
-    BindingException exception = org.junit.jupiter.api.Assertions.assertThrows(
+    BindingException exception = assertThrows(
         BindingException.class,
         () -> config.load(bindingConfigFile));
 
     String message = exception.getMessage();
-    org.junit.jupiter.api.Assertions.assertTrue(
+    assertTrue(
         message != null && (message.contains("class") || message.contains("ClassNotFound")),
         "Error message should indicate class not found: " + message);
   }

--- a/databind/src/test/java/gov/nist/secauto/metaschema/databind/codegen/config/DefaultBindingConfigurationTest.java
+++ b/databind/src/test/java/gov/nist/secauto/metaschema/databind/codegen/config/DefaultBindingConfigurationTest.java
@@ -15,6 +15,7 @@ import gov.nist.secauto.metaschema.core.model.IModule;
 import gov.nist.secauto.metaschema.core.model.INamedModelInstanceAbsolute;
 import gov.nist.secauto.metaschema.core.model.ModelType;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
+import gov.nist.secauto.metaschema.databind.io.BindingException;
 
 import org.jmock.Expectations;
 import org.jmock.junit5.JUnit5Mockery;
@@ -47,7 +48,7 @@ class DefaultBindingConfigurationTest {
   private final IModule module = context.mock(IModule.class);
 
   @Test
-  void testLoader() throws MalformedURLException, IOException {
+  void testLoader() throws MalformedURLException, IOException, BindingException {
     File bindingConfigFile = new File("src/test/resources/metaschema/binding-config.xml");
 
     DefaultBindingConfiguration config = new DefaultBindingConfiguration();
@@ -75,7 +76,7 @@ class DefaultBindingConfigurationTest {
   }
 
   @Test
-  void testCollectionClassOverride() throws IOException {
+  void testCollectionClassOverride() throws IOException, BindingException {
     // Test loading binding configuration with collection-class overrides
     File bindingConfigFile = new File("src/test/resources/metaschema/binding-config-with-collection-class.xml");
     URI assemblyMetaschemaLocation = new File("src/test/resources/metaschema/assembly/metaschema.xml")
@@ -151,7 +152,7 @@ class DefaultBindingConfigurationTest {
   }
 
   @Test
-  void testPropertyBindingWithoutJavaElement() throws IOException {
+  void testPropertyBindingWithoutJavaElement() throws IOException, BindingException {
     // Test property-binding element that has no <java> child
     File bindingConfigFile = new File("src/test/resources/metaschema/binding-config-edge-cases.xml");
     URI assemblyMetaschemaLocation = new File("src/test/resources/metaschema/assembly/metaschema.xml")
@@ -190,7 +191,7 @@ class DefaultBindingConfigurationTest {
   }
 
   @Test
-  void testDefinitionNotInBindingConfig() throws IOException {
+  void testDefinitionNotInBindingConfig() throws IOException, BindingException {
     // Test querying a definition from a module that has no binding config
     File bindingConfigFile = new File("src/test/resources/metaschema/binding-config-with-collection-class.xml");
     URI unknownModuleLocation = new File("src/test/resources/metaschema/unknown-module.xml")
@@ -223,7 +224,7 @@ class DefaultBindingConfigurationTest {
   }
 
   @Test
-  void testFieldDefinitionPropertyBinding() throws IOException {
+  void testFieldDefinitionPropertyBinding() throws IOException, BindingException {
     // Test property binding on a field definition (not just assembly)
     File bindingConfigFile = new File("src/test/resources/metaschema/binding-config-edge-cases.xml");
     URI assemblyMetaschemaLocation = new File("src/test/resources/metaschema/assembly/metaschema.xml")
@@ -258,7 +259,7 @@ class DefaultBindingConfigurationTest {
   }
 
   @Test
-  void testDuplicatePropertyBindingLastWins() throws IOException {
+  void testDuplicatePropertyBindingLastWins() throws IOException, BindingException {
     // Test that duplicate property bindings use last-wins semantics
     File bindingConfigFile = new File("src/test/resources/metaschema/binding-config-edge-cases.xml");
     URI assemblyMetaschemaLocation = new File("src/test/resources/metaschema/assembly/metaschema.xml")
@@ -295,7 +296,7 @@ class DefaultBindingConfigurationTest {
   }
 
   @Test
-  void testChoiceGroupBindingParsing() throws IOException {
+  void testChoiceGroupBindingParsing() throws IOException, BindingException {
     // Test that choice-group-binding elements are parsed from XML config
     File bindingConfigFile = new File("src/test/resources/metaschema/binding-config-with-choice-groups.xml");
     URI assemblyMetaschemaLocation = new File("src/test/resources/metaschema/assembly/metaschema.xml")
@@ -361,7 +362,7 @@ class DefaultBindingConfigurationTest {
   }
 
   @Test
-  void testEmptyChoiceGroupBindings() throws IOException {
+  void testEmptyChoiceGroupBindings() throws IOException, BindingException {
     // Test that empty choice group bindings map is returned when none configured
     File bindingConfigFile = new File("src/test/resources/metaschema/binding-config-with-choice-groups.xml");
     URI assemblyMetaschemaLocation = new File("src/test/resources/metaschema/assembly/metaschema.xml")
@@ -397,6 +398,41 @@ class DefaultBindingConfigurationTest {
         "Choice group bindings map should not be null");
     assertEquals(0, defConfig.getChoiceGroupBindings().size(),
         "Choice group bindings map should be empty");
+  }
+
+  @Test
+  void testInvalidCollectionClassThrowsError() {
+    // Test that specifying a class that doesn't implement List for a List field
+    // throws an error
+    File bindingConfigFile = new File("src/test/resources/metaschema/binding-config-invalid-collection-class.xml");
+
+    DefaultBindingConfiguration config = new DefaultBindingConfiguration();
+
+    BindingException exception = org.junit.jupiter.api.Assertions.assertThrows(
+        BindingException.class,
+        () -> config.load(bindingConfigFile));
+
+    String message = exception.getMessage();
+    org.junit.jupiter.api.Assertions.assertTrue(
+        message != null && (message.contains("Collection") || message.contains("collection")),
+        "Error message should indicate type incompatibility: " + message);
+  }
+
+  @Test
+  void testNonExistentCollectionClassThrowsError() {
+    // Test that specifying a non-existent class throws an error
+    File bindingConfigFile = new File("src/test/resources/metaschema/binding-config-nonexistent-class.xml");
+
+    DefaultBindingConfiguration config = new DefaultBindingConfiguration();
+
+    BindingException exception = org.junit.jupiter.api.Assertions.assertThrows(
+        BindingException.class,
+        () -> config.load(bindingConfigFile));
+
+    String message = exception.getMessage();
+    org.junit.jupiter.api.Assertions.assertTrue(
+        message != null && (message.contains("class") || message.contains("ClassNotFound")),
+        "Error message should indicate class not found: " + message);
   }
 
 }

--- a/databind/src/test/java/gov/nist/secauto/metaschema/databind/codegen/config/DefaultChoiceGroupBindingConfigurationTest.java
+++ b/databind/src/test/java/gov/nist/secauto/metaschema/databind/codegen/config/DefaultChoiceGroupBindingConfigurationTest.java
@@ -16,6 +16,7 @@ import gov.nist.secauto.metaschema.core.model.IAssemblyDefinition;
 import gov.nist.secauto.metaschema.core.model.IModule;
 import gov.nist.secauto.metaschema.core.model.ModelType;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
+import gov.nist.secauto.metaschema.databind.io.BindingException;
 
 import org.jmock.Expectations;
 import org.jmock.junit5.JUnit5Mockery;
@@ -53,7 +54,7 @@ class DefaultChoiceGroupBindingConfigurationTest {
   private DefaultBindingConfiguration bindingConfig;
 
   @BeforeEach
-  void setUp() throws IOException {
+  void setUp() throws IOException, BindingException {
     bindingConfig = new DefaultBindingConfiguration();
     bindingConfig.load(BINDING_CONFIG_FILE);
   }

--- a/databind/src/test/java/gov/nist/secauto/metaschema/databind/io/MetaschemaModuleMetaschemaTest.java
+++ b/databind/src/test/java/gov/nist/secauto/metaschema/databind/io/MetaschemaModuleMetaschemaTest.java
@@ -43,8 +43,8 @@ class MetaschemaModuleMetaschemaTest {
   void testReadMetaschemaAsXml() throws IOException {
     IBindingContext context = IBindingContext.newInstance();
 
-    // Disable required field validation since Metaschema modules are validated by
-    // schema and the pre-generated binding classes don't preserve choice group info
+    // Disable required field validation because pre-generated binding classes
+    // don't preserve choice group information. See issue #594.
     IDeserializer<METASCHEMA> xmlDeserializer = context.newDeserializer(Format.XML, METASCHEMA.class);
     xmlDeserializer.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
     METASCHEMA metaschema = xmlDeserializer.deserialize(METASCHEMA_FILE);

--- a/databind/src/test/java/gov/nist/secauto/metaschema/databind/io/MetaschemaModuleMetaschemaTest.java
+++ b/databind/src/test/java/gov/nist/secauto/metaschema/databind/io/MetaschemaModuleMetaschemaTest.java
@@ -43,7 +43,11 @@ class MetaschemaModuleMetaschemaTest {
   void testReadMetaschemaAsXml() throws IOException {
     IBindingContext context = IBindingContext.newInstance();
 
-    METASCHEMA metaschema = context.newDeserializer(Format.XML, METASCHEMA.class).deserialize(METASCHEMA_FILE);
+    // Disable required field validation since Metaschema modules are validated by
+    // schema and the pre-generated binding classes don't preserve choice group info
+    IDeserializer<METASCHEMA> xmlDeserializer = context.newDeserializer(Format.XML, METASCHEMA.class);
+    xmlDeserializer.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
+    METASCHEMA metaschema = xmlDeserializer.deserialize(METASCHEMA_FILE);
 
     {
       ISerializer<METASCHEMA> serializer = context.newSerializer(Format.XML, METASCHEMA.class);
@@ -62,18 +66,21 @@ class MetaschemaModuleMetaschemaTest {
 
     {
       IDeserializer<METASCHEMA> deserializer = context.newDeserializer(Format.XML, METASCHEMA.class);
+      deserializer.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
       deserializer.deserialize(
           ObjectUtils.notNull(Paths.get("target/metaschema.xml")));
     }
 
     {
       IDeserializer<METASCHEMA> deserializer = context.newDeserializer(Format.JSON, METASCHEMA.class);
+      deserializer.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
       deserializer.deserialize(
           ObjectUtils.notNull(Paths.get("target/metaschema.json")));
     }
 
     {
       IDeserializer<METASCHEMA> deserializer = context.newDeserializer(Format.YAML, METASCHEMA.class);
+      deserializer.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
       deserializer.deserialize(
           ObjectUtils.notNull(Paths.get("target/metaschema.yaml")));
     }

--- a/databind/src/test/java/gov/nist/secauto/metaschema/databind/io/MetaschemaModuleMetaschemaTest.java
+++ b/databind/src/test/java/gov/nist/secauto/metaschema/databind/io/MetaschemaModuleMetaschemaTest.java
@@ -7,6 +7,7 @@ package gov.nist.secauto.metaschema.databind.io;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import gov.nist.secauto.metaschema.core.model.IBoundObject;
 import gov.nist.secauto.metaschema.core.model.MetaschemaException;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import gov.nist.secauto.metaschema.databind.IBindingContext;
@@ -39,51 +40,44 @@ class MetaschemaModuleMetaschemaTest {
         .build();
   }
 
+  /**
+   * Deserialize content with required field validation disabled.
+   * <p>
+   * Required field validation is disabled because pre-generated binding classes
+   * don't preserve choice group information. See issue #594. TODO: Remove this
+   * workaround when #594 is implemented.
+   */
+  @NonNull
+  private static <T extends IBoundObject> T deserializeWithValidationDisabled(
+      @NonNull IBindingContext context,
+      @NonNull Format format,
+      @NonNull Class<T> clazz,
+      @NonNull Path path) throws IOException {
+    IDeserializer<T> deserializer = context.newDeserializer(format, clazz);
+    deserializer.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
+    return deserializer.deserialize(path);
+  }
+
   @Test
   void testReadMetaschemaAsXml() throws IOException {
     IBindingContext context = IBindingContext.newInstance();
 
-    // Disable required field validation because pre-generated binding classes
-    // don't preserve choice group information. See issue #594.
-    IDeserializer<METASCHEMA> xmlDeserializer = context.newDeserializer(Format.XML, METASCHEMA.class);
-    xmlDeserializer.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
-    METASCHEMA metaschema = xmlDeserializer.deserialize(METASCHEMA_FILE);
+    METASCHEMA metaschema = deserializeWithValidationDisabled(
+        context, Format.XML, METASCHEMA.class, METASCHEMA_FILE);
 
-    {
-      ISerializer<METASCHEMA> serializer = context.newSerializer(Format.XML, METASCHEMA.class);
-      serializer.serialize(metaschema, ObjectUtils.notNull(Paths.get("target/metaschema.xml")));
-    }
+    // Serialize to all formats
+    Path xmlPath = ObjectUtils.notNull(Paths.get("target/metaschema.xml"));
+    Path jsonPath = ObjectUtils.notNull(Paths.get("target/metaschema.json"));
+    Path yamlPath = ObjectUtils.notNull(Paths.get("target/metaschema.yaml"));
 
-    {
-      ISerializer<METASCHEMA> serializer = context.newSerializer(Format.JSON, METASCHEMA.class);
-      serializer.serialize(metaschema, ObjectUtils.notNull(Paths.get("target/metaschema.json")));
-    }
+    context.newSerializer(Format.XML, METASCHEMA.class).serialize(metaschema, xmlPath);
+    context.newSerializer(Format.JSON, METASCHEMA.class).serialize(metaschema, jsonPath);
+    context.newSerializer(Format.YAML, METASCHEMA.class).serialize(metaschema, yamlPath);
 
-    {
-      ISerializer<METASCHEMA> serializer = context.newSerializer(Format.YAML, METASCHEMA.class);
-      serializer.serialize(metaschema, ObjectUtils.notNull(Paths.get("target/metaschema.yaml")));
-    }
-
-    {
-      IDeserializer<METASCHEMA> deserializer = context.newDeserializer(Format.XML, METASCHEMA.class);
-      deserializer.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
-      deserializer.deserialize(
-          ObjectUtils.notNull(Paths.get("target/metaschema.xml")));
-    }
-
-    {
-      IDeserializer<METASCHEMA> deserializer = context.newDeserializer(Format.JSON, METASCHEMA.class);
-      deserializer.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
-      deserializer.deserialize(
-          ObjectUtils.notNull(Paths.get("target/metaschema.json")));
-    }
-
-    {
-      IDeserializer<METASCHEMA> deserializer = context.newDeserializer(Format.YAML, METASCHEMA.class);
-      deserializer.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
-      deserializer.deserialize(
-          ObjectUtils.notNull(Paths.get("target/metaschema.yaml")));
-    }
+    // Round-trip: deserialize from all formats
+    deserializeWithValidationDisabled(context, Format.XML, METASCHEMA.class, xmlPath);
+    deserializeWithValidationDisabled(context, Format.JSON, METASCHEMA.class, jsonPath);
+    deserializeWithValidationDisabled(context, Format.YAML, METASCHEMA.class, yamlPath);
   }
 
   @Test

--- a/databind/src/test/java/gov/nist/secauto/metaschema/databind/io/RequiredFieldValidationTest.java
+++ b/databind/src/test/java/gov/nist/secauto/metaschema/databind/io/RequiredFieldValidationTest.java
@@ -1,0 +1,197 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.databind.io;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import gov.nist.secauto.metaschema.core.model.IBoundObject;
+import gov.nist.secauto.metaschema.core.model.MetaschemaException;
+import gov.nist.secauto.metaschema.core.util.ObjectUtils;
+import gov.nist.secauto.metaschema.databind.IBindingContext;
+import gov.nist.secauto.metaschema.databind.codegen.AbstractMetaschemaTest;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Tests for required field validation during deserialization.
+ */
+class RequiredFieldValidationTest
+    extends AbstractMetaschemaTest {
+
+  private static final Path METASCHEMA_PATH
+      = Paths.get("src/test/resources/metaschema/required-fields/metaschema.xml");
+  private static final Path VALID_XML_PATH
+      = Paths.get("src/test/resources/metaschema/required-fields/valid-example.xml");
+  private static final Path MISSING_FLAG_XML_PATH
+      = Paths.get("src/test/resources/metaschema/required-fields/missing-required-flag.xml");
+  private static final Path MISSING_FIELD_XML_PATH
+      = Paths.get("src/test/resources/metaschema/required-fields/missing-required-field.xml");
+  private static final Path MISSING_ASSEMBLY_XML_PATH
+      = Paths.get("src/test/resources/metaschema/required-fields/missing-required-assembly.xml");
+  private static final Path VALID_JSON_PATH
+      = Paths.get("src/test/resources/metaschema/required-fields/valid-example.json");
+  private static final Path MISSING_FLAG_JSON_PATH
+      = Paths.get("src/test/resources/metaschema/required-fields/missing-required-flag.json");
+  private static final Path MISSING_FIELD_JSON_PATH
+      = Paths.get("src/test/resources/metaschema/required-fields/missing-required-field.json");
+  private static final String ROOT_CLASS_NAME
+      = "gov.nist.csrc.ns.metaschema.testing.required_fields.Root";
+
+  private static Class<? extends IBoundObject> rootClass;
+
+  @BeforeAll
+  static void setup() throws IOException, ClassNotFoundException, MetaschemaException, BindingException {
+    RequiredFieldValidationTest test = new RequiredFieldValidationTest();
+    rootClass = test.compileModule(
+        ObjectUtils.notNull(METASCHEMA_PATH),
+        null,
+        ROOT_CLASS_NAME,
+        ObjectUtils.notNull(Paths.get("target/generated-test-sources/required-fields")));
+  }
+
+  @Test
+  void testValidXmlParsesSuccessfully() throws IOException {
+    IBindingContext bindingContext = newBindingContext();
+    assertDoesNotThrow(() -> {
+      IDeserializer<?> deserializer = bindingContext.newDeserializer(Format.XML, rootClass);
+      Object result = deserializer.deserialize(ObjectUtils.notNull(VALID_XML_PATH));
+      assertNotNull(result, "Valid XML should parse successfully");
+    });
+  }
+
+  @Test
+  void testValidJsonParsesSuccessfully() throws IOException {
+    IBindingContext bindingContext = newBindingContext();
+    assertDoesNotThrow(() -> {
+      IDeserializer<?> deserializer = bindingContext.newDeserializer(Format.JSON, rootClass);
+      Object result = deserializer.deserialize(ObjectUtils.notNull(VALID_JSON_PATH));
+      assertNotNull(result, "Valid JSON should parse successfully");
+    });
+  }
+
+  @Test
+  void testMissingRequiredFlagInXmlThrowsError() throws IOException {
+    IBindingContext bindingContext = newBindingContext();
+    IDeserializer<?> deserializer = bindingContext.newDeserializer(Format.XML, rootClass);
+    deserializer.enableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
+
+    IOException exception = assertThrows(IOException.class, () -> {
+      deserializer.deserialize(ObjectUtils.notNull(MISSING_FLAG_XML_PATH));
+    });
+
+    String message = exception.getMessage();
+    assertTrue(message != null && message.contains("required"),
+        "Error message should indicate missing required field: " + message);
+  }
+
+  @Test
+  void testMissingRequiredFieldInXmlThrowsError() throws IOException {
+    IBindingContext bindingContext = newBindingContext();
+    IDeserializer<?> deserializer = bindingContext.newDeserializer(Format.XML, rootClass);
+    deserializer.enableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
+
+    IOException exception = assertThrows(IOException.class, () -> {
+      deserializer.deserialize(ObjectUtils.notNull(MISSING_FIELD_XML_PATH));
+    });
+
+    String message = exception.getMessage();
+    assertTrue(message != null && message.contains("required"),
+        "Error message should indicate missing required field: " + message);
+  }
+
+  @Test
+  void testMissingRequiredAssemblyInXmlThrowsError() throws IOException {
+    IBindingContext bindingContext = newBindingContext();
+    IDeserializer<?> deserializer = bindingContext.newDeserializer(Format.XML, rootClass);
+    deserializer.enableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
+
+    IOException exception = assertThrows(IOException.class, () -> {
+      deserializer.deserialize(ObjectUtils.notNull(MISSING_ASSEMBLY_XML_PATH));
+    });
+
+    String message = exception.getMessage();
+    assertTrue(message != null && message.contains("required"),
+        "Error message should indicate missing required field: " + message);
+  }
+
+  @Test
+  void testMissingRequiredFlagInJsonThrowsError() throws IOException {
+    IBindingContext bindingContext = newBindingContext();
+    IDeserializer<?> deserializer = bindingContext.newDeserializer(Format.JSON, rootClass);
+    deserializer.enableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
+
+    IOException exception = assertThrows(IOException.class, () -> {
+      deserializer.deserialize(ObjectUtils.notNull(MISSING_FLAG_JSON_PATH));
+    });
+
+    String message = exception.getMessage();
+    assertTrue(message != null && message.contains("required"),
+        "Error message should indicate missing required field: " + message);
+  }
+
+  @Test
+  void testMissingRequiredFieldInJsonThrowsError() throws IOException {
+    IBindingContext bindingContext = newBindingContext();
+    IDeserializer<?> deserializer = bindingContext.newDeserializer(Format.JSON, rootClass);
+    deserializer.enableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
+
+    IOException exception = assertThrows(IOException.class, () -> {
+      deserializer.deserialize(ObjectUtils.notNull(MISSING_FIELD_JSON_PATH));
+    });
+
+    String message = exception.getMessage();
+    assertTrue(message != null && message.contains("required"),
+        "Error message should indicate missing required field: " + message);
+  }
+
+  @Test
+  void testValidationCanBeToggledViaFeatureFlag() throws IOException {
+    IBindingContext bindingContext = newBindingContext();
+
+    // First verify that validation is enabled by default (throws error)
+    IDeserializer<?> deserializer1 = bindingContext.newDeserializer(Format.XML, rootClass);
+    assertThrows(IOException.class, () -> {
+      deserializer1.deserialize(ObjectUtils.notNull(MISSING_FLAG_XML_PATH));
+    }, "Should throw when validation is enabled by default");
+
+    // Now disable validation and verify it parses without error
+    IDeserializer<?> deserializer2 = bindingContext.newDeserializer(Format.XML, rootClass);
+    deserializer2.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
+    assertDoesNotThrow(() -> {
+      Object result = deserializer2.deserialize(ObjectUtils.notNull(MISSING_FLAG_XML_PATH));
+      assertNotNull(result, "Should parse without error when validation is disabled");
+    });
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = { "XML", "JSON" })
+  void testErrorMessageIncludesFieldName(String formatName) throws IOException {
+    Format format = Format.valueOf(formatName);
+    Path missingFlagPath = format == Format.XML ? MISSING_FLAG_XML_PATH : MISSING_FLAG_JSON_PATH;
+
+    IBindingContext bindingContext = newBindingContext();
+    IDeserializer<?> deserializer = bindingContext.newDeserializer(format, rootClass);
+    deserializer.enableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
+
+    IOException exception = assertThrows(IOException.class, () -> {
+      deserializer.deserialize(ObjectUtils.notNull(missingFlagPath));
+    });
+
+    String message = exception.getMessage();
+    assertTrue(message != null && message.contains("required-flag"),
+        "Error message should include the field name 'required-flag': " + message);
+  }
+}

--- a/databind/src/test/java/gov/nist/secauto/metaschema/databind/io/json/JsonParserTest.java
+++ b/databind/src/test/java/gov/nist/secauto/metaschema/databind/io/json/JsonParserTest.java
@@ -30,6 +30,10 @@ class JsonParserTest
 
     IBoundLoader loader = bindingContext.newBoundLoader();
     loader.enableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_CONSTRAINTS);
+    // Disable required field validation since dynamically compiled binding classes
+    // don't preserve choice group information. The metaschema has a choice between
+    // x and y, and the example provides y, which should satisfy the choice.
+    loader.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
     Object obj = loader.load(ObjectUtils.notNull(
         Paths.get("src/test/resources/metaschema/308-choice-regression/example.json")));
     assertNotNull(obj);

--- a/databind/src/test/java/gov/nist/secauto/metaschema/databind/io/json/JsonParserTest.java
+++ b/databind/src/test/java/gov/nist/secauto/metaschema/databind/io/json/JsonParserTest.java
@@ -30,9 +30,12 @@ class JsonParserTest
 
     IBoundLoader loader = bindingContext.newBoundLoader();
     loader.enableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_CONSTRAINTS);
-    // Disable required field validation since dynamically compiled binding classes
-    // don't preserve choice group information. The metaschema has a choice between
-    // x and y, and the example provides y, which should satisfy the choice.
+    // Disable required field validation because dynamically compiled binding
+    // classes
+    // don't preserve choice group information (see issue #594). The metaschema has
+    // a
+    // choice between x and y, and the example provides y, which should satisfy the
+    // choice.
     loader.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
     Object obj = loader.load(ObjectUtils.notNull(
         Paths.get("src/test/resources/metaschema/308-choice-regression/example.json")));

--- a/databind/src/test/java/gov/nist/secauto/metaschema/databind/model/impl/BoundChoiceTest.java
+++ b/databind/src/test/java/gov/nist/secauto/metaschema/databind/model/impl/BoundChoiceTest.java
@@ -1,0 +1,227 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.databind.model.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import gov.nist.secauto.metaschema.core.model.IBoundObject;
+import gov.nist.secauto.metaschema.core.model.IChoiceInstance;
+import gov.nist.secauto.metaschema.core.model.IMetaschemaData;
+import gov.nist.secauto.metaschema.databind.IBindingContext;
+import gov.nist.secauto.metaschema.databind.model.IBoundDefinitionModelAssembly;
+import gov.nist.secauto.metaschema.databind.model.annotations.BoundChoice;
+import gov.nist.secauto.metaschema.databind.model.annotations.BoundField;
+import gov.nist.secauto.metaschema.databind.model.annotations.MetaschemaAssembly;
+import gov.nist.secauto.metaschema.databind.testing.model.TestModule;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+/**
+ * Tests for the {@link BoundChoice} annotation and
+ * {@link BoundInstanceModelChoice} class.
+ */
+class BoundChoiceTest {
+
+  /**
+   * Test assembly with valid adjacent choice fields.
+   */
+  @MetaschemaAssembly(
+      name = "valid-choice-assembly",
+      rootName = "valid-choice-assembly",
+      moduleClass = TestModule.class)
+  public static class ValidChoiceAssembly implements IBoundObject {
+    private IMetaschemaData metaschemaData;
+
+    @BoundField(useName = "option-a")
+    @BoundChoice(choiceId = "choice-1")
+    private String optionA;
+
+    @BoundField(useName = "option-b")
+    @BoundChoice(choiceId = "choice-1")
+    private String optionB;
+
+    @BoundField(useName = "other-field")
+    private String otherField;
+
+    @Override
+    public IMetaschemaData getMetaschemaData() {
+      return metaschemaData;
+    }
+
+    public String getOptionA() {
+      return optionA;
+    }
+
+    public void setOptionA(String optionA) {
+      this.optionA = optionA;
+    }
+
+    public String getOptionB() {
+      return optionB;
+    }
+
+    public void setOptionB(String optionB) {
+      this.optionB = optionB;
+    }
+
+    public String getOtherField() {
+      return otherField;
+    }
+
+    public void setOtherField(String otherField) {
+      this.otherField = otherField;
+    }
+  }
+
+  /**
+   * Test assembly with non-adjacent choice fields (invalid).
+   */
+  @MetaschemaAssembly(
+      name = "invalid-choice-assembly",
+      rootName = "invalid-choice-assembly",
+      moduleClass = TestModule.class)
+  public static class InvalidChoiceAssembly implements IBoundObject {
+    private IMetaschemaData metaschemaData;
+
+    @BoundField(useName = "option-a")
+    @BoundChoice(choiceId = "choice-1")
+    private String optionA;
+
+    @BoundField(useName = "interrupting-field")
+    private String interruptingField;
+
+    @BoundField(useName = "option-b")
+    @BoundChoice(choiceId = "choice-1")
+    private String optionB;
+
+    @Override
+    public IMetaschemaData getMetaschemaData() {
+      return metaschemaData;
+    }
+  }
+
+  /**
+   * Test assembly with multiple choice groups.
+   */
+  @MetaschemaAssembly(
+      name = "multi-choice-assembly",
+      rootName = "multi-choice-assembly",
+      moduleClass = TestModule.class)
+  public static class MultiChoiceAssembly implements IBoundObject {
+    private IMetaschemaData metaschemaData;
+
+    @BoundField(useName = "choice1-a")
+    @BoundChoice(choiceId = "choice-1")
+    private String choice1A;
+
+    @BoundField(useName = "choice1-b")
+    @BoundChoice(choiceId = "choice-1")
+    private String choice1B;
+
+    @BoundField(useName = "choice2-a")
+    @BoundChoice(choiceId = "choice-2")
+    private String choice2A;
+
+    @BoundField(useName = "choice2-b")
+    @BoundChoice(choiceId = "choice-2")
+    private String choice2B;
+
+    @Override
+    public IMetaschemaData getMetaschemaData() {
+      return metaschemaData;
+    }
+  }
+
+  @Test
+  void testValidChoiceInstancesCreated() {
+    IBindingContext context = IBindingContext.newInstance();
+    IBoundDefinitionModelAssembly definition = (IBoundDefinitionModelAssembly) context
+        .getBoundDefinitionForClass(ValidChoiceAssembly.class);
+
+    assertNotNull(definition, "Definition should not be null");
+
+    List<IChoiceInstance> choices = definition.getChoiceInstances();
+    assertNotNull(choices, "Choice instances should not be null");
+    assertEquals(1, choices.size(), "Should have exactly one choice instance");
+
+    IChoiceInstance choice = choices.get(0);
+    assertNotNull(choice, "Choice instance should not be null");
+    assertEquals(2, choice.getNamedModelInstances().size(),
+        "Choice should have 2 alternatives");
+  }
+
+  @Test
+  void testInvalidNonAdjacentChoiceThrowsException() {
+    IBindingContext context = IBindingContext.newInstance();
+
+    // Attempting to get definition for class with non-adjacent choice fields
+    // should throw IllegalStateException when model is accessed
+    assertThrows(IllegalStateException.class, () -> {
+      IBoundDefinitionModelAssembly definition = (IBoundDefinitionModelAssembly) context
+          .getBoundDefinitionForClass(InvalidChoiceAssembly.class);
+      // Force model initialization by accessing the choice instances
+      definition.getChoiceInstances();
+    }, "Should throw exception for non-adjacent choice fields");
+  }
+
+  @Test
+  void testMultipleChoiceGroups() {
+    IBindingContext context = IBindingContext.newInstance();
+    IBoundDefinitionModelAssembly definition = (IBoundDefinitionModelAssembly) context
+        .getBoundDefinitionForClass(MultiChoiceAssembly.class);
+
+    assertNotNull(definition, "Definition should not be null");
+
+    List<IChoiceInstance> choices = definition.getChoiceInstances();
+    assertNotNull(choices, "Choice instances should not be null");
+    assertEquals(2, choices.size(), "Should have exactly two choice instances");
+
+    // Each choice should have 2 alternatives
+    for (IChoiceInstance choice : choices) {
+      assertEquals(2, choice.getNamedModelInstances().size(),
+          "Each choice should have 2 alternatives");
+    }
+  }
+
+  @Test
+  void testChoiceInstanceProperties() {
+    IBindingContext context = IBindingContext.newInstance();
+    IBoundDefinitionModelAssembly definition = (IBoundDefinitionModelAssembly) context
+        .getBoundDefinitionForClass(ValidChoiceAssembly.class);
+
+    List<IChoiceInstance> choices = definition.getChoiceInstances();
+    IChoiceInstance choice = choices.get(0);
+
+    // Verify IChoiceInstance properties
+    // Annotation-based bindings default to optional choices (minOccurs = 0)
+    assertEquals(0, choice.getMinOccurs(), "minOccurs should be 0 for optional choice");
+    assertEquals(1, choice.getMaxOccurs(), "maxOccurs should be 1");
+    assertNotNull(choice.getContainingDefinition(), "Containing definition should not be null");
+    assertEquals(definition, choice.getContainingDefinition(),
+        "Containing definition should be the parent assembly");
+
+    // Verify the choice contains the expected fields
+    assertTrue(choice.getFieldInstances().size() > 0 || choice.getAssemblyInstances().size() > 0,
+        "Choice should contain field or assembly instances");
+  }
+
+  @Test
+  void testBoundInstanceModelChoiceId() {
+    IBindingContext context = IBindingContext.newInstance();
+    IBoundDefinitionModelAssembly definition = (IBoundDefinitionModelAssembly) context
+        .getBoundDefinitionForClass(ValidChoiceAssembly.class);
+
+    List<IChoiceInstance> choices = definition.getChoiceInstances();
+    BoundInstanceModelChoice choice = (BoundInstanceModelChoice) choices.get(0);
+
+    assertEquals("choice-1", choice.getChoiceId(), "Choice ID should match annotation");
+  }
+}

--- a/databind/src/test/resources/metaschema/binding-config-invalid-collection-class.xml
+++ b/databind/src/test/resources/metaschema/binding-config-invalid-collection-class.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Test configuration with invalid collection class (String does not implement Collection or Map) -->
+<metaschema-bindings
+    xmlns="https://csrc.nist.gov/ns/metaschema-binding/1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <metaschema-binding href="./assembly/metaschema.xml">
+    <define-assembly-binding name="top-level">
+      <!-- String does not implement Collection or Map, so this should fail -->
+      <property-binding name="children">
+        <java>
+          <collection-class>java.lang.String</collection-class>
+        </java>
+      </property-binding>
+    </define-assembly-binding>
+  </metaschema-binding>
+</metaschema-bindings>

--- a/databind/src/test/resources/metaschema/binding-config-nonexistent-class.xml
+++ b/databind/src/test/resources/metaschema/binding-config-nonexistent-class.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Test configuration with a non-existent class -->
+<metaschema-bindings
+    xmlns="https://csrc.nist.gov/ns/metaschema-binding/1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <metaschema-binding href="./assembly/metaschema.xml">
+    <define-assembly-binding name="top-level">
+      <property-binding name="children">
+        <java>
+          <collection-class>com.nonexistent.FakeCollection</collection-class>
+        </java>
+      </property-binding>
+    </define-assembly-binding>
+  </metaschema-binding>
+</metaschema-bindings>

--- a/databind/src/test/resources/metaschema/recursive-imports/child-a.xml
+++ b/databind/src/test/resources/metaschema/recursive-imports/child-a.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<METASCHEMA xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0">
+  <schema-name>Child A Metaschema</schema-name>
+  <schema-version>1.0</schema-version>
+  <short-name>child-a</short-name>
+  <namespace>http://csrc.nist.gov/ns/metaschema/testing/recursive-imports</namespace>
+  <json-base-uri>http://csrc.nist.gov/ns/metaschema/testing/recursive-imports</json-base-uri>
+
+  <import href="grandchild.xml"/>
+
+  <define-assembly name="child-a-assembly">
+    <formal-name>Child A Assembly</formal-name>
+    <description>Assembly defined in child A module</description>
+    <root-name>child-a-root</root-name>
+    <model>
+      <assembly ref="grandchild-assembly"/>
+    </model>
+  </define-assembly>
+</METASCHEMA>

--- a/databind/src/test/resources/metaschema/recursive-imports/child-b.xml
+++ b/databind/src/test/resources/metaschema/recursive-imports/child-b.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<METASCHEMA xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0">
+  <schema-name>Child B Metaschema</schema-name>
+  <schema-version>1.0</schema-version>
+  <short-name>child-b</short-name>
+  <namespace>http://csrc.nist.gov/ns/metaschema/testing/recursive-imports</namespace>
+  <json-base-uri>http://csrc.nist.gov/ns/metaschema/testing/recursive-imports</json-base-uri>
+
+  <define-assembly name="child-b-assembly">
+    <formal-name>Child B Assembly</formal-name>
+    <description>Assembly defined in child B module</description>
+    <root-name>child-b-root</root-name>
+    <model/>
+  </define-assembly>
+</METASCHEMA>

--- a/databind/src/test/resources/metaschema/recursive-imports/grandchild.xml
+++ b/databind/src/test/resources/metaschema/recursive-imports/grandchild.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<METASCHEMA xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0">
+  <schema-name>Grandchild Metaschema</schema-name>
+  <schema-version>1.0</schema-version>
+  <short-name>grandchild</short-name>
+  <namespace>http://csrc.nist.gov/ns/metaschema/testing/recursive-imports</namespace>
+  <json-base-uri>http://csrc.nist.gov/ns/metaschema/testing/recursive-imports</json-base-uri>
+
+  <define-assembly name="grandchild-assembly">
+    <formal-name>Grandchild Assembly</formal-name>
+    <description>Assembly defined in grandchild module</description>
+    <root-name>grandchild-root</root-name>
+    <model/>
+  </define-assembly>
+</METASCHEMA>

--- a/databind/src/test/resources/metaschema/recursive-imports/parent.xml
+++ b/databind/src/test/resources/metaschema/recursive-imports/parent.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<METASCHEMA xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0">
+  <schema-name>Parent Metaschema</schema-name>
+  <schema-version>1.0</schema-version>
+  <short-name>parent</short-name>
+  <namespace>http://csrc.nist.gov/ns/metaschema/testing/recursive-imports</namespace>
+  <json-base-uri>http://csrc.nist.gov/ns/metaschema/testing/recursive-imports</json-base-uri>
+
+  <import href="child-a.xml"/>
+  <import href="child-b.xml"/>
+
+  <define-assembly name="parent-root">
+    <formal-name>Parent Root</formal-name>
+    <description>Root assembly in parent module</description>
+    <root-name>parent-root</root-name>
+    <model>
+      <assembly ref="child-a-assembly"/>
+      <assembly ref="child-b-assembly"/>
+    </model>
+  </define-assembly>
+</METASCHEMA>

--- a/databind/src/test/resources/metaschema/required-fields/metaschema.xml
+++ b/databind/src/test/resources/metaschema/required-fields/metaschema.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<METASCHEMA xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <schema-name>Required Fields Test</schema-name>
+  <schema-version>1.0</schema-version>
+  <short-name>required-fields-test</short-name>
+  <namespace>http://csrc.nist.gov/ns/metaschema/testing/required-fields</namespace>
+  <json-base-uri>http://csrc.nist.gov/ns/metaschema/testing/required-fields</json-base-uri>
+
+  <define-assembly name="root">
+    <formal-name>Root</formal-name>
+    <description>Root assembly with required fields</description>
+    <root-name>root</root-name>
+    <flag ref="required-flag" required="yes" />
+    <flag ref="optional-flag" />
+    <model>
+      <field ref="required-field" min-occurs="1" />
+      <field ref="optional-field" />
+      <assembly ref="required-assembly" min-occurs="1" />
+      <assembly ref="optional-assembly" />
+    </model>
+  </define-assembly>
+
+  <define-flag name="required-flag">
+    <formal-name>Required Flag</formal-name>
+    <description>A required flag</description>
+  </define-flag>
+
+  <define-flag name="optional-flag">
+    <formal-name>Optional Flag</formal-name>
+    <description>An optional flag</description>
+  </define-flag>
+
+  <define-field name="required-field">
+    <formal-name>Required Field</formal-name>
+    <description>A required field</description>
+  </define-field>
+
+  <define-field name="optional-field">
+    <formal-name>Optional Field</formal-name>
+    <description>An optional field</description>
+  </define-field>
+
+  <define-assembly name="required-assembly">
+    <formal-name>Required Assembly</formal-name>
+    <description>A required assembly</description>
+    <flag ref="id" required="yes" />
+  </define-assembly>
+
+  <define-assembly name="optional-assembly">
+    <formal-name>Optional Assembly</formal-name>
+    <description>An optional assembly</description>
+  </define-assembly>
+
+  <define-flag name="id">
+    <formal-name>Identifier</formal-name>
+    <description>An identifier</description>
+  </define-flag>
+</METASCHEMA>

--- a/databind/src/test/resources/metaschema/required-fields/missing-required-assembly.xml
+++ b/databind/src/test/resources/metaschema/required-fields/missing-required-assembly.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Missing required-assembly element -->
+<root xmlns="http://csrc.nist.gov/ns/metaschema/testing/required-fields"
+      required-flag="value1">
+  <required-field>Required field value</required-field>
+</root>

--- a/databind/src/test/resources/metaschema/required-fields/missing-required-field.json
+++ b/databind/src/test/resources/metaschema/required-fields/missing-required-field.json
@@ -1,0 +1,8 @@
+{
+  "root": {
+    "required-flag": "value1",
+    "required-assembly": {
+      "id": "assembly-1"
+    }
+  }
+}

--- a/databind/src/test/resources/metaschema/required-fields/missing-required-field.xml
+++ b/databind/src/test/resources/metaschema/required-fields/missing-required-field.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Missing required-field element -->
+<root xmlns="http://csrc.nist.gov/ns/metaschema/testing/required-fields"
+      required-flag="value1">
+  <required-assembly id="assembly-1" />
+</root>

--- a/databind/src/test/resources/metaschema/required-fields/missing-required-flag.json
+++ b/databind/src/test/resources/metaschema/required-fields/missing-required-flag.json
@@ -1,0 +1,8 @@
+{
+  "root": {
+    "required-field": "Required field value",
+    "required-assembly": {
+      "id": "assembly-1"
+    }
+  }
+}

--- a/databind/src/test/resources/metaschema/required-fields/missing-required-flag.xml
+++ b/databind/src/test/resources/metaschema/required-fields/missing-required-flag.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Missing required-flag attribute -->
+<root xmlns="http://csrc.nist.gov/ns/metaschema/testing/required-fields">
+  <required-field>Required field value</required-field>
+  <required-assembly id="assembly-1" />
+</root>

--- a/databind/src/test/resources/metaschema/required-fields/valid-example.json
+++ b/databind/src/test/resources/metaschema/required-fields/valid-example.json
@@ -1,0 +1,9 @@
+{
+  "root": {
+    "required-flag": "value1",
+    "required-field": "Required field value",
+    "required-assembly": {
+      "id": "assembly-1"
+    }
+  }
+}

--- a/databind/src/test/resources/metaschema/required-fields/valid-example.xml
+++ b/databind/src/test/resources/metaschema/required-fields/valid-example.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root xmlns="http://csrc.nist.gov/ns/metaschema/testing/required-fields"
+      required-flag="value1">
+  <required-field>Required field value</required-field>
+  <required-assembly id="assembly-1" />
+</root>

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractConvertSubcommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractConvertSubcommand.java
@@ -15,7 +15,6 @@ import gov.nist.secauto.metaschema.core.model.MetaschemaException;
 import gov.nist.secauto.metaschema.core.util.AutoCloser;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import gov.nist.secauto.metaschema.databind.IBindingContext;
-import gov.nist.secauto.metaschema.databind.io.DeserializationFeature;
 import gov.nist.secauto.metaschema.databind.io.Format;
 import gov.nist.secauto.metaschema.databind.io.IBoundLoader;
 
@@ -129,10 +128,6 @@ public abstract class AbstractConvertSubcommand
       try {
         IBindingContext bindingContext = getBindingContext();
         IBoundLoader loader = bindingContext.newBoundLoader();
-        // Disable required field validation because pre-generated binding classes
-        // don't preserve choice group information. See issue #594.
-        // TODO: Remove this workaround when #594 is implemented.
-        loader.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
         if (LOGGER.isInfoEnabled()) {
           LOGGER.info("Converting '{}'.", source);
         }

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractConvertSubcommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractConvertSubcommand.java
@@ -15,6 +15,7 @@ import gov.nist.secauto.metaschema.core.model.MetaschemaException;
 import gov.nist.secauto.metaschema.core.util.AutoCloser;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import gov.nist.secauto.metaschema.databind.IBindingContext;
+import gov.nist.secauto.metaschema.databind.io.DeserializationFeature;
 import gov.nist.secauto.metaschema.databind.io.Format;
 import gov.nist.secauto.metaschema.databind.io.IBoundLoader;
 
@@ -128,6 +129,10 @@ public abstract class AbstractConvertSubcommand
       try {
         IBindingContext bindingContext = getBindingContext();
         IBoundLoader loader = bindingContext.newBoundLoader();
+        // Disable required field validation because pre-generated binding classes
+        // don't preserve choice group information. See issue #594.
+        // TODO: Remove this workaround when #594 is implemented.
+        loader.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
         if (LOGGER.isInfoEnabled()) {
           LOGGER.info("Converting '{}'.", source);
         }

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractValidateContentCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractValidateContentCommand.java
@@ -29,7 +29,6 @@ import gov.nist.secauto.metaschema.core.util.IVersionInfo;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import gov.nist.secauto.metaschema.databind.IBindingContext;
 import gov.nist.secauto.metaschema.databind.IBindingContext.ISchemaValidationProvider;
-import gov.nist.secauto.metaschema.databind.io.DeserializationFeature;
 import gov.nist.secauto.metaschema.databind.io.Format;
 import gov.nist.secauto.metaschema.databind.io.IBoundLoader;
 import gov.nist.secauto.metaschema.modules.sarif.SarifValidationHandler;
@@ -244,10 +243,6 @@ public abstract class AbstractValidateContentCommand
 
       IBindingContext bindingContext = getBindingContext(constraintSets);
       IBoundLoader loader = bindingContext.newBoundLoader();
-      // Disable required field validation because pre-generated binding classes
-      // don't preserve choice group information. See issue #594.
-      // TODO: Remove this workaround when #594 is implemented.
-      loader.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
       Format asFormat = MetaschemaCommands.determineSourceFormat(
           cmdLine,
           MetaschemaCommands.AS_FORMAT_OPTION,

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractValidateContentCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/AbstractValidateContentCommand.java
@@ -29,6 +29,7 @@ import gov.nist.secauto.metaschema.core.util.IVersionInfo;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import gov.nist.secauto.metaschema.databind.IBindingContext;
 import gov.nist.secauto.metaschema.databind.IBindingContext.ISchemaValidationProvider;
+import gov.nist.secauto.metaschema.databind.io.DeserializationFeature;
 import gov.nist.secauto.metaschema.databind.io.Format;
 import gov.nist.secauto.metaschema.databind.io.IBoundLoader;
 import gov.nist.secauto.metaschema.modules.sarif.SarifValidationHandler;
@@ -243,6 +244,10 @@ public abstract class AbstractValidateContentCommand
 
       IBindingContext bindingContext = getBindingContext(constraintSets);
       IBoundLoader loader = bindingContext.newBoundLoader();
+      // Disable required field validation because pre-generated binding classes
+      // don't preserve choice group information. See issue #594.
+      // TODO: Remove this workaround when #594 is implemented.
+      loader.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
       Format asFormat = MetaschemaCommands.determineSourceFormat(
           cmdLine,
           MetaschemaCommands.AS_FORMAT_OPTION,

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/metapath/EvaluateMetapathCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/metapath/EvaluateMetapathCommand.java
@@ -25,7 +25,6 @@ import gov.nist.secauto.metaschema.core.model.MetaschemaException;
 import gov.nist.secauto.metaschema.core.util.CollectionUtil;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import gov.nist.secauto.metaschema.databind.IBindingContext;
-import gov.nist.secauto.metaschema.databind.io.DeserializationFeature;
 import gov.nist.secauto.metaschema.databind.io.IBoundLoader;
 
 import org.apache.commons.cli.CommandLine;
@@ -145,10 +144,6 @@ class EvaluateMetapathCommand
         // load the content
 
         IBoundLoader loader = bindingContext.newBoundLoader();
-        // Disable required field validation because pre-generated binding classes
-        // don't preserve choice group information. See issue #594.
-        // TODO: Remove this workaround when #594 is implemented.
-        loader.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
 
         String contentLocation = ObjectUtils.requireNonNull(cmdLine.getOptionValue(CONTENT_OPTION));
         URI contentResource;

--- a/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/metapath/EvaluateMetapathCommand.java
+++ b/metaschema-cli/src/main/java/gov/nist/secauto/metaschema/cli/commands/metapath/EvaluateMetapathCommand.java
@@ -25,6 +25,7 @@ import gov.nist.secauto.metaschema.core.model.MetaschemaException;
 import gov.nist.secauto.metaschema.core.util.CollectionUtil;
 import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import gov.nist.secauto.metaschema.databind.IBindingContext;
+import gov.nist.secauto.metaschema.databind.io.DeserializationFeature;
 import gov.nist.secauto.metaschema.databind.io.IBoundLoader;
 
 import org.apache.commons.cli.CommandLine;
@@ -144,6 +145,10 @@ class EvaluateMetapathCommand
         // load the content
 
         IBoundLoader loader = bindingContext.newBoundLoader();
+        // Disable required field validation because pre-generated binding classes
+        // don't preserve choice group information. See issue #594.
+        // TODO: Remove this workaround when #594 is implemented.
+        loader.disableFeature(DeserializationFeature.DESERIALIZE_VALIDATE_REQUIRED_FIELDS);
 
         String contentLocation = ObjectUtils.requireNonNull(cmdLine.getOptionValue(CONTENT_OPTION));
         URI contentResource;

--- a/metaschema-maven-plugin/src/main/java/gov/nist/secauto/metaschema/maven/plugin/GenerateSourcesMojo.java
+++ b/metaschema-maven-plugin/src/main/java/gov/nist/secauto/metaschema/maven/plugin/GenerateSourcesMojo.java
@@ -10,6 +10,7 @@ import gov.nist.secauto.metaschema.core.util.ObjectUtils;
 import gov.nist.secauto.metaschema.databind.codegen.IProduction;
 import gov.nist.secauto.metaschema.databind.codegen.JavaGenerator;
 import gov.nist.secauto.metaschema.databind.codegen.config.DefaultBindingConfiguration;
+import gov.nist.secauto.metaschema.databind.io.BindingException;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -88,7 +89,7 @@ public class GenerateSourcesMojo
           getLog().info("Loading binding configuration: " + config.getPath());
         }
         bindingConfiguration.load(config);
-      } catch (IOException ex) {
+      } catch (IOException | BindingException ex) {
         throw new MojoExecutionException(
             String.format("Unable to load binding configuration from '%s'.", config.getPath()), ex);
       }


### PR DESCRIPTION
## Summary

Add validation during deserialization to provide meaningful errors when:
- Required fields are missing (flags with `required="true"`, model instances with `min-occurs > 0`)
- Binding configuration specifies invalid collection class types

**Required field validation:**
- Validates required flags and model instances are present during parsing
- Respects default values - fields with defaults are not considered missing
- Reports clear error messages listing all missing required fields by name
- Controlled via `DESERIALIZE_VALIDATE_REQUIRED_FIELDS` feature flag
- Enabled by default now that choice validation works correctly

**Choice instance support (issue #594):**
- Add `@BoundChoice` annotation to mark fields as mutually exclusive choice alternatives
- Add `BoundInstanceModelChoice` implementing `IChoiceInstance` interface
- Update `AssemblyModelGenerator` to detect and create choice instances during introspection
- Fix `AbstractProblemHandler.isChoiceSatisfied()` to properly handle choice instances
- Regenerate Metaschema binding classes with `@BoundChoice` annotations
- Remove CLI workarounds that disabled validation (no longer needed)

**Collection class type validation:**
- Validates that `collection-class` in binding configuration implements `Collection` or `Map`
- Throws `BindingException` with clear message for invalid types (e.g., `String`)
- Validates at configuration load time for early error detection

## Related Issues

- Closes #594 (Choice Instance Support for Annotation-Based Bindings)

## Test plan

- [x] Valid XML/JSON documents parse successfully
- [x] Missing required flag throws IOException with field name in message
- [x] Missing required field throws IOException with field name in message  
- [x] Missing required assembly throws IOException with field name in message
- [x] Fields with default values do not trigger validation errors
- [x] Validation can be toggled via feature flag
- [x] Invalid collection class (e.g., String) throws BindingException
- [x] Non-existent collection class throws BindingException
- [x] Valid collection classes (List, Set, Map implementations) are accepted
- [x] Choice alternatives properly detected via @BoundChoice annotation
- [x] Choice validation correctly checks if at least one alternative is set
- [x] All tests pass
- [x] Full CI build passes (`mvn clean install -PCI -Prelease`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Required-field validation during deserialization (enabled by default).
  * Annotation-based choice group support for mutually exclusive fields.
  * Binding configuration now validates collection-class declarations.

* **Improvements**
  * Clearer error messages when required fields or assemblies are missing.
  * Improved handling to disable required-field checks during schema validation.

* **Tests**
  * New and extended tests and fixtures covering required-field validation, choice handling, and binding config errors.

* **Configuration**
  * New feature flag "validate-required-fields" (default: true).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->