### PR TITLE
fix(codegen): isRequired() returns false for choice block properties

### DIFF
--- a/.claude/rules/development-workflow.md
+++ b/.claude/rules/development-workflow.md
@@ -50,6 +50,16 @@ If you think any of these, STOP and check for skills:
 - `superpowers:requesting-code-review` - Review implementation against plan
 - `superpowers:testing-anti-patterns` - Avoid common testing mistakes
 
+### Project Conventions Override Skill Defaults
+
+Managed skills (superpowers plugin) provide general templates that may specify default file paths or workflows. **Project-specific conventions in `.claude/rules/` always take precedence.**
+
+Examples:
+- Brainstorming skill outputs to `docs/plans/` by default → Use `PRDs/[date]-[name]/` per `prd-conventions.md`
+- Skills may have their own directory structures → Follow project conventions instead
+
+When in doubt, check `.claude/rules/` for project-specific guidance before following skill defaults.
+
 ### Instructions ≠ Permission to Skip Workflows
 User instructions describe WHAT to do, not HOW. "Add X" or "Fix Y" does NOT mean skip brainstorming, TDD, or verification workflows.
 

--- a/PRDs/20251231-choice-required-fix/PRD.md
+++ b/PRDs/20251231-choice-required-fix/PRD.md
@@ -1,0 +1,73 @@
+# PRD: Fix isRequired() for Choice Block Properties
+
+## Problem Statement
+
+The `isRequired()` method in the code generator type info classes returns `true` for fields with `min-occurs="1"`, but doesn't account for fields that are inside `<choice>` blocks.
+
+### Example
+
+In `metaschema-module-metaschema.xml`, the `root-name` field is defined as:
+
+```xml
+<choice>
+    <define-field name="root-name" as-type="token" min-occurs="1">
+        <formal-name>Root Name</formal-name>
+        ...
+    </define-field>
+</choice>
+```
+
+The field has `min-occurs="1"`, making `isRequired()` return `true`. However, since it's inside a `<choice>` block, it's only required when that choice branch is taken - not always.
+
+### Impact
+
+When the code generator generates getters with `@NonNull` annotations (based on `isRequired()` returning `true`), fields inside choice blocks that aren't populated can cause issues:
+- Static analysis tools expect non-null values
+- Runtime `ObjectUtils.requireNonNull()` calls would throw `NullPointerException`
+
+## Goals
+
+1. Fix `isRequired()` to return `false` for properties inside choice blocks
+2. Ensure all generated getter/setters have proper `@Nullable`/`@NonNull` annotations based on:
+   - Required properties (minOccurs >= 1, not in choice) → `@NonNull`
+   - Optional properties (minOccurs = 0 or in choice) → `@Nullable`
+   - Collection properties → `@NonNull` (lazy initialized)
+3. Ensure Javadocs on generated getters/setters document nullability behavior
+4. Document the `isRequired()` behavior in interface Javadoc
+
+## Non-Goals
+
+- Runtime validation of choice constraints (handled by validation framework)
+- Changes to flag handling (flags cannot be inside choices in Metaschema)
+
+## Solution
+
+### Approach
+
+Properties inside Metaschema choice blocks are treated as optional for null-safety purposes, regardless of their `min-occurs` value. The requirement is conditional on the choice branch being taken.
+
+### Technical Design
+
+The infrastructure for tracking choice membership already exists:
+- `AbstractNamedModelInstanceTypeInfo` has a `choiceId` field
+- `setChoiceId()` is called when processing `IChoiceInstance` in `AssemblyDefinitionTypeInfoImpl`
+- The `@BoundChoice` annotation is already generated for choice properties
+
+The fix: Update `isRequired()` to check if `getChoiceId() != null` and return `false` in that case.
+
+### Impact on Generated Code
+
+For properties inside choice blocks:
+- Getter return annotation: `@NonNull` → `@Nullable`
+- Setter parameter annotation: `@NonNull` → `@Nullable`
+
+## Success Metrics
+
+1. All existing tests pass
+2. New unit tests verify `isRequired()` behavior for choice properties
+3. Regenerated bootstrap binding classes have correct `@Nullable` annotations
+4. Build passes with `mvn clean install -PCI -Prelease`
+
+## Related
+
+- GitHub Issue: [#604](https://github.com/metaschema-framework/metaschema-java/issues/604)

--- a/PRDs/20251231-choice-required-fix/implementation-plan.md
+++ b/PRDs/20251231-choice-required-fix/implementation-plan.md
@@ -1,0 +1,118 @@
+# Implementation Plan: Fix isRequired() for Choice Block Properties
+
+## Overview
+
+This PR fixes issue #604 where `isRequired()` incorrectly returns `true` for properties inside choice blocks.
+
+## PR Scope
+
+Single PR containing:
+- Fix to `isRequired()` logic
+- Javadoc updates
+- Unit tests
+- Regenerated bootstrap binding classes
+
+## Tasks
+
+### Task 1: Write Unit Tests (TDD - RED phase)
+
+Create tests that verify `isRequired()` behavior before implementing the fix.
+
+**File:** `databind/src/test/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/AbstractNamedModelInstanceTypeInfoTest.java`
+
+**Test cases:**
+- [x] Property outside choice with minOccurs=1, maxOccurs=1 → returns `true`
+- [x] Property outside choice with minOccurs=0 → returns `false`
+- [x] Property inside choice with minOccurs=1, maxOccurs=1 → returns `false`
+- [x] Property inside choice with minOccurs=0 → returns `false`
+- [x] Collection property (maxOccurs > 1) → returns `false`
+
+### Task 2: Implement Fix (TDD - GREEN phase)
+
+Update `isRequired()` to check for choice membership.
+
+**File:** `databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/AbstractNamedModelInstanceTypeInfo.java`
+
+**Change:**
+```java
+@Override
+public boolean isRequired() {
+  // Properties inside choice blocks are never required because
+  // the requirement is conditional on the choice branch being taken
+  if (getChoiceId() != null) {
+    return false;
+  }
+
+  INSTANCE instance = getInstance();
+  return instance.getMinOccurs() >= 1 && instance.getMaxOccurs() == 1;
+}
+```
+
+### Task 3: Update Javadoc
+
+Document the choice block behavior and enhance setter Javadoc.
+
+**Files:**
+- `databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/IPropertyTypeInfo.java`
+- `databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/INamedModelInstanceTypeInfo.java`
+
+**Changes:**
+1. Update `isRequired()` Javadoc to document choice block behavior
+2. Enhance `buildSetterJavadoc()` to document nullability for optional parameters:
+   - Required: "the value to set"
+   - Optional: "the value to set, or {@code null} to clear"
+
+### Task 4: Regenerate Bootstrap Binding Classes
+
+Regenerate all bootstrap binding classes to pick up annotation changes.
+
+```bash
+mvn install -DskipTests
+mvn -f databind/pom-bootstrap-model.xml generate-sources
+mvn -f databind/pom-bootstrap-config.xml generate-sources
+mvn -f metaschema-testing/pom-bootstrap.xml generate-sources
+```
+
+### Task 5: Verify Build
+
+Run full CI build to ensure all tests pass.
+
+```bash
+mvn clean install -PCI -Prelease
+```
+
+## Acceptance Criteria
+
+### Core Fix
+- [x] All unit tests pass
+- [x] New tests verify `isRequired()` returns `false` for choice properties
+- [x] `IPropertyTypeInfo.isRequired()` Javadoc documents the choice block behavior
+
+### Generated Code Quality
+- [x] All generated getters have correct null-safety annotations:
+  - `@NonNull` for required properties (minOccurs >= 1, not in choice)
+  - `@NonNull` for collection properties (lazy initialized)
+  - `@Nullable` for optional properties (minOccurs = 0 or in choice)
+- [x] All generated setters have matching null-safety annotations on parameters
+- [x] Generated getter/setter Javadocs document nullability behavior
+
+### Bootstrap Bindings
+- [x] Bootstrap binding classes regenerated with correct annotations
+- [x] Verify choice properties in regenerated classes have `@Nullable` annotations
+
+### Build Verification
+- [x] Build passes: `mvn clean install -PCI -Prelease`
+
+## Files Changed Summary
+
+| File | Change Type |
+|------|-------------|
+| `databind/.../typeinfo/AbstractNamedModelInstanceTypeInfo.java` | Modified |
+| `databind/.../typeinfo/IPropertyTypeInfo.java` | Modified |
+| `databind/.../typeinfo/INamedModelInstanceTypeInfo.java` | Modified |
+| `databind/.../typeinfo/INamedInstanceTypeInfo.java` | Modified |
+| `databind/.../typeinfo/AbstractNamedModelInstanceTypeInfoTest.java` | New |
+| `.claude/rules/development-workflow.md` | Modified |
+| `databind/.../model/metaschema/binding/*.java` | Regenerated |
+| `databind/.../config/binding/*.java` | Regenerated |
+| `metaschema-testing/.../testsuite/*.java` | Regenerated |

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/AbstractNamedModelInstanceTypeInfo.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/AbstractNamedModelInstanceTypeInfo.java
@@ -74,6 +74,12 @@ abstract class AbstractNamedModelInstanceTypeInfo<INSTANCE extends INamedModelIn
 
   @Override
   public boolean isRequired() {
+    // Properties inside choice blocks are never required because
+    // the requirement is conditional on the choice branch being taken
+    if (getChoiceId() != null) {
+      return false;
+    }
+
     INSTANCE instance = getInstance();
     // A model instance is required if minOccurs >= 1 AND it's a single item (not a
     // collection)

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/INamedInstanceTypeInfo.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/INamedInstanceTypeInfo.java
@@ -101,6 +101,12 @@ public interface INamedInstanceTypeInfo extends IInstanceTypeInfo {
 
     builder.addJavadoc("\n");
     builder.addJavadoc("@param $L\n", paramName);
-    builder.addJavadoc("          the $L value to set\n", propertyName);
+    // Collections and required properties require non-null values;
+    // optional properties can be set to null to clear
+    if (isRequired() || isCollectionType()) {
+      builder.addJavadoc("          the $L value to set\n", propertyName);
+    } else {
+      builder.addJavadoc("          the $L value to set, or {@code null} to clear\n", propertyName);
+    }
   }
 }

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/INamedModelInstanceTypeInfo.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/INamedModelInstanceTypeInfo.java
@@ -124,6 +124,12 @@ public interface INamedModelInstanceTypeInfo extends IModelInstanceTypeInfo {
 
     builder.addJavadoc("\n");
     builder.addJavadoc("@param $L\n", paramName);
-    builder.addJavadoc("          the $L value to set\n", propertyName);
+    // Collections and required properties require non-null values;
+    // optional properties can be set to null to clear
+    if (isRequired() || isCollectionType()) {
+      builder.addJavadoc("          the $L value to set\n", propertyName);
+    } else {
+      builder.addJavadoc("          the $L value to set, or {@code null} to clear\n", propertyName);
+    }
   }
 }

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/IPropertyTypeInfo.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/IPropertyTypeInfo.java
@@ -18,14 +18,21 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 
 public interface IPropertyTypeInfo extends ITypeInfo {
   /**
-   * Determines if this property is required to have a value.
+   * Determines if this property is unconditionally required to have a value.
    *
    * <p>
    * For flags, this checks
    * {@link gov.nist.secauto.metaschema.core.model.IFlagInstance#isRequired()}.
    * For model instances, this is based on minimum occurrence constraints.
    *
-   * @return {@code true} if a value is required, or {@code false} otherwise
+   * <p>
+   * <strong>Choice blocks:</strong> Properties inside Metaschema choice blocks
+   * always return {@code false}, regardless of their {@code min-occurs} value.
+   * The requirement is conditional on the choice branch being taken, so for
+   * null-safety purposes they are treated as optional.
+   *
+   * @return {@code true} if a value is unconditionally required, or {@code false}
+   *         otherwise
    */
   default boolean isRequired() {
     return false;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/config/binding/MetaschemaBindings.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/config/binding/MetaschemaBindings.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../metaschema/metaschema-bindings.yaml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.config.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -38,21 +39,20 @@ import org.apache.commons.lang3.builder.ToStringStyle;
     description = "The root element for a set of metaschema binding customizations.",
     name = "metaschema-bindings",
     moduleClass = MetaschemaBindingsModule.class,
-    rootName = "metaschema-bindings"
-)
+    rootName = "metaschema-bindings")
 public class MetaschemaBindings implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
   /**
-   * Defines binding configurations that apply to a whole model described by a namespace.
+   * Defines binding configurations that apply to a whole model described by a
+   * namespace.
    */
   @BoundAssembly(
       formalName = "Model Binding",
       description = "Defines binding configurations that apply to a whole model described by a namespace.",
       useName = "model-binding",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "model-bindings", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "model-bindings", inJson = JsonGroupAsBehavior.LIST))
   private List<ModelBinding> _modelBindings;
 
   /**
@@ -63,22 +63,25 @@ public class MetaschemaBindings implements IBoundObject {
       description = "Defines a binding for a given metaschema identified by a relative URL.",
       useName = "metaschema-binding",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "metaschema-bindings", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "metaschema-bindings", inJson = JsonGroupAsBehavior.LIST))
   private List<MetaschemaBinding> _metaschemaBindings;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings}
+   * instance with no metadata.
    */
   public MetaschemaBindings() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public MetaschemaBindings(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -93,7 +96,8 @@ public class MetaschemaBindings implements IBoundObject {
    * Get the model Binding.
    *
    * <p>
-   * Defines binding configurations that apply to a whole model described by a namespace.
+   * Defines binding configurations that apply to a whole model described by a
+   * namespace.
    *
    * @return the model-binding value
    */
@@ -109,10 +113,11 @@ public class MetaschemaBindings implements IBoundObject {
    * Set the model Binding.
    *
    * <p>
-   * Defines binding configurations that apply to a whole model described by a namespace.
+   * Defines binding configurations that apply to a whole model described by a
+   * namespace.
    *
    * @param value
-   *           the model-binding value to set
+   *          the model-binding value to set
    */
   public void setModelBindings(@NonNull List<ModelBinding> value) {
     _modelBindings = value;
@@ -120,11 +125,13 @@ public class MetaschemaBindings implements IBoundObject {
 
   /**
    * Add a new {@link ModelBinding} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addModelBinding(ModelBinding item) {
-    ModelBinding value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    ModelBinding value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_modelBindings == null) {
       _modelBindings = new LinkedList<>();
     }
@@ -132,12 +139,15 @@ public class MetaschemaBindings implements IBoundObject {
   }
 
   /**
-   * Remove the first matching {@link ModelBinding} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link ModelBinding} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeModelBinding(ModelBinding item) {
-    ModelBinding value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    ModelBinding value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _modelBindings != null && _modelBindings.remove(value);
   }
 
@@ -164,7 +174,7 @@ public class MetaschemaBindings implements IBoundObject {
    * Defines a binding for a given metaschema identified by a relative URL.
    *
    * @param value
-   *           the metaschema-binding value to set
+   *          the metaschema-binding value to set
    */
   public void setMetaschemaBindings(@NonNull List<MetaschemaBinding> value) {
     _metaschemaBindings = value;
@@ -172,11 +182,13 @@ public class MetaschemaBindings implements IBoundObject {
 
   /**
    * Add a new {@link MetaschemaBinding} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addMetaschemaBinding(MetaschemaBinding item) {
-    MetaschemaBinding value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    MetaschemaBinding value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_metaschemaBindings == null) {
       _metaschemaBindings = new LinkedList<>();
     }
@@ -184,12 +196,15 @@ public class MetaschemaBindings implements IBoundObject {
   }
 
   /**
-   * Remove the first matching {@link MetaschemaBinding} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link MetaschemaBinding} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeMetaschemaBinding(MetaschemaBinding item) {
-    MetaschemaBinding value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    MetaschemaBinding value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _metaschemaBindings != null && _metaschemaBindings.remove(value);
   }
 
@@ -199,27 +214,27 @@ public class MetaschemaBindings implements IBoundObject {
   }
 
   /**
-   * Defines binding configurations that apply to a whole model described by a namespace.
+   * Defines binding configurations that apply to a whole model described by a
+   * namespace.
    */
   @MetaschemaAssembly(
       formalName = "Model Binding",
       description = "Defines binding configurations that apply to a whole model described by a namespace.",
       name = "model-binding",
-      moduleClass = MetaschemaBindingsModule.class
-  )
+      moduleClass = MetaschemaBindingsModule.class)
   public static class ModelBinding implements IBoundObject {
     private final IMetaschemaData __metaschemaData;
 
     /**
-     * A URI referencing the namespace of one or more related metaschema definitions.
+     * A URI referencing the namespace of one or more related metaschema
+     * definitions.
      */
     @BoundFlag(
         formalName = "Namespace",
         description = "A URI referencing the namespace of one or more related metaschema definitions.",
         name = "namespace",
         required = true,
-        typeAdapter = UriAdapter.class
-    )
+        typeAdapter = UriAdapter.class)
     private URI _namespace;
 
     /**
@@ -228,22 +243,25 @@ public class MetaschemaBindings implements IBoundObject {
     @BoundAssembly(
         formalName = "Java Model Binding",
         description = "Java-specific binding configuration for a model namespace.",
-        useName = "java"
-    )
+        useName = "java")
     private Java _java;
 
     /**
-     * Constructs a new {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.ModelBinding} instance with no metadata.
+     * Constructs a new
+     * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.ModelBinding}
+     * instance with no metadata.
      */
     public ModelBinding() {
       this(null);
     }
 
     /**
-     * Constructs a new {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.ModelBinding} instance with the specified metadata.
+     * Constructs a new
+     * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.ModelBinding}
+     * instance with the specified metadata.
      *
      * @param data
-     *           the metaschema data, or {@code null} if none
+     *          the metaschema data, or {@code null} if none
      */
     public ModelBinding(IMetaschemaData data) {
       this.__metaschemaData = data;
@@ -258,7 +276,8 @@ public class MetaschemaBindings implements IBoundObject {
      * Get the namespace.
      *
      * <p>
-     * A URI referencing the namespace of one or more related metaschema definitions.
+     * A URI referencing the namespace of one or more related metaschema
+     * definitions.
      *
      * @return the namespace value
      */
@@ -271,10 +290,11 @@ public class MetaschemaBindings implements IBoundObject {
      * Set the namespace.
      *
      * <p>
-     * A URI referencing the namespace of one or more related metaschema definitions.
+     * A URI referencing the namespace of one or more related metaschema
+     * definitions.
      *
      * @param value
-     *           the namespace value to set
+     *          the namespace value to set
      */
     public void setNamespace(@NonNull URI value) {
       _namespace = value;
@@ -300,7 +320,7 @@ public class MetaschemaBindings implements IBoundObject {
      * Java-specific binding configuration for a model namespace.
      *
      * @param value
-     *           the java value to set
+     *          the java value to set, or {@code null} to clear
      */
     public void setJava(@Nullable Java value) {
       _java = value;
@@ -318,8 +338,7 @@ public class MetaschemaBindings implements IBoundObject {
         formalName = "Java Model Binding",
         description = "Java-specific binding configuration for a model namespace.",
         name = "java",
-        moduleClass = MetaschemaBindingsModule.class
-    )
+        moduleClass = MetaschemaBindingsModule.class)
     public static class Java implements IBoundObject {
       private final IMetaschemaData __metaschemaData;
 
@@ -330,22 +349,25 @@ public class MetaschemaBindings implements IBoundObject {
           formalName = "Use Package Name",
           description = "The Java package name to use for classes generated from this namespace.",
           useName = "use-package-name",
-          typeAdapter = TokenAdapter.class
-      )
+          typeAdapter = TokenAdapter.class)
       private String _usePackageName;
 
       /**
-       * Constructs a new {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.ModelBinding.Java} instance with no metadata.
+       * Constructs a new
+       * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.ModelBinding.Java}
+       * instance with no metadata.
        */
       public Java() {
         this(null);
       }
 
       /**
-       * Constructs a new {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.ModelBinding.Java} instance with the specified metadata.
+       * Constructs a new
+       * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.ModelBinding.Java}
+       * instance with the specified metadata.
        *
        * @param data
-       *           the metaschema data, or {@code null} if none
+       *          the metaschema data, or {@code null} if none
        */
       public Java(IMetaschemaData data) {
         this.__metaschemaData = data;
@@ -376,7 +398,7 @@ public class MetaschemaBindings implements IBoundObject {
        * The Java package name to use for classes generated from this namespace.
        *
        * @param value
-       *           the use-package-name value to set
+       *          the use-package-name value to set, or {@code null} to clear
        */
       public void setUsePackageName(@Nullable String value) {
         _usePackageName = value;
@@ -396,59 +418,62 @@ public class MetaschemaBindings implements IBoundObject {
       formalName = "Metaschema Binding",
       description = "Defines a binding for a given metaschema identified by a relative URL.",
       name = "metaschema-binding",
-      moduleClass = MetaschemaBindingsModule.class
-  )
+      moduleClass = MetaschemaBindingsModule.class)
   public static class MetaschemaBinding implements IBoundObject {
     private final IMetaschemaData __metaschemaData;
 
     /**
-     * A URL relative to this binding configuration file, pointing to a metaschema definition.
+     * A URL relative to this binding configuration file, pointing to a metaschema
+     * definition.
      */
     @BoundFlag(
         formalName = "Href",
         description = "A URL relative to this binding configuration file, pointing to a metaschema definition.",
         name = "href",
         required = true,
-        typeAdapter = UriReferenceAdapter.class
-    )
+        typeAdapter = UriReferenceAdapter.class)
     private URI _href;
 
     /**
-     * Provides binding configurations for a given defined assembly within the parent metaschema.
+     * Provides binding configurations for a given defined assembly within the
+     * parent metaschema.
      */
     @BoundAssembly(
         formalName = "Define Assembly Binding",
         description = "Provides binding configurations for a given defined assembly within the parent metaschema.",
         useName = "define-assembly-binding",
         maxOccurs = -1,
-        groupAs = @GroupAs(name = "define-assembly-bindings", inJson = JsonGroupAsBehavior.LIST)
-    )
+        groupAs = @GroupAs(name = "define-assembly-bindings", inJson = JsonGroupAsBehavior.LIST))
     private List<DefineAssemblyBinding> _defineAssemblyBindings;
 
     /**
-     * Provides binding configurations for a given defined field within the parent metaschema.
+     * Provides binding configurations for a given defined field within the parent
+     * metaschema.
      */
     @BoundAssembly(
         formalName = "Define Field Binding",
         description = "Provides binding configurations for a given defined field within the parent metaschema.",
         useName = "define-field-binding",
         maxOccurs = -1,
-        groupAs = @GroupAs(name = "define-field-bindings", inJson = JsonGroupAsBehavior.LIST)
-    )
+        groupAs = @GroupAs(name = "define-field-bindings", inJson = JsonGroupAsBehavior.LIST))
     private List<DefineFieldBinding> _defineFieldBindings;
 
     /**
-     * Constructs a new {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding} instance with no metadata.
+     * Constructs a new
+     * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding}
+     * instance with no metadata.
      */
     public MetaschemaBinding() {
       this(null);
     }
 
     /**
-     * Constructs a new {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding} instance with the specified metadata.
+     * Constructs a new
+     * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding}
+     * instance with the specified metadata.
      *
      * @param data
-     *           the metaschema data, or {@code null} if none
+     *          the metaschema data, or {@code null} if none
      */
     public MetaschemaBinding(IMetaschemaData data) {
       this.__metaschemaData = data;
@@ -463,7 +488,8 @@ public class MetaschemaBindings implements IBoundObject {
      * Get the href.
      *
      * <p>
-     * A URL relative to this binding configuration file, pointing to a metaschema definition.
+     * A URL relative to this binding configuration file, pointing to a metaschema
+     * definition.
      *
      * @return the href value
      */
@@ -476,10 +502,11 @@ public class MetaschemaBindings implements IBoundObject {
      * Set the href.
      *
      * <p>
-     * A URL relative to this binding configuration file, pointing to a metaschema definition.
+     * A URL relative to this binding configuration file, pointing to a metaschema
+     * definition.
      *
      * @param value
-     *           the href value to set
+     *          the href value to set
      */
     public void setHref(@NonNull URI value) {
       _href = value;
@@ -489,7 +516,8 @@ public class MetaschemaBindings implements IBoundObject {
      * Get the define Assembly Binding.
      *
      * <p>
-     * Provides binding configurations for a given defined assembly within the parent metaschema.
+     * Provides binding configurations for a given defined assembly within the
+     * parent metaschema.
      *
      * @return the define-assembly-binding value
      */
@@ -505,10 +533,11 @@ public class MetaschemaBindings implements IBoundObject {
      * Set the define Assembly Binding.
      *
      * <p>
-     * Provides binding configurations for a given defined assembly within the parent metaschema.
+     * Provides binding configurations for a given defined assembly within the
+     * parent metaschema.
      *
      * @param value
-     *           the define-assembly-binding value to set
+     *          the define-assembly-binding value to set
      */
     public void setDefineAssemblyBindings(@NonNull List<DefineAssemblyBinding> value) {
       _defineAssemblyBindings = value;
@@ -516,11 +545,13 @@ public class MetaschemaBindings implements IBoundObject {
 
     /**
      * Add a new {@link DefineAssemblyBinding} item to the underlying collection.
-     * @param item the item to add
+     *
+     * @param item
+     *          the item to add
      * @return {@code true}
      */
     public boolean addDefineAssemblyBinding(DefineAssemblyBinding item) {
-      DefineAssemblyBinding value = ObjectUtils.requireNonNull(item,"item cannot be null");
+      DefineAssemblyBinding value = ObjectUtils.requireNonNull(item, "item cannot be null");
       if (_defineAssemblyBindings == null) {
         _defineAssemblyBindings = new LinkedList<>();
       }
@@ -528,12 +559,15 @@ public class MetaschemaBindings implements IBoundObject {
     }
 
     /**
-     * Remove the first matching {@link DefineAssemblyBinding} item from the underlying collection.
-     * @param item the item to remove
+     * Remove the first matching {@link DefineAssemblyBinding} item from the
+     * underlying collection.
+     *
+     * @param item
+     *          the item to remove
      * @return {@code true} if the item was removed or {@code false} otherwise
      */
     public boolean removeDefineAssemblyBinding(DefineAssemblyBinding item) {
-      DefineAssemblyBinding value = ObjectUtils.requireNonNull(item,"item cannot be null");
+      DefineAssemblyBinding value = ObjectUtils.requireNonNull(item, "item cannot be null");
       return _defineAssemblyBindings != null && _defineAssemblyBindings.remove(value);
     }
 
@@ -541,7 +575,8 @@ public class MetaschemaBindings implements IBoundObject {
      * Get the define Field Binding.
      *
      * <p>
-     * Provides binding configurations for a given defined field within the parent metaschema.
+     * Provides binding configurations for a given defined field within the parent
+     * metaschema.
      *
      * @return the define-field-binding value
      */
@@ -557,10 +592,11 @@ public class MetaschemaBindings implements IBoundObject {
      * Set the define Field Binding.
      *
      * <p>
-     * Provides binding configurations for a given defined field within the parent metaschema.
+     * Provides binding configurations for a given defined field within the parent
+     * metaschema.
      *
      * @param value
-     *           the define-field-binding value to set
+     *          the define-field-binding value to set
      */
     public void setDefineFieldBindings(@NonNull List<DefineFieldBinding> value) {
       _defineFieldBindings = value;
@@ -568,11 +604,13 @@ public class MetaschemaBindings implements IBoundObject {
 
     /**
      * Add a new {@link DefineFieldBinding} item to the underlying collection.
-     * @param item the item to add
+     *
+     * @param item
+     *          the item to add
      * @return {@code true}
      */
     public boolean addDefineFieldBinding(DefineFieldBinding item) {
-      DefineFieldBinding value = ObjectUtils.requireNonNull(item,"item cannot be null");
+      DefineFieldBinding value = ObjectUtils.requireNonNull(item, "item cannot be null");
       if (_defineFieldBindings == null) {
         _defineFieldBindings = new LinkedList<>();
       }
@@ -580,12 +618,15 @@ public class MetaschemaBindings implements IBoundObject {
     }
 
     /**
-     * Remove the first matching {@link DefineFieldBinding} item from the underlying collection.
-     * @param item the item to remove
+     * Remove the first matching {@link DefineFieldBinding} item from the underlying
+     * collection.
+     *
+     * @param item
+     *          the item to remove
      * @return {@code true} if the item was removed or {@code false} otherwise
      */
     public boolean removeDefineFieldBinding(DefineFieldBinding item) {
-      DefineFieldBinding value = ObjectUtils.requireNonNull(item,"item cannot be null");
+      DefineFieldBinding value = ObjectUtils.requireNonNull(item, "item cannot be null");
       return _defineFieldBindings != null && _defineFieldBindings.remove(value);
     }
 
@@ -595,14 +636,14 @@ public class MetaschemaBindings implements IBoundObject {
     }
 
     /**
-     * Provides binding configurations for a given defined assembly within the parent metaschema.
+     * Provides binding configurations for a given defined assembly within the
+     * parent metaschema.
      */
     @MetaschemaAssembly(
         formalName = "Define Assembly Binding",
         description = "Provides binding configurations for a given defined assembly within the parent metaschema.",
         name = "define-assembly-binding",
-        moduleClass = MetaschemaBindingsModule.class
-    )
+        moduleClass = MetaschemaBindingsModule.class)
     public static class DefineAssemblyBinding implements IBoundObject {
       private final IMetaschemaData __metaschemaData;
 
@@ -613,19 +654,18 @@ public class MetaschemaBindings implements IBoundObject {
           formalName = "Name",
           description = "The name of the metaschema assembly. Used for top-level definitions.",
           name = "name",
-          typeAdapter = TokenAdapter.class
-      )
+          typeAdapter = TokenAdapter.class)
       private String _name;
 
       /**
-       * A Metapath expression targeting the assembly definition(s) within the metaschema. Used for inline definitions.
+       * A Metapath expression targeting the assembly definition(s) within the
+       * metaschema. Used for inline definitions.
        */
       @BoundFlag(
           formalName = "Target",
           description = "A Metapath expression targeting the assembly definition(s) within the metaschema. Used for inline definitions.",
           name = "target",
-          typeAdapter = StringAdapter.class
-      )
+          typeAdapter = StringAdapter.class)
       private String _target;
 
       /**
@@ -634,8 +674,7 @@ public class MetaschemaBindings implements IBoundObject {
       @BoundAssembly(
           formalName = "Java Object Definition Binding",
           description = "Field and assembly binding configurations for Java bound classes.",
-          useName = "java"
-      )
+          useName = "java")
       private Java _java;
 
       /**
@@ -646,8 +685,7 @@ public class MetaschemaBindings implements IBoundObject {
           description = "Provides binding configurations for a property within the parent definition.",
           useName = "property-binding",
           maxOccurs = -1,
-          groupAs = @GroupAs(name = "property-bindings", inJson = JsonGroupAsBehavior.LIST)
-      )
+          groupAs = @GroupAs(name = "property-bindings", inJson = JsonGroupAsBehavior.LIST))
       private List<PropertyBinding> _propertyBindings;
 
       /**
@@ -658,22 +696,25 @@ public class MetaschemaBindings implements IBoundObject {
           description = "Provides binding configuration for a choice group within the parent assembly.",
           useName = "choice-group-binding",
           maxOccurs = -1,
-          groupAs = @GroupAs(name = "choice-group-bindings", inJson = JsonGroupAsBehavior.LIST)
-      )
+          groupAs = @GroupAs(name = "choice-group-bindings", inJson = JsonGroupAsBehavior.LIST))
       private List<ChoiceGroupBinding> _choiceGroupBindings;
 
       /**
-       * Constructs a new {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding} instance with no metadata.
+       * Constructs a new
+       * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding}
+       * instance with no metadata.
        */
       public DefineAssemblyBinding() {
         this(null);
       }
 
       /**
-       * Constructs a new {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding} instance with the specified metadata.
+       * Constructs a new
+       * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding}
+       * instance with the specified metadata.
        *
        * @param data
-       *           the metaschema data, or {@code null} if none
+       *          the metaschema data, or {@code null} if none
        */
       public DefineAssemblyBinding(IMetaschemaData data) {
         this.__metaschemaData = data;
@@ -704,7 +745,7 @@ public class MetaschemaBindings implements IBoundObject {
        * The name of the metaschema assembly. Used for top-level definitions.
        *
        * @param value
-       *           the name value to set
+       *          the name value to set, or {@code null} to clear
        */
       public void setName(@Nullable String value) {
         _name = value;
@@ -714,7 +755,8 @@ public class MetaschemaBindings implements IBoundObject {
        * Get the target.
        *
        * <p>
-       * A Metapath expression targeting the assembly definition(s) within the metaschema. Used for inline definitions.
+       * A Metapath expression targeting the assembly definition(s) within the
+       * metaschema. Used for inline definitions.
        *
        * @return the target value, or {@code null} if not set
        */
@@ -727,10 +769,11 @@ public class MetaschemaBindings implements IBoundObject {
        * Set the target.
        *
        * <p>
-       * A Metapath expression targeting the assembly definition(s) within the metaschema. Used for inline definitions.
+       * A Metapath expression targeting the assembly definition(s) within the
+       * metaschema. Used for inline definitions.
        *
        * @param value
-       *           the target value to set
+       *          the target value to set, or {@code null} to clear
        */
       public void setTarget(@Nullable String value) {
         _target = value;
@@ -756,7 +799,7 @@ public class MetaschemaBindings implements IBoundObject {
        * Field and assembly binding configurations for Java bound classes.
        *
        * @param value
-       *           the java value to set
+       *          the java value to set, or {@code null} to clear
        */
       public void setJava(@Nullable Java value) {
         _java = value;
@@ -785,7 +828,7 @@ public class MetaschemaBindings implements IBoundObject {
        * Provides binding configurations for a property within the parent definition.
        *
        * @param value
-       *           the property-binding value to set
+       *          the property-binding value to set
        */
       public void setPropertyBindings(@NonNull List<PropertyBinding> value) {
         _propertyBindings = value;
@@ -793,11 +836,13 @@ public class MetaschemaBindings implements IBoundObject {
 
       /**
        * Add a new {@link PropertyBinding} item to the underlying collection.
-       * @param item the item to add
+       *
+       * @param item
+       *          the item to add
        * @return {@code true}
        */
       public boolean addPropertyBinding(PropertyBinding item) {
-        PropertyBinding value = ObjectUtils.requireNonNull(item,"item cannot be null");
+        PropertyBinding value = ObjectUtils.requireNonNull(item, "item cannot be null");
         if (_propertyBindings == null) {
           _propertyBindings = new LinkedList<>();
         }
@@ -805,12 +850,15 @@ public class MetaschemaBindings implements IBoundObject {
       }
 
       /**
-       * Remove the first matching {@link PropertyBinding} item from the underlying collection.
-       * @param item the item to remove
+       * Remove the first matching {@link PropertyBinding} item from the underlying
+       * collection.
+       *
+       * @param item
+       *          the item to remove
        * @return {@code true} if the item was removed or {@code false} otherwise
        */
       public boolean removePropertyBinding(PropertyBinding item) {
-        PropertyBinding value = ObjectUtils.requireNonNull(item,"item cannot be null");
+        PropertyBinding value = ObjectUtils.requireNonNull(item, "item cannot be null");
         return _propertyBindings != null && _propertyBindings.remove(value);
       }
 
@@ -837,7 +885,7 @@ public class MetaschemaBindings implements IBoundObject {
        * Provides binding configuration for a choice group within the parent assembly.
        *
        * @param value
-       *           the choice-group-binding value to set
+       *          the choice-group-binding value to set
        */
       public void setChoiceGroupBindings(@NonNull List<ChoiceGroupBinding> value) {
         _choiceGroupBindings = value;
@@ -845,11 +893,13 @@ public class MetaschemaBindings implements IBoundObject {
 
       /**
        * Add a new {@link ChoiceGroupBinding} item to the underlying collection.
-       * @param item the item to add
+       *
+       * @param item
+       *          the item to add
        * @return {@code true}
        */
       public boolean addChoiceGroupBinding(ChoiceGroupBinding item) {
-        ChoiceGroupBinding value = ObjectUtils.requireNonNull(item,"item cannot be null");
+        ChoiceGroupBinding value = ObjectUtils.requireNonNull(item, "item cannot be null");
         if (_choiceGroupBindings == null) {
           _choiceGroupBindings = new LinkedList<>();
         }
@@ -857,12 +907,15 @@ public class MetaschemaBindings implements IBoundObject {
       }
 
       /**
-       * Remove the first matching {@link ChoiceGroupBinding} item from the underlying collection.
-       * @param item the item to remove
+       * Remove the first matching {@link ChoiceGroupBinding} item from the underlying
+       * collection.
+       *
+       * @param item
+       *          the item to remove
        * @return {@code true} if the item was removed or {@code false} otherwise
        */
       public boolean removeChoiceGroupBinding(ChoiceGroupBinding item) {
-        ChoiceGroupBinding value = ObjectUtils.requireNonNull(item,"item cannot be null");
+        ChoiceGroupBinding value = ObjectUtils.requireNonNull(item, "item cannot be null");
         return _choiceGroupBindings != null && _choiceGroupBindings.remove(value);
       }
 
@@ -878,8 +931,7 @@ public class MetaschemaBindings implements IBoundObject {
           formalName = "Java Object Definition Binding",
           description = "Field and assembly binding configurations for Java bound classes.",
           name = "java",
-          moduleClass = MetaschemaBindingsModule.class
-      )
+          moduleClass = MetaschemaBindingsModule.class)
       public static class Java implements IBoundObject {
         private final IMetaschemaData __metaschemaData;
 
@@ -890,12 +942,12 @@ public class MetaschemaBindings implements IBoundObject {
             formalName = "Use Class Name",
             description = "The Java class name to use for the generated class.",
             useName = "use-class-name",
-            typeAdapter = TokenAdapter.class
-        )
+            typeAdapter = TokenAdapter.class)
         private String _useClassName;
 
         /**
-         * A fully qualified Java interface name that the generated class should implement.
+         * A fully qualified Java interface name that the generated class should
+         * implement.
          */
         @BoundField(
             formalName = "Implement Interface",
@@ -903,8 +955,7 @@ public class MetaschemaBindings implements IBoundObject {
             useName = "implement-interface",
             maxOccurs = -1,
             groupAs = @GroupAs(name = "implement-interfaces", inJson = JsonGroupAsBehavior.LIST),
-            typeAdapter = TokenAdapter.class
-        )
+            typeAdapter = TokenAdapter.class)
         private List<String> _implementInterfaces;
 
         /**
@@ -914,8 +965,7 @@ public class MetaschemaBindings implements IBoundObject {
             formalName = "Extend Base Class",
             description = "A fully qualified Java class name that the generated class should extend.",
             useName = "extend-base-class",
-            typeAdapter = TokenAdapter.class
-        )
+            typeAdapter = TokenAdapter.class)
         private String _extendBaseClass;
 
         /**
@@ -925,22 +975,25 @@ public class MetaschemaBindings implements IBoundObject {
             formalName = "Collection Class",
             description = "A fully qualified Java collection class name to use instead of the default.",
             useName = "collection-class",
-            typeAdapter = TokenAdapter.class
-        )
+            typeAdapter = TokenAdapter.class)
         private String _collectionClass;
 
         /**
-         * Constructs a new {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.Java} instance with no metadata.
+         * Constructs a new
+         * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.Java}
+         * instance with no metadata.
          */
         public Java() {
           this(null);
         }
 
         /**
-         * Constructs a new {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.Java} instance with the specified metadata.
+         * Constructs a new
+         * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.Java}
+         * instance with the specified metadata.
          *
          * @param data
-         *           the metaschema data, or {@code null} if none
+         *          the metaschema data, or {@code null} if none
          */
         public Java(IMetaschemaData data) {
           this.__metaschemaData = data;
@@ -971,7 +1024,7 @@ public class MetaschemaBindings implements IBoundObject {
          * The Java class name to use for the generated class.
          *
          * @param value
-         *           the use-class-name value to set
+         *          the use-class-name value to set, or {@code null} to clear
          */
         public void setUseClassName(@Nullable String value) {
           _useClassName = value;
@@ -981,7 +1034,8 @@ public class MetaschemaBindings implements IBoundObject {
          * Get the implement Interface.
          *
          * <p>
-         * A fully qualified Java interface name that the generated class should implement.
+         * A fully qualified Java interface name that the generated class should
+         * implement.
          *
          * @return the implement-interface value
          */
@@ -997,10 +1051,11 @@ public class MetaschemaBindings implements IBoundObject {
          * Set the implement Interface.
          *
          * <p>
-         * A fully qualified Java interface name that the generated class should implement.
+         * A fully qualified Java interface name that the generated class should
+         * implement.
          *
          * @param value
-         *           the implement-interface value to set
+         *          the implement-interface value to set
          */
         public void setImplementInterfaces(@NonNull List<String> value) {
           _implementInterfaces = value;
@@ -1008,11 +1063,13 @@ public class MetaschemaBindings implements IBoundObject {
 
         /**
          * Add a new {@link String} item to the underlying collection.
-         * @param item the item to add
+         *
+         * @param item
+         *          the item to add
          * @return {@code true}
          */
         public boolean addImplementInterface(String item) {
-          String value = ObjectUtils.requireNonNull(item,"item cannot be null");
+          String value = ObjectUtils.requireNonNull(item, "item cannot be null");
           if (_implementInterfaces == null) {
             _implementInterfaces = new LinkedList<>();
           }
@@ -1021,11 +1078,13 @@ public class MetaschemaBindings implements IBoundObject {
 
         /**
          * Remove the first matching {@link String} item from the underlying collection.
-         * @param item the item to remove
+         *
+         * @param item
+         *          the item to remove
          * @return {@code true} if the item was removed or {@code false} otherwise
          */
         public boolean removeImplementInterface(String item) {
-          String value = ObjectUtils.requireNonNull(item,"item cannot be null");
+          String value = ObjectUtils.requireNonNull(item, "item cannot be null");
           return _implementInterfaces != null && _implementInterfaces.remove(value);
         }
 
@@ -1049,7 +1108,7 @@ public class MetaschemaBindings implements IBoundObject {
          * A fully qualified Java class name that the generated class should extend.
          *
          * @param value
-         *           the extend-base-class value to set
+         *          the extend-base-class value to set, or {@code null} to clear
          */
         public void setExtendBaseClass(@Nullable String value) {
           _extendBaseClass = value;
@@ -1075,7 +1134,7 @@ public class MetaschemaBindings implements IBoundObject {
          * A fully qualified Java collection class name to use instead of the default.
          *
          * @param value
-         *           the collection-class value to set
+         *          the collection-class value to set, or {@code null} to clear
          */
         public void setCollectionClass(@Nullable String value) {
           _collectionClass = value;
@@ -1094,8 +1153,7 @@ public class MetaschemaBindings implements IBoundObject {
           formalName = "Property Binding",
           description = "Provides binding configurations for a property within the parent definition.",
           name = "property-binding",
-          moduleClass = MetaschemaBindingsModule.class
-      )
+          moduleClass = MetaschemaBindingsModule.class)
       public static class PropertyBinding implements IBoundObject {
         private final IMetaschemaData __metaschemaData;
 
@@ -1107,8 +1165,7 @@ public class MetaschemaBindings implements IBoundObject {
             description = "The name of the property within the parent definition.",
             name = "name",
             required = true,
-            typeAdapter = TokenAdapter.class
-        )
+            typeAdapter = TokenAdapter.class)
         private String _name;
 
         /**
@@ -1117,22 +1174,25 @@ public class MetaschemaBindings implements IBoundObject {
         @BoundAssembly(
             formalName = "Java Property Binding",
             description = "Java-specific binding configuration for a property.",
-            useName = "java"
-        )
+            useName = "java")
         private Java _java;
 
         /**
-         * Constructs a new {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.PropertyBinding} instance with no metadata.
+         * Constructs a new
+         * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.PropertyBinding}
+         * instance with no metadata.
          */
         public PropertyBinding() {
           this(null);
         }
 
         /**
-         * Constructs a new {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.PropertyBinding} instance with the specified metadata.
+         * Constructs a new
+         * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.PropertyBinding}
+         * instance with the specified metadata.
          *
          * @param data
-         *           the metaschema data, or {@code null} if none
+         *          the metaschema data, or {@code null} if none
          */
         public PropertyBinding(IMetaschemaData data) {
           this.__metaschemaData = data;
@@ -1163,7 +1223,7 @@ public class MetaschemaBindings implements IBoundObject {
          * The name of the property within the parent definition.
          *
          * @param value
-         *           the name value to set
+         *          the name value to set
          */
         public void setName(@NonNull String value) {
           _name = value;
@@ -1189,7 +1249,7 @@ public class MetaschemaBindings implements IBoundObject {
          * Java-specific binding configuration for a property.
          *
          * @param value
-         *           the java value to set
+         *          the java value to set, or {@code null} to clear
          */
         public void setJava(@Nullable Java value) {
           _java = value;
@@ -1207,8 +1267,7 @@ public class MetaschemaBindings implements IBoundObject {
             formalName = "Java Property Binding",
             description = "Java-specific binding configuration for a property.",
             name = "java",
-            moduleClass = MetaschemaBindingsModule.class
-        )
+            moduleClass = MetaschemaBindingsModule.class)
         public static class Java implements IBoundObject {
           private final IMetaschemaData __metaschemaData;
 
@@ -1219,22 +1278,25 @@ public class MetaschemaBindings implements IBoundObject {
               formalName = "Collection Class",
               description = "A fully qualified Java collection class name to use instead of the default.",
               useName = "collection-class",
-              typeAdapter = TokenAdapter.class
-          )
+              typeAdapter = TokenAdapter.class)
           private String _collectionClass;
 
           /**
-           * Constructs a new {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.PropertyBinding.Java} instance with no metadata.
+           * Constructs a new
+           * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.PropertyBinding.Java}
+           * instance with no metadata.
            */
           public Java() {
             this(null);
           }
 
           /**
-           * Constructs a new {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.PropertyBinding.Java} instance with the specified metadata.
+           * Constructs a new
+           * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.PropertyBinding.Java}
+           * instance with the specified metadata.
            *
            * @param data
-           *           the metaschema data, or {@code null} if none
+           *          the metaschema data, or {@code null} if none
            */
           public Java(IMetaschemaData data) {
             this.__metaschemaData = data;
@@ -1265,7 +1327,7 @@ public class MetaschemaBindings implements IBoundObject {
            * A fully qualified Java collection class name to use instead of the default.
            *
            * @param value
-           *           the collection-class value to set
+           *          the collection-class value to set, or {@code null} to clear
            */
           public void setCollectionClass(@Nullable String value) {
             _collectionClass = value;
@@ -1285,8 +1347,7 @@ public class MetaschemaBindings implements IBoundObject {
           formalName = "Choice Group Binding",
           description = "Provides binding configuration for a choice group within the parent assembly.",
           name = "choice-group-binding",
-          moduleClass = MetaschemaBindingsModule.class
-      )
+          moduleClass = MetaschemaBindingsModule.class)
       public static class ChoiceGroupBinding implements IBoundObject {
         private final IMetaschemaData __metaschemaData;
 
@@ -1298,32 +1359,35 @@ public class MetaschemaBindings implements IBoundObject {
             description = "The name of the choice group (matches the group-as name in the metaschema).",
             name = "name",
             required = true,
-            typeAdapter = TokenAdapter.class
-        )
+            typeAdapter = TokenAdapter.class)
         private String _name;
 
         /**
-         * A fully qualified Java type for collection items. When specified, the generated field and getter will use this type instead of Object.
+         * A fully qualified Java type for collection items. When specified, the
+         * generated field and getter will use this type instead of Object.
          */
         @BoundField(
             formalName = "Item Type",
             description = "A fully qualified Java type for collection items. When specified, the generated field and getter will use this type instead of Object.",
-            useName = "item-type"
-        )
+            useName = "item-type")
         private ItemType _itemType;
 
         /**
-         * Constructs a new {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.ChoiceGroupBinding} instance with no metadata.
+         * Constructs a new
+         * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.ChoiceGroupBinding}
+         * instance with no metadata.
          */
         public ChoiceGroupBinding() {
           this(null);
         }
 
         /**
-         * Constructs a new {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.ChoiceGroupBinding} instance with the specified metadata.
+         * Constructs a new
+         * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.ChoiceGroupBinding}
+         * instance with the specified metadata.
          *
          * @param data
-         *           the metaschema data, or {@code null} if none
+         *          the metaschema data, or {@code null} if none
          */
         public ChoiceGroupBinding(IMetaschemaData data) {
           this.__metaschemaData = data;
@@ -1354,7 +1418,7 @@ public class MetaschemaBindings implements IBoundObject {
          * The name of the choice group (matches the group-as name in the metaschema).
          *
          * @param value
-         *           the name value to set
+         *          the name value to set
          */
         public void setName(@NonNull String value) {
           _name = value;
@@ -1364,7 +1428,8 @@ public class MetaschemaBindings implements IBoundObject {
          * Get the item Type.
          *
          * <p>
-         * A fully qualified Java type for collection items. When specified, the generated field and getter will use this type instead of Object.
+         * A fully qualified Java type for collection items. When specified, the
+         * generated field and getter will use this type instead of Object.
          *
          * @return the item-type value, or {@code null} if not set
          */
@@ -1377,10 +1442,11 @@ public class MetaschemaBindings implements IBoundObject {
          * Set the item Type.
          *
          * <p>
-         * A fully qualified Java type for collection items. When specified, the generated field and getter will use this type instead of Object.
+         * A fully qualified Java type for collection items. When specified, the
+         * generated field and getter will use this type instead of Object.
          *
          * @param value
-         *           the item-type value to set
+         *          the item-type value to set, or {@code null} to clear
          */
         public void setItemType(@Nullable ItemType value) {
           _itemType = value;
@@ -1392,47 +1458,50 @@ public class MetaschemaBindings implements IBoundObject {
         }
 
         /**
-         * A fully qualified Java type for collection items. When specified, the generated field and getter will use this type instead of Object.
+         * A fully qualified Java type for collection items. When specified, the
+         * generated field and getter will use this type instead of Object.
          */
         @MetaschemaField(
             formalName = "Item Type",
             description = "A fully qualified Java type for collection items. When specified, the generated field and getter will use this type instead of Object.",
             name = "item-type",
-            moduleClass = MetaschemaBindingsModule.class
-        )
+            moduleClass = MetaschemaBindingsModule.class)
         public static class ItemType implements IBoundObject {
           private final IMetaschemaData __metaschemaData;
 
           /**
-           * Whether to use a wildcard bounded type (List&lt;? extends Type&gt;). Defaults to true.
+           * Whether to use a wildcard bounded type (List&lt;? extends Type&gt;). Defaults
+           * to true.
            */
           @BoundFlag(
               formalName = "Use Wildcard",
               description = "Whether to use a wildcard bounded type (List<? extends Type>). Defaults to true.",
               name = "use-wildcard",
               defaultValue = "true",
-              typeAdapter = BooleanAdapter.class
-          )
+              typeAdapter = BooleanAdapter.class)
           private Boolean _useWildcard;
 
           @BoundFieldValue(
               valueKeyName = "STRVALUE",
-              typeAdapter = TokenAdapter.class
-          )
+              typeAdapter = TokenAdapter.class)
           private String _value;
 
           /**
-           * Constructs a new {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.ChoiceGroupBinding.ItemType} instance with no metadata.
+           * Constructs a new
+           * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.ChoiceGroupBinding.ItemType}
+           * instance with no metadata.
            */
           public ItemType() {
             this(null);
           }
 
           /**
-           * Constructs a new {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.ChoiceGroupBinding.ItemType} instance with the specified metadata.
+           * Constructs a new
+           * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineAssemblyBinding.ChoiceGroupBinding.ItemType}
+           * instance with the specified metadata.
            *
            * @param data
-           *           the metaschema data, or {@code null} if none
+           *          the metaschema data, or {@code null} if none
            */
           public ItemType(IMetaschemaData data) {
             this.__metaschemaData = data;
@@ -1447,7 +1516,8 @@ public class MetaschemaBindings implements IBoundObject {
            * Get the use Wildcard.
            *
            * <p>
-           * Whether to use a wildcard bounded type (List&lt;? extends Type&gt;). Defaults to true.
+           * Whether to use a wildcard bounded type (List&lt;? extends Type&gt;). Defaults
+           * to true.
            *
            * @return the use-wildcard value, or {@code null} if not set
            */
@@ -1460,10 +1530,11 @@ public class MetaschemaBindings implements IBoundObject {
            * Set the use Wildcard.
            *
            * <p>
-           * Whether to use a wildcard bounded type (List&lt;? extends Type&gt;). Defaults to true.
+           * Whether to use a wildcard bounded type (List&lt;? extends Type&gt;). Defaults
+           * to true.
            *
            * @param value
-           *           the use-wildcard value to set
+           *          the use-wildcard value to set, or {@code null} to clear
            */
           public void setUseWildcard(@Nullable Boolean value) {
             _useWildcard = value;
@@ -1487,14 +1558,14 @@ public class MetaschemaBindings implements IBoundObject {
     }
 
     /**
-     * Provides binding configurations for a given defined field within the parent metaschema.
+     * Provides binding configurations for a given defined field within the parent
+     * metaschema.
      */
     @MetaschemaAssembly(
         formalName = "Define Field Binding",
         description = "Provides binding configurations for a given defined field within the parent metaschema.",
         name = "define-field-binding",
-        moduleClass = MetaschemaBindingsModule.class
-    )
+        moduleClass = MetaschemaBindingsModule.class)
     public static class DefineFieldBinding implements IBoundObject {
       private final IMetaschemaData __metaschemaData;
 
@@ -1505,19 +1576,18 @@ public class MetaschemaBindings implements IBoundObject {
           formalName = "Name",
           description = "The name of the metaschema field. Used for top-level definitions.",
           name = "name",
-          typeAdapter = TokenAdapter.class
-      )
+          typeAdapter = TokenAdapter.class)
       private String _name;
 
       /**
-       * A Metapath expression targeting the field definition(s) within the metaschema. Used for inline definitions.
+       * A Metapath expression targeting the field definition(s) within the
+       * metaschema. Used for inline definitions.
        */
       @BoundFlag(
           formalName = "Target",
           description = "A Metapath expression targeting the field definition(s) within the metaschema. Used for inline definitions.",
           name = "target",
-          typeAdapter = StringAdapter.class
-      )
+          typeAdapter = StringAdapter.class)
       private String _target;
 
       /**
@@ -1526,8 +1596,7 @@ public class MetaschemaBindings implements IBoundObject {
       @BoundAssembly(
           formalName = "Java Object Definition Binding",
           description = "Field and assembly binding configurations for Java bound classes.",
-          useName = "java"
-      )
+          useName = "java")
       private Java _java;
 
       /**
@@ -1538,22 +1607,25 @@ public class MetaschemaBindings implements IBoundObject {
           description = "Provides binding configurations for a property within the parent definition.",
           useName = "property-binding",
           maxOccurs = -1,
-          groupAs = @GroupAs(name = "property-bindings", inJson = JsonGroupAsBehavior.LIST)
-      )
+          groupAs = @GroupAs(name = "property-bindings", inJson = JsonGroupAsBehavior.LIST))
       private List<PropertyBinding> _propertyBindings;
 
       /**
-       * Constructs a new {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineFieldBinding} instance with no metadata.
+       * Constructs a new
+       * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineFieldBinding}
+       * instance with no metadata.
        */
       public DefineFieldBinding() {
         this(null);
       }
 
       /**
-       * Constructs a new {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineFieldBinding} instance with the specified metadata.
+       * Constructs a new
+       * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineFieldBinding}
+       * instance with the specified metadata.
        *
        * @param data
-       *           the metaschema data, or {@code null} if none
+       *          the metaschema data, or {@code null} if none
        */
       public DefineFieldBinding(IMetaschemaData data) {
         this.__metaschemaData = data;
@@ -1584,7 +1656,7 @@ public class MetaschemaBindings implements IBoundObject {
        * The name of the metaschema field. Used for top-level definitions.
        *
        * @param value
-       *           the name value to set
+       *          the name value to set, or {@code null} to clear
        */
       public void setName(@Nullable String value) {
         _name = value;
@@ -1594,7 +1666,8 @@ public class MetaschemaBindings implements IBoundObject {
        * Get the target.
        *
        * <p>
-       * A Metapath expression targeting the field definition(s) within the metaschema. Used for inline definitions.
+       * A Metapath expression targeting the field definition(s) within the
+       * metaschema. Used for inline definitions.
        *
        * @return the target value, or {@code null} if not set
        */
@@ -1607,10 +1680,11 @@ public class MetaschemaBindings implements IBoundObject {
        * Set the target.
        *
        * <p>
-       * A Metapath expression targeting the field definition(s) within the metaschema. Used for inline definitions.
+       * A Metapath expression targeting the field definition(s) within the
+       * metaschema. Used for inline definitions.
        *
        * @param value
-       *           the target value to set
+       *          the target value to set, or {@code null} to clear
        */
       public void setTarget(@Nullable String value) {
         _target = value;
@@ -1636,7 +1710,7 @@ public class MetaschemaBindings implements IBoundObject {
        * Field and assembly binding configurations for Java bound classes.
        *
        * @param value
-       *           the java value to set
+       *          the java value to set, or {@code null} to clear
        */
       public void setJava(@Nullable Java value) {
         _java = value;
@@ -1665,7 +1739,7 @@ public class MetaschemaBindings implements IBoundObject {
        * Provides binding configurations for a property within the parent definition.
        *
        * @param value
-       *           the property-binding value to set
+       *          the property-binding value to set
        */
       public void setPropertyBindings(@NonNull List<PropertyBinding> value) {
         _propertyBindings = value;
@@ -1673,11 +1747,13 @@ public class MetaschemaBindings implements IBoundObject {
 
       /**
        * Add a new {@link PropertyBinding} item to the underlying collection.
-       * @param item the item to add
+       *
+       * @param item
+       *          the item to add
        * @return {@code true}
        */
       public boolean addPropertyBinding(PropertyBinding item) {
-        PropertyBinding value = ObjectUtils.requireNonNull(item,"item cannot be null");
+        PropertyBinding value = ObjectUtils.requireNonNull(item, "item cannot be null");
         if (_propertyBindings == null) {
           _propertyBindings = new LinkedList<>();
         }
@@ -1685,12 +1761,15 @@ public class MetaschemaBindings implements IBoundObject {
       }
 
       /**
-       * Remove the first matching {@link PropertyBinding} item from the underlying collection.
-       * @param item the item to remove
+       * Remove the first matching {@link PropertyBinding} item from the underlying
+       * collection.
+       *
+       * @param item
+       *          the item to remove
        * @return {@code true} if the item was removed or {@code false} otherwise
        */
       public boolean removePropertyBinding(PropertyBinding item) {
-        PropertyBinding value = ObjectUtils.requireNonNull(item,"item cannot be null");
+        PropertyBinding value = ObjectUtils.requireNonNull(item, "item cannot be null");
         return _propertyBindings != null && _propertyBindings.remove(value);
       }
 
@@ -1706,8 +1785,7 @@ public class MetaschemaBindings implements IBoundObject {
           formalName = "Java Object Definition Binding",
           description = "Field and assembly binding configurations for Java bound classes.",
           name = "java",
-          moduleClass = MetaschemaBindingsModule.class
-      )
+          moduleClass = MetaschemaBindingsModule.class)
       public static class Java implements IBoundObject {
         private final IMetaschemaData __metaschemaData;
 
@@ -1718,12 +1796,12 @@ public class MetaschemaBindings implements IBoundObject {
             formalName = "Use Class Name",
             description = "The Java class name to use for the generated class.",
             useName = "use-class-name",
-            typeAdapter = TokenAdapter.class
-        )
+            typeAdapter = TokenAdapter.class)
         private String _useClassName;
 
         /**
-         * A fully qualified Java interface name that the generated class should implement.
+         * A fully qualified Java interface name that the generated class should
+         * implement.
          */
         @BoundField(
             formalName = "Implement Interface",
@@ -1731,8 +1809,7 @@ public class MetaschemaBindings implements IBoundObject {
             useName = "implement-interface",
             maxOccurs = -1,
             groupAs = @GroupAs(name = "implement-interfaces", inJson = JsonGroupAsBehavior.LIST),
-            typeAdapter = TokenAdapter.class
-        )
+            typeAdapter = TokenAdapter.class)
         private List<String> _implementInterfaces;
 
         /**
@@ -1742,8 +1819,7 @@ public class MetaschemaBindings implements IBoundObject {
             formalName = "Extend Base Class",
             description = "A fully qualified Java class name that the generated class should extend.",
             useName = "extend-base-class",
-            typeAdapter = TokenAdapter.class
-        )
+            typeAdapter = TokenAdapter.class)
         private String _extendBaseClass;
 
         /**
@@ -1753,22 +1829,25 @@ public class MetaschemaBindings implements IBoundObject {
             formalName = "Collection Class",
             description = "A fully qualified Java collection class name to use instead of the default.",
             useName = "collection-class",
-            typeAdapter = TokenAdapter.class
-        )
+            typeAdapter = TokenAdapter.class)
         private String _collectionClass;
 
         /**
-         * Constructs a new {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineFieldBinding.Java} instance with no metadata.
+         * Constructs a new
+         * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineFieldBinding.Java}
+         * instance with no metadata.
          */
         public Java() {
           this(null);
         }
 
         /**
-         * Constructs a new {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineFieldBinding.Java} instance with the specified metadata.
+         * Constructs a new
+         * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineFieldBinding.Java}
+         * instance with the specified metadata.
          *
          * @param data
-         *           the metaschema data, or {@code null} if none
+         *          the metaschema data, or {@code null} if none
          */
         public Java(IMetaschemaData data) {
           this.__metaschemaData = data;
@@ -1799,7 +1878,7 @@ public class MetaschemaBindings implements IBoundObject {
          * The Java class name to use for the generated class.
          *
          * @param value
-         *           the use-class-name value to set
+         *          the use-class-name value to set, or {@code null} to clear
          */
         public void setUseClassName(@Nullable String value) {
           _useClassName = value;
@@ -1809,7 +1888,8 @@ public class MetaschemaBindings implements IBoundObject {
          * Get the implement Interface.
          *
          * <p>
-         * A fully qualified Java interface name that the generated class should implement.
+         * A fully qualified Java interface name that the generated class should
+         * implement.
          *
          * @return the implement-interface value
          */
@@ -1825,10 +1905,11 @@ public class MetaschemaBindings implements IBoundObject {
          * Set the implement Interface.
          *
          * <p>
-         * A fully qualified Java interface name that the generated class should implement.
+         * A fully qualified Java interface name that the generated class should
+         * implement.
          *
          * @param value
-         *           the implement-interface value to set
+         *          the implement-interface value to set
          */
         public void setImplementInterfaces(@NonNull List<String> value) {
           _implementInterfaces = value;
@@ -1836,11 +1917,13 @@ public class MetaschemaBindings implements IBoundObject {
 
         /**
          * Add a new {@link String} item to the underlying collection.
-         * @param item the item to add
+         *
+         * @param item
+         *          the item to add
          * @return {@code true}
          */
         public boolean addImplementInterface(String item) {
-          String value = ObjectUtils.requireNonNull(item,"item cannot be null");
+          String value = ObjectUtils.requireNonNull(item, "item cannot be null");
           if (_implementInterfaces == null) {
             _implementInterfaces = new LinkedList<>();
           }
@@ -1849,11 +1932,13 @@ public class MetaschemaBindings implements IBoundObject {
 
         /**
          * Remove the first matching {@link String} item from the underlying collection.
-         * @param item the item to remove
+         *
+         * @param item
+         *          the item to remove
          * @return {@code true} if the item was removed or {@code false} otherwise
          */
         public boolean removeImplementInterface(String item) {
-          String value = ObjectUtils.requireNonNull(item,"item cannot be null");
+          String value = ObjectUtils.requireNonNull(item, "item cannot be null");
           return _implementInterfaces != null && _implementInterfaces.remove(value);
         }
 
@@ -1877,7 +1962,7 @@ public class MetaschemaBindings implements IBoundObject {
          * A fully qualified Java class name that the generated class should extend.
          *
          * @param value
-         *           the extend-base-class value to set
+         *          the extend-base-class value to set, or {@code null} to clear
          */
         public void setExtendBaseClass(@Nullable String value) {
           _extendBaseClass = value;
@@ -1903,7 +1988,7 @@ public class MetaschemaBindings implements IBoundObject {
          * A fully qualified Java collection class name to use instead of the default.
          *
          * @param value
-         *           the collection-class value to set
+         *          the collection-class value to set, or {@code null} to clear
          */
         public void setCollectionClass(@Nullable String value) {
           _collectionClass = value;
@@ -1922,8 +2007,7 @@ public class MetaschemaBindings implements IBoundObject {
           formalName = "Property Binding",
           description = "Provides binding configurations for a property within the parent definition.",
           name = "property-binding",
-          moduleClass = MetaschemaBindingsModule.class
-      )
+          moduleClass = MetaschemaBindingsModule.class)
       public static class PropertyBinding implements IBoundObject {
         private final IMetaschemaData __metaschemaData;
 
@@ -1935,8 +2019,7 @@ public class MetaschemaBindings implements IBoundObject {
             description = "The name of the property within the parent definition.",
             name = "name",
             required = true,
-            typeAdapter = TokenAdapter.class
-        )
+            typeAdapter = TokenAdapter.class)
         private String _name;
 
         /**
@@ -1945,22 +2028,25 @@ public class MetaschemaBindings implements IBoundObject {
         @BoundAssembly(
             formalName = "Java Property Binding",
             description = "Java-specific binding configuration for a property.",
-            useName = "java"
-        )
+            useName = "java")
         private Java _java;
 
         /**
-         * Constructs a new {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineFieldBinding.PropertyBinding} instance with no metadata.
+         * Constructs a new
+         * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineFieldBinding.PropertyBinding}
+         * instance with no metadata.
          */
         public PropertyBinding() {
           this(null);
         }
 
         /**
-         * Constructs a new {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineFieldBinding.PropertyBinding} instance with the specified metadata.
+         * Constructs a new
+         * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineFieldBinding.PropertyBinding}
+         * instance with the specified metadata.
          *
          * @param data
-         *           the metaschema data, or {@code null} if none
+         *          the metaschema data, or {@code null} if none
          */
         public PropertyBinding(IMetaschemaData data) {
           this.__metaschemaData = data;
@@ -1991,7 +2077,7 @@ public class MetaschemaBindings implements IBoundObject {
          * The name of the property within the parent definition.
          *
          * @param value
-         *           the name value to set
+         *          the name value to set
          */
         public void setName(@NonNull String value) {
           _name = value;
@@ -2017,7 +2103,7 @@ public class MetaschemaBindings implements IBoundObject {
          * Java-specific binding configuration for a property.
          *
          * @param value
-         *           the java value to set
+         *          the java value to set, or {@code null} to clear
          */
         public void setJava(@Nullable Java value) {
           _java = value;
@@ -2035,8 +2121,7 @@ public class MetaschemaBindings implements IBoundObject {
             formalName = "Java Property Binding",
             description = "Java-specific binding configuration for a property.",
             name = "java",
-            moduleClass = MetaschemaBindingsModule.class
-        )
+            moduleClass = MetaschemaBindingsModule.class)
         public static class Java implements IBoundObject {
           private final IMetaschemaData __metaschemaData;
 
@@ -2047,22 +2132,25 @@ public class MetaschemaBindings implements IBoundObject {
               formalName = "Collection Class",
               description = "A fully qualified Java collection class name to use instead of the default.",
               useName = "collection-class",
-              typeAdapter = TokenAdapter.class
-          )
+              typeAdapter = TokenAdapter.class)
           private String _collectionClass;
 
           /**
-           * Constructs a new {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineFieldBinding.PropertyBinding.Java} instance with no metadata.
+           * Constructs a new
+           * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineFieldBinding.PropertyBinding.Java}
+           * instance with no metadata.
            */
           public Java() {
             this(null);
           }
 
           /**
-           * Constructs a new {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineFieldBinding.PropertyBinding.Java} instance with the specified metadata.
+           * Constructs a new
+           * {@code gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindings.MetaschemaBinding.DefineFieldBinding.PropertyBinding.Java}
+           * instance with the specified metadata.
            *
            * @param data
-           *           the metaschema data, or {@code null} if none
+           *          the metaschema data, or {@code null} if none
            */
           public Java(IMetaschemaData data) {
             this.__metaschemaData = data;
@@ -2093,7 +2181,7 @@ public class MetaschemaBindings implements IBoundObject {
            * A fully qualified Java collection class name to use instead of the default.
            *
            * @param value
-           *           the collection-class value to set
+           *          the collection-class value to set, or {@code null} to clear
            */
           public void setCollectionClass(@Nullable String value) {
             _collectionClass = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/config/binding/MetaschemaBindingsModule.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/config/binding/MetaschemaBindingsModule.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../metaschema/metaschema-bindings.yaml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.config.binding;
 
 import gov.nist.secauto.metaschema.core.datatype.markup.MarkupLine;
@@ -17,19 +18,21 @@ import java.util.List;
 
 /**
  * Metaschema Binding Configuration
- * <p>This module defines the binding configuration format used to customize
- * Java code generation from Metaschema modules. It allows specifying
- * package names, class names, interface implementations, base classes,
- * and collection types for generated binding classes.</p>
+ * <p>
+ * This module defines the binding configuration format used to customize Java
+ * code generation from Metaschema modules. It allows specifying package names,
+ * class names, interface implementations, base classes, and collection types
+ * for generated binding classes.
+ * </p>
  */
 @MetaschemaModule(
     assemblies = MetaschemaBindings.class,
     remarks = "This module defines the binding configuration format used to customize\n"
-            + "Java code generation from Metaschema modules. It allows specifying\n"
-            + "package names, class names, interface implementations, base classes,\n"
-            + "and collection types for generated binding classes."
-)
-public final class MetaschemaBindingsModule extends AbstractBoundModule {
+        + "Java code generation from Metaschema modules. It allows specifying\n"
+        + "package names, class names, interface implementations, base classes,\n"
+        + "and collection types for generated binding classes.")
+public final class MetaschemaBindingsModule
+    extends AbstractBoundModule {
   private static final MarkupLine NAME = MarkupLine.fromMarkdown("Metaschema Binding Configuration");
 
   private static final String SHORT_NAME = "metaschema-bindings";
@@ -40,18 +43,19 @@ public final class MetaschemaBindingsModule extends AbstractBoundModule {
 
   private static final URI JSON_BASE_URI = URI.create("https://csrc.nist.gov/ns/metaschema-binding/1.0");
 
-  private static final MarkupMultiline REMARKS = MarkupMultiline.fromMarkdown("This module defines the binding configuration format used to customize\n"
-      + "Java code generation from Metaschema modules. It allows specifying\n"
-      + "package names, class names, interface implementations, base classes,\n"
-      + "and collection types for generated binding classes.");
+  private static final MarkupMultiline REMARKS
+      = MarkupMultiline.fromMarkdown("This module defines the binding configuration format used to customize\n"
+          + "Java code generation from Metaschema modules. It allows specifying\n"
+          + "package names, class names, interface implementations, base classes,\n"
+          + "and collection types for generated binding classes.");
 
   /**
    * Construct a new module instance.
    *
    * @param importedModules
-   *           modules imported by this module
+   *          modules imported by this module
    * @param bindingContext
-   *           the binding context to associate with this module
+   *          the binding context to associate with this module
    */
   public MetaschemaBindingsModule(List<? extends IBoundModule> importedModules,
       IBindingContext bindingContext) {

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/config/binding/package-info.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/config/binding/package-info.java
@@ -5,16 +5,24 @@
 // Generated from: ../../../../../../../../metaschema/metaschema-bindings.yaml
 // Do not edit - changes will be lost when regenerated.
 /**
- * Provides generated Metaschema binding classes for module(s): Metaschema Binding Configuration.
+ * Provides generated Metaschema binding classes for module(s): Metaschema
+ * Binding Configuration.
  * <p>
  * version 1.0.0
  * <p>
- * <p>This module defines the binding configuration format used to customize
-Java code generation from Metaschema modules. It allows specifying
-package names, class names, interface implementations, base classes,
-and collection types for generated binding classes.</p>
+ * <p>
+ * This module defines the binding configuration format used to customize Java
+ * code generation from Metaschema modules. It allows specifying package names,
+ * class names, interface implementations, base classes, and collection types
+ * for generated binding classes.
+ * </p>
  */
+
 @gov.nist.secauto.metaschema.databind.model.annotations.MetaschemaPackage(moduleClass = {
-  gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindingsModule.class})
-@gov.nist.secauto.metaschema.databind.model.annotations.XmlSchema(namespace = "https://csrc.nist.gov/ns/metaschema-binding/1.0", xmlns = {@gov.nist.secauto.metaschema.databind.model.annotations.XmlNs(prefix = "", namespace = "https://csrc.nist.gov/ns/metaschema-binding/1.0")}, xmlElementFormDefault = gov.nist.secauto.metaschema.databind.model.annotations.XmlNsForm.QUALIFIED)
+    gov.nist.secauto.metaschema.databind.config.binding.MetaschemaBindingsModule.class })
+@gov.nist.secauto.metaschema.databind.model.annotations.XmlSchema(
+    namespace = "https://csrc.nist.gov/ns/metaschema-binding/1.0",
+    xmlns = { @gov.nist.secauto.metaschema.databind.model.annotations.XmlNs(prefix = "",
+        namespace = "https://csrc.nist.gov/ns/metaschema-binding/1.0") },
+    xmlElementFormDefault = gov.nist.secauto.metaschema.databind.model.annotations.XmlNsForm.QUALIFIED)
 package gov.nist.secauto.metaschema.databind.config.binding;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/Any.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/Any.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import gov.nist.secauto.metaschema.core.model.IBoundObject;
@@ -16,23 +17,26 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @MetaschemaAssembly(
     formalName = "Any Additional Content",
     name = "any",
-    moduleClass = MetaschemaModelModule.class
-)
+    moduleClass = MetaschemaModelModule.class)
 public class Any implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.Any} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.Any}
+   * instance with no metadata.
    */
   public Any() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.Any} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.Any}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public Any(IMetaschemaData data) {
     this.__metaschemaData = data;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/AssemblyConstraints.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/AssemblyConstraints.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -24,8 +25,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 
 @MetaschemaAssembly(
     name = "assembly-constraints",
-    moduleClass = MetaschemaModelModule.class
-)
+    moduleClass = MetaschemaModelModule.class)
 public class AssemblyConstraints implements IModelConstraintsBase {
   private final IMetaschemaData __metaschemaData;
 
@@ -33,8 +33,7 @@ public class AssemblyConstraints implements IModelConstraintsBase {
       formalName = "Constraint Let Expression",
       useName = "let",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "lets", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "lets", inJson = JsonGroupAsBehavior.LIST))
   private List<ConstraintLetExpression> _lets;
 
   @BoundChoiceGroup(
@@ -42,30 +41,41 @@ public class AssemblyConstraints implements IModelConstraintsBase {
       maxOccurs = -1,
       groupAs = @GroupAs(name = "rules", inJson = JsonGroupAsBehavior.LIST),
       assemblies = {
-          @BoundGroupedAssembly(formalName = "Allowed Values Constraint", useName = "allowed-values", binding = TargetedAllowedValuesConstraint.class),
-          @BoundGroupedAssembly(formalName = "Expect Condition Constraint", useName = "expect", binding = TargetedExpectConstraint.class),
-          @BoundGroupedAssembly(formalName = "Targeted Index Has Key Constraint", useName = "index-has-key", binding = TargetedIndexHasKeyConstraint.class),
-          @BoundGroupedAssembly(formalName = "Value Matches Constraint", useName = "matches", binding = TargetedMatchesConstraint.class),
-          @BoundGroupedAssembly(formalName = "Targeted Unique Constraint", useName = "is-unique", binding = TargetedIsUniqueConstraint.class),
-          @BoundGroupedAssembly(formalName = "Targeted Index Constraint", useName = "index", binding = TargetedIndexConstraint.class),
-          @BoundGroupedAssembly(formalName = "Targeted Cardinality Constraint", useName = "has-cardinality", binding = TargetedHasCardinalityConstraint.class),
-          @BoundGroupedAssembly(formalName = "Report Condition Constraint", useName = "report", binding = TargetedReportConstraint.class)
-      }
-  )
+          @BoundGroupedAssembly(formalName = "Allowed Values Constraint", useName = "allowed-values",
+              binding = TargetedAllowedValuesConstraint.class),
+          @BoundGroupedAssembly(formalName = "Expect Condition Constraint", useName = "expect",
+              binding = TargetedExpectConstraint.class),
+          @BoundGroupedAssembly(formalName = "Targeted Index Has Key Constraint", useName = "index-has-key",
+              binding = TargetedIndexHasKeyConstraint.class),
+          @BoundGroupedAssembly(formalName = "Value Matches Constraint", useName = "matches",
+              binding = TargetedMatchesConstraint.class),
+          @BoundGroupedAssembly(formalName = "Targeted Unique Constraint", useName = "is-unique",
+              binding = TargetedIsUniqueConstraint.class),
+          @BoundGroupedAssembly(formalName = "Targeted Index Constraint", useName = "index",
+              binding = TargetedIndexConstraint.class),
+          @BoundGroupedAssembly(formalName = "Targeted Cardinality Constraint", useName = "has-cardinality",
+              binding = TargetedHasCardinalityConstraint.class),
+          @BoundGroupedAssembly(formalName = "Report Condition Constraint", useName = "report",
+              binding = TargetedReportConstraint.class)
+      })
   private List<? extends ITargetedConstraintBase> _rules;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyConstraints} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyConstraints}
+   * instance with no metadata.
    */
   public AssemblyConstraints() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyConstraints} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyConstraints}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public AssemblyConstraints(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -94,7 +104,7 @@ public class AssemblyConstraints implements IModelConstraintsBase {
    * Set the constraint Let Expression.
    *
    * @param value
-   *           the let value to set
+   *          the let value to set
    */
   public void setLets(@NonNull List<ConstraintLetExpression> value) {
     _lets = value;
@@ -102,11 +112,13 @@ public class AssemblyConstraints implements IModelConstraintsBase {
 
   /**
    * Add a new {@link ConstraintLetExpression} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addLet(ConstraintLetExpression item) {
-    ConstraintLetExpression value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    ConstraintLetExpression value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_lets == null) {
       _lets = new LinkedList<>();
     }
@@ -114,12 +126,15 @@ public class AssemblyConstraints implements IModelConstraintsBase {
   }
 
   /**
-   * Remove the first matching {@link ConstraintLetExpression} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link ConstraintLetExpression} item from the
+   * underlying collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeLet(ConstraintLetExpression item) {
-    ConstraintLetExpression value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    ConstraintLetExpression value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _lets != null && _lets.remove(value);
   }
 
@@ -147,7 +162,7 @@ public class AssemblyConstraints implements IModelConstraintsBase {
    * Items in this collection must implement {@link ITargetedConstraintBase}.
    *
    * @param value
-   *           the rules items to set
+   *          the rules items to set
    */
   public void setRules(@NonNull List<? extends ITargetedConstraintBase> value) {
     _rules = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/AssemblyModel.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/AssemblyModel.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -39,8 +40,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 
 @MetaschemaAssembly(
     name = "assembly-model",
-    moduleClass = MetaschemaModelModule.class
-)
+    moduleClass = MetaschemaModelModule.class)
 public class AssemblyModel implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
@@ -48,34 +48,40 @@ public class AssemblyModel implements IBoundObject {
       maxOccurs = -1,
       groupAs = @GroupAs(name = "instances", inJson = JsonGroupAsBehavior.LIST),
       assemblies = {
-          @BoundGroupedAssembly(formalName = "Assembly Reference", useName = "assembly", discriminatorValue = "assembly-ref", binding = AssemblyReference.class),
-          @BoundGroupedAssembly(formalName = "Inline Assembly Definition", useName = "define-assembly", discriminatorValue = "assembly", binding = InlineDefineAssembly.class),
-          @BoundGroupedAssembly(formalName = "Field Reference", useName = "field", discriminatorValue = "field-ref", binding = FieldReference.class),
-          @BoundGroupedAssembly(formalName = "Inline Field Definition", useName = "define-field", discriminatorValue = "field", binding = InlineDefineField.class),
+          @BoundGroupedAssembly(formalName = "Assembly Reference", useName = "assembly",
+              discriminatorValue = "assembly-ref", binding = AssemblyReference.class),
+          @BoundGroupedAssembly(formalName = "Inline Assembly Definition", useName = "define-assembly",
+              discriminatorValue = "assembly", binding = InlineDefineAssembly.class),
+          @BoundGroupedAssembly(formalName = "Field Reference", useName = "field", discriminatorValue = "field-ref",
+              binding = FieldReference.class),
+          @BoundGroupedAssembly(formalName = "Inline Field Definition", useName = "define-field",
+              discriminatorValue = "field", binding = InlineDefineField.class),
           @BoundGroupedAssembly(formalName = "Choice", useName = "choice", binding = Choice.class),
           @BoundGroupedAssembly(formalName = "Choice Grouping", useName = "choice-group", binding = ChoiceGroup.class)
-      }
-  )
+      })
   private List<Object> _instances;
 
   @BoundAssembly(
       formalName = "Any Additional Content",
-      useName = "any"
-  )
+      useName = "any")
   private Any _any;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyModel} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyModel}
+   * instance with no metadata.
    */
   public AssemblyModel() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyModel} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyModel}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public AssemblyModel(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -103,7 +109,7 @@ public class AssemblyModel implements IBoundObject {
    * Set the {@code instances} choice group items.
    *
    * @param value
-   *           the instances items to set
+   *          the instances items to set
    */
   public void setInstances(@NonNull List<Object> value) {
     _instances = value;
@@ -123,7 +129,7 @@ public class AssemblyModel implements IBoundObject {
    * Set the any Additional Content.
    *
    * @param value
-   *           the any value to set
+   *          the any value to set, or {@code null} to clear
    */
   public void setAny(@Nullable Any value) {
     _any = value;
@@ -137,8 +143,7 @@ public class AssemblyModel implements IBoundObject {
   @MetaschemaAssembly(
       formalName = "Choice",
       name = "choice",
-      moduleClass = MetaschemaModelModule.class
-  )
+      moduleClass = MetaschemaModelModule.class)
   public static class Choice implements IBoundObject {
     private final IMetaschemaData __metaschemaData;
 
@@ -147,32 +152,38 @@ public class AssemblyModel implements IBoundObject {
         maxOccurs = -1,
         groupAs = @GroupAs(name = "choices", inJson = JsonGroupAsBehavior.LIST),
         assemblies = {
-            @BoundGroupedAssembly(formalName = "Assembly Reference", useName = "assembly", discriminatorValue = "assembly-ref", binding = AssemblyReference.class),
-            @BoundGroupedAssembly(formalName = "Inline Assembly Definition", useName = "define-assembly", discriminatorValue = "assembly", binding = InlineDefineAssembly.class),
-            @BoundGroupedAssembly(formalName = "Field Reference", useName = "field", discriminatorValue = "field-ref", binding = FieldReference.class),
-            @BoundGroupedAssembly(formalName = "Inline Field Definition", useName = "define-field", discriminatorValue = "field", binding = InlineDefineField.class)
-        }
-    )
+            @BoundGroupedAssembly(formalName = "Assembly Reference", useName = "assembly",
+                discriminatorValue = "assembly-ref", binding = AssemblyReference.class),
+            @BoundGroupedAssembly(formalName = "Inline Assembly Definition", useName = "define-assembly",
+                discriminatorValue = "assembly", binding = InlineDefineAssembly.class),
+            @BoundGroupedAssembly(formalName = "Field Reference", useName = "field", discriminatorValue = "field-ref",
+                binding = FieldReference.class),
+            @BoundGroupedAssembly(formalName = "Inline Field Definition", useName = "define-field",
+                discriminatorValue = "field", binding = InlineDefineField.class)
+        })
     private List<Object> _choices;
 
     @BoundAssembly(
         formalName = "Any Additional Content",
-        useName = "any"
-    )
+        useName = "any")
     private Any _any;
 
     /**
-     * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyModel.Choice} instance with no metadata.
+     * Constructs a new
+     * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyModel.Choice}
+     * instance with no metadata.
      */
     public Choice() {
       this(null);
     }
 
     /**
-     * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyModel.Choice} instance with the specified metadata.
+     * Constructs a new
+     * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyModel.Choice}
+     * instance with the specified metadata.
      *
      * @param data
-     *           the metaschema data, or {@code null} if none
+     *          the metaschema data, or {@code null} if none
      */
     public Choice(IMetaschemaData data) {
       this.__metaschemaData = data;
@@ -200,7 +211,7 @@ public class AssemblyModel implements IBoundObject {
      * Set the {@code choices} choice group items.
      *
      * @param value
-     *           the choices items to set
+     *          the choices items to set
      */
     public void setChoices(@NonNull List<Object> value) {
       _choices = value;
@@ -220,7 +231,7 @@ public class AssemblyModel implements IBoundObject {
      * Set the any Additional Content.
      *
      * @param value
-     *           the any value to set
+     *          the any value to set, or {@code null} to clear
      */
     public void setAny(@Nullable Any value) {
       _any = value;
@@ -235,8 +246,7 @@ public class AssemblyModel implements IBoundObject {
   @MetaschemaAssembly(
       formalName = "Choice Grouping",
       name = "choice-group",
-      moduleClass = MetaschemaModelModule.class
-  )
+      moduleClass = MetaschemaModelModule.class)
   public static class ChoiceGroup implements IBoundObject {
     private final IMetaschemaData __metaschemaData;
 
@@ -244,8 +254,7 @@ public class AssemblyModel implements IBoundObject {
         formalName = "Minimum Occurrence",
         name = "min-occurs",
         defaultValue = "0",
-        typeAdapter = NonNegativeIntegerAdapter.class
-    )
+        typeAdapter = NonNegativeIntegerAdapter.class)
     private BigInteger _minOccurs;
 
     @BoundFlag(
@@ -253,33 +262,32 @@ public class AssemblyModel implements IBoundObject {
         name = "max-occurs",
         defaultValue = "unbounded",
         typeAdapter = StringAdapter.class,
-        valueConstraints = @ValueConstraints(matches = @Matches(level = IConstraint.Level.ERROR, pattern = "^[1-9][0-9]*|unbounded$"))
-    )
+        valueConstraints = @ValueConstraints(
+            matches = @Matches(level = IConstraint.Level.ERROR, pattern = "^[1-9][0-9]*|unbounded$")))
     private String _maxOccurs;
 
     /**
-     * Used in JSON (and similar formats) to identify a flag that will be used as the property name in an object hold a collection of sibling objects. Requires that siblings must never share <code>json-key</code> values.
+     * Used in JSON (and similar formats) to identify a flag that will be used as
+     * the property name in an object hold a collection of sibling objects. Requires
+     * that siblings must never share <code>json-key</code> values.
      */
     @BoundAssembly(
         formalName = "JSON Key",
         description = "Used in JSON (and similar formats) to identify a flag that will be used as the property name in an object hold a collection of sibling objects. Requires that siblings must never share `json-key` values.",
-        useName = "json-key"
-    )
+        useName = "json-key")
     private JsonKey _jsonKey;
 
     @BoundAssembly(
         formalName = "Group As",
         useName = "group-as",
-        minOccurs = 1
-    )
+        minOccurs = 1)
     private GroupingAs _groupAs;
 
     @BoundField(
         formalName = "Discriminator JSON Property",
         useName = "discriminator",
         defaultValue = "object-type",
-        typeAdapter = TokenAdapter.class
-    )
+        typeAdapter = TokenAdapter.class)
     private String _discriminator;
 
     @BoundChoiceGroup(
@@ -287,36 +295,43 @@ public class AssemblyModel implements IBoundObject {
         maxOccurs = -1,
         groupAs = @GroupAs(name = "choices", inJson = JsonGroupAsBehavior.LIST),
         assemblies = {
-            @BoundGroupedAssembly(formalName = "Grouping Assembly Reference", useName = "assembly", discriminatorValue = "assembly-ref", binding = Assembly.class),
-            @BoundGroupedAssembly(formalName = "Inline Assembly Definition", useName = "define-assembly", discriminatorValue = "assembly", binding = DefineAssembly.class),
-            @BoundGroupedAssembly(formalName = "Grouping Field Reference", useName = "field", discriminatorValue = "field-ref", binding = Field.class),
-            @BoundGroupedAssembly(formalName = "Inline Field Definition", useName = "define-field", discriminatorValue = "field", binding = DefineField.class)
-        }
-    )
+            @BoundGroupedAssembly(formalName = "Grouping Assembly Reference", useName = "assembly",
+                discriminatorValue = "assembly-ref", binding = Assembly.class),
+            @BoundGroupedAssembly(formalName = "Inline Assembly Definition", useName = "define-assembly",
+                discriminatorValue = "assembly", binding = DefineAssembly.class),
+            @BoundGroupedAssembly(formalName = "Grouping Field Reference", useName = "field",
+                discriminatorValue = "field-ref", binding = Field.class),
+            @BoundGroupedAssembly(formalName = "Inline Field Definition", useName = "define-field",
+                discriminatorValue = "field", binding = DefineField.class)
+        })
     private List<Object> _choices;
 
     /**
-     * Any explanatory or helpful information to be provided about the remarks parent.
+     * Any explanatory or helpful information to be provided about the remarks
+     * parent.
      */
     @BoundField(
         formalName = "Remarks",
         description = "Any explanatory or helpful information to be provided about the remarks parent.",
-        useName = "remarks"
-    )
+        useName = "remarks")
     private Remarks _remarks;
 
     /**
-     * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyModel.ChoiceGroup} instance with no metadata.
+     * Constructs a new
+     * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyModel.ChoiceGroup}
+     * instance with no metadata.
      */
     public ChoiceGroup() {
       this(null);
     }
 
     /**
-     * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyModel.ChoiceGroup} instance with the specified metadata.
+     * Constructs a new
+     * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyModel.ChoiceGroup}
+     * instance with the specified metadata.
      *
      * @param data
-     *           the metaschema data, or {@code null} if none
+     *          the metaschema data, or {@code null} if none
      */
     public ChoiceGroup(IMetaschemaData data) {
       this.__metaschemaData = data;
@@ -341,7 +356,7 @@ public class AssemblyModel implements IBoundObject {
      * Set the minimum Occurrence.
      *
      * @param value
-     *           the min-occurs value to set
+     *          the min-occurs value to set, or {@code null} to clear
      */
     public void setMinOccurs(@Nullable BigInteger value) {
       _minOccurs = value;
@@ -361,7 +376,7 @@ public class AssemblyModel implements IBoundObject {
      * Set the maximum Occurrence.
      *
      * @param value
-     *           the max-occurs value to set
+     *          the max-occurs value to set, or {@code null} to clear
      */
     public void setMaxOccurs(@Nullable String value) {
       _maxOccurs = value;
@@ -371,7 +386,9 @@ public class AssemblyModel implements IBoundObject {
      * Get the jSON Key.
      *
      * <p>
-     * Used in JSON (and similar formats) to identify a flag that will be used as the property name in an object hold a collection of sibling objects. Requires that siblings must never share <code>json-key</code> values.
+     * Used in JSON (and similar formats) to identify a flag that will be used as
+     * the property name in an object hold a collection of sibling objects. Requires
+     * that siblings must never share <code>json-key</code> values.
      *
      * @return the json-key value, or {@code null} if not set
      */
@@ -384,10 +401,12 @@ public class AssemblyModel implements IBoundObject {
      * Set the jSON Key.
      *
      * <p>
-     * Used in JSON (and similar formats) to identify a flag that will be used as the property name in an object hold a collection of sibling objects. Requires that siblings must never share <code>json-key</code> values.
+     * Used in JSON (and similar formats) to identify a flag that will be used as
+     * the property name in an object hold a collection of sibling objects. Requires
+     * that siblings must never share <code>json-key</code> values.
      *
      * @param value
-     *           the json-key value to set
+     *          the json-key value to set, or {@code null} to clear
      */
     public void setJsonKey(@Nullable JsonKey value) {
       _jsonKey = value;
@@ -407,7 +426,7 @@ public class AssemblyModel implements IBoundObject {
      * Set the group As.
      *
      * @param value
-     *           the group-as value to set
+     *          the group-as value to set
      */
     public void setGroupAs(@NonNull GroupingAs value) {
       _groupAs = value;
@@ -427,7 +446,7 @@ public class AssemblyModel implements IBoundObject {
      * Set the discriminator JSON Property.
      *
      * @param value
-     *           the discriminator value to set
+     *          the discriminator value to set, or {@code null} to clear
      */
     public void setDiscriminator(@Nullable String value) {
       _discriminator = value;
@@ -450,7 +469,7 @@ public class AssemblyModel implements IBoundObject {
      * Set the {@code choices} choice group items.
      *
      * @param value
-     *           the choices items to set
+     *          the choices items to set
      */
     public void setChoices(@NonNull List<Object> value) {
       _choices = value;
@@ -460,7 +479,8 @@ public class AssemblyModel implements IBoundObject {
      * Get the remarks.
      *
      * <p>
-     * Any explanatory or helpful information to be provided about the remarks parent.
+     * Any explanatory or helpful information to be provided about the remarks
+     * parent.
      *
      * @return the remarks value, or {@code null} if not set
      */
@@ -473,10 +493,11 @@ public class AssemblyModel implements IBoundObject {
      * Set the remarks.
      *
      * <p>
-     * Any explanatory or helpful information to be provided about the remarks parent.
+     * Any explanatory or helpful information to be provided about the remarks
+     * parent.
      *
      * @param value
-     *           the remarks value to set
+     *          the remarks value to set, or {@code null} to clear
      */
     public void setRemarks(@Nullable Remarks value) {
       _remarks = value;
@@ -490,8 +511,7 @@ public class AssemblyModel implements IBoundObject {
     @MetaschemaAssembly(
         formalName = "Grouping Assembly Reference",
         name = "assembly",
-        moduleClass = MetaschemaModelModule.class
-    )
+        moduleClass = MetaschemaModelModule.class)
     public static class Assembly implements IBoundObject {
       private final IMetaschemaData __metaschemaData;
 
@@ -499,22 +519,19 @@ public class AssemblyModel implements IBoundObject {
           formalName = "Global Assembly Reference",
           name = "ref",
           required = true,
-          typeAdapter = TokenAdapter.class
-      )
+          typeAdapter = TokenAdapter.class)
       private String _ref;
 
       @BoundFlag(
           formalName = "Assembly Reference Binary Name",
           name = "index",
-          typeAdapter = PositiveIntegerAdapter.class
-      )
+          typeAdapter = PositiveIntegerAdapter.class)
       private BigInteger _index;
 
       @BoundFlag(
           formalName = "Deprecated Version",
           name = "deprecated",
-          typeAdapter = StringAdapter.class
-      )
+          typeAdapter = StringAdapter.class)
       private String _deprecated;
 
       /**
@@ -524,27 +541,25 @@ public class AssemblyModel implements IBoundObject {
           formalName = "Formal Name",
           description = "A formal name for the data construct, to be presented in documentation.",
           useName = "formal-name",
-          typeAdapter = StringAdapter.class
-      )
+          typeAdapter = StringAdapter.class)
       private String _formalName;
 
       /**
-       * A short description of the data construct's purpose, describing the constructs semantics.
+       * A short description of the data construct's purpose, describing the
+       * constructs semantics.
        */
       @BoundField(
           formalName = "Description",
           description = "A short description of the data construct's purpose, describing the constructs semantics.",
           useName = "description",
-          typeAdapter = MarkupLineAdapter.class
-      )
+          typeAdapter = MarkupLineAdapter.class)
       private MarkupLine _description;
 
       @BoundAssembly(
           formalName = "Property",
           useName = "prop",
           maxOccurs = -1,
-          groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST)
-      )
+          groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST))
       private List<Property> _props;
 
       /**
@@ -553,39 +568,41 @@ public class AssemblyModel implements IBoundObject {
       @BoundField(
           formalName = "Use Name",
           description = "Allows the name of the definition to be overridden.",
-          useName = "use-name"
-      )
+          useName = "use-name")
       private UseName _useName;
 
       @BoundField(
           formalName = "Grouping Discriminator Value",
           useName = "discriminator-value",
-          typeAdapter = TokenAdapter.class
-      )
+          typeAdapter = TokenAdapter.class)
       private String _discriminatorValue;
 
       /**
-       * Any explanatory or helpful information to be provided about the remarks parent.
+       * Any explanatory or helpful information to be provided about the remarks
+       * parent.
        */
       @BoundField(
           formalName = "Remarks",
           description = "Any explanatory or helpful information to be provided about the remarks parent.",
-          useName = "remarks"
-      )
+          useName = "remarks")
       private Remarks _remarks;
 
       /**
-       * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyModel.ChoiceGroup.Assembly} instance with no metadata.
+       * Constructs a new
+       * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyModel.ChoiceGroup.Assembly}
+       * instance with no metadata.
        */
       public Assembly() {
         this(null);
       }
 
       /**
-       * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyModel.ChoiceGroup.Assembly} instance with the specified metadata.
+       * Constructs a new
+       * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyModel.ChoiceGroup.Assembly}
+       * instance with the specified metadata.
        *
        * @param data
-       *           the metaschema data, or {@code null} if none
+       *          the metaschema data, or {@code null} if none
        */
       public Assembly(IMetaschemaData data) {
         this.__metaschemaData = data;
@@ -610,7 +627,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the global Assembly Reference.
        *
        * @param value
-       *           the ref value to set
+       *          the ref value to set
        */
       public void setRef(@NonNull String value) {
         _ref = value;
@@ -630,7 +647,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the assembly Reference Binary Name.
        *
        * @param value
-       *           the index value to set
+       *          the index value to set, or {@code null} to clear
        */
       public void setIndex(@Nullable BigInteger value) {
         _index = value;
@@ -650,7 +667,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the deprecated Version.
        *
        * @param value
-       *           the deprecated value to set
+       *          the deprecated value to set, or {@code null} to clear
        */
       public void setDeprecated(@Nullable String value) {
         _deprecated = value;
@@ -676,7 +693,7 @@ public class AssemblyModel implements IBoundObject {
        * A formal name for the data construct, to be presented in documentation.
        *
        * @param value
-       *           the formal-name value to set
+       *          the formal-name value to set, or {@code null} to clear
        */
       public void setFormalName(@Nullable String value) {
         _formalName = value;
@@ -686,7 +703,8 @@ public class AssemblyModel implements IBoundObject {
        * Get the description.
        *
        * <p>
-       * A short description of the data construct's purpose, describing the constructs semantics.
+       * A short description of the data construct's purpose, describing the
+       * constructs semantics.
        *
        * @return the description value, or {@code null} if not set
        */
@@ -699,10 +717,11 @@ public class AssemblyModel implements IBoundObject {
        * Set the description.
        *
        * <p>
-       * A short description of the data construct's purpose, describing the constructs semantics.
+       * A short description of the data construct's purpose, describing the
+       * constructs semantics.
        *
        * @param value
-       *           the description value to set
+       *          the description value to set, or {@code null} to clear
        */
       public void setDescription(@Nullable MarkupLine value) {
         _description = value;
@@ -725,7 +744,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the property.
        *
        * @param value
-       *           the prop value to set
+       *          the prop value to set
        */
       public void setProps(@NonNull List<Property> value) {
         _props = value;
@@ -733,11 +752,13 @@ public class AssemblyModel implements IBoundObject {
 
       /**
        * Add a new {@link Property} item to the underlying collection.
-       * @param item the item to add
+       *
+       * @param item
+       *          the item to add
        * @return {@code true}
        */
       public boolean addProp(Property item) {
-        Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+        Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
         if (_props == null) {
           _props = new LinkedList<>();
         }
@@ -745,12 +766,15 @@ public class AssemblyModel implements IBoundObject {
       }
 
       /**
-       * Remove the first matching {@link Property} item from the underlying collection.
-       * @param item the item to remove
+       * Remove the first matching {@link Property} item from the underlying
+       * collection.
+       *
+       * @param item
+       *          the item to remove
        * @return {@code true} if the item was removed or {@code false} otherwise
        */
       public boolean removeProp(Property item) {
-        Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+        Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
         return _props != null && _props.remove(value);
       }
 
@@ -774,7 +798,7 @@ public class AssemblyModel implements IBoundObject {
        * Allows the name of the definition to be overridden.
        *
        * @param value
-       *           the use-name value to set
+       *          the use-name value to set, or {@code null} to clear
        */
       public void setUseName(@Nullable UseName value) {
         _useName = value;
@@ -794,7 +818,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the grouping Discriminator Value.
        *
        * @param value
-       *           the discriminator-value value to set
+       *          the discriminator-value value to set, or {@code null} to clear
        */
       public void setDiscriminatorValue(@Nullable String value) {
         _discriminatorValue = value;
@@ -804,7 +828,8 @@ public class AssemblyModel implements IBoundObject {
        * Get the remarks.
        *
        * <p>
-       * Any explanatory or helpful information to be provided about the remarks parent.
+       * Any explanatory or helpful information to be provided about the remarks
+       * parent.
        *
        * @return the remarks value, or {@code null} if not set
        */
@@ -817,10 +842,11 @@ public class AssemblyModel implements IBoundObject {
        * Set the remarks.
        *
        * <p>
-       * Any explanatory or helpful information to be provided about the remarks parent.
+       * Any explanatory or helpful information to be provided about the remarks
+       * parent.
        *
        * @param value
-       *           the remarks value to set
+       *          the remarks value to set, or {@code null} to clear
        */
       public void setRemarks(@Nullable Remarks value) {
         _remarks = value;
@@ -835,8 +861,7 @@ public class AssemblyModel implements IBoundObject {
     @MetaschemaAssembly(
         formalName = "Inline Assembly Definition",
         name = "define-assembly",
-        moduleClass = MetaschemaModelModule.class
-    )
+        moduleClass = MetaschemaModelModule.class)
     public static class DefineAssembly implements IBoundObject {
       private final IMetaschemaData __metaschemaData;
 
@@ -844,22 +869,19 @@ public class AssemblyModel implements IBoundObject {
           formalName = "Inline Assembly Name",
           name = "name",
           required = true,
-          typeAdapter = TokenAdapter.class
-      )
+          typeAdapter = TokenAdapter.class)
       private String _name;
 
       @BoundFlag(
           formalName = "Inline Assembly Binary Name",
           name = "index",
-          typeAdapter = PositiveIntegerAdapter.class
-      )
+          typeAdapter = PositiveIntegerAdapter.class)
       private BigInteger _index;
 
       @BoundFlag(
           formalName = "Deprecated Version",
           name = "deprecated",
-          typeAdapter = StringAdapter.class
-      )
+          typeAdapter = StringAdapter.class)
       private String _deprecated;
 
       /**
@@ -869,86 +891,85 @@ public class AssemblyModel implements IBoundObject {
           formalName = "Formal Name",
           description = "A formal name for the data construct, to be presented in documentation.",
           useName = "formal-name",
-          typeAdapter = StringAdapter.class
-      )
+          typeAdapter = StringAdapter.class)
       private String _formalName;
 
       /**
-       * A short description of the data construct's purpose, describing the constructs semantics.
+       * A short description of the data construct's purpose, describing the
+       * constructs semantics.
        */
       @BoundField(
           formalName = "Description",
           description = "A short description of the data construct's purpose, describing the constructs semantics.",
           useName = "description",
-          typeAdapter = MarkupLineAdapter.class
-      )
+          typeAdapter = MarkupLineAdapter.class)
       private MarkupLine _description;
 
       @BoundAssembly(
           formalName = "Property",
           useName = "prop",
           maxOccurs = -1,
-          groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST)
-      )
+          groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST))
       private List<Property> _props;
 
       @BoundField(
           formalName = "Grouping Discriminator Value",
           useName = "discriminator-value",
-          typeAdapter = TokenAdapter.class
-      )
+          typeAdapter = TokenAdapter.class)
       private String _discriminatorValue;
 
       @BoundChoiceGroup(
           maxOccurs = -1,
           groupAs = @GroupAs(name = "flags", inJson = JsonGroupAsBehavior.LIST),
           assemblies = {
-              @BoundGroupedAssembly(formalName = "Inline Flag Definition", useName = "define-flag", discriminatorValue = "flag", binding = InlineDefineFlag.class),
-              @BoundGroupedAssembly(formalName = "Flag Reference", useName = "flag", discriminatorValue = "flag-ref", binding = FlagReference.class)
-          }
-      )
+              @BoundGroupedAssembly(formalName = "Inline Flag Definition", useName = "define-flag",
+                  discriminatorValue = "flag", binding = InlineDefineFlag.class),
+              @BoundGroupedAssembly(formalName = "Flag Reference", useName = "flag", discriminatorValue = "flag-ref",
+                  binding = FlagReference.class)
+          })
       private List<Object> _flags;
 
       @BoundAssembly(
-          useName = "model"
-      )
+          useName = "model")
       private AssemblyModel _model;
 
       @BoundAssembly(
-          useName = "constraint"
-      )
+          useName = "constraint")
       private AssemblyConstraints _constraint;
 
       /**
-       * Any explanatory or helpful information to be provided about the remarks parent.
+       * Any explanatory or helpful information to be provided about the remarks
+       * parent.
        */
       @BoundField(
           formalName = "Remarks",
           description = "Any explanatory or helpful information to be provided about the remarks parent.",
-          useName = "remarks"
-      )
+          useName = "remarks")
       private Remarks _remarks;
 
       @BoundAssembly(
           formalName = "Example",
           useName = "example",
           maxOccurs = -1,
-          groupAs = @GroupAs(name = "examples", inJson = JsonGroupAsBehavior.LIST)
-      )
+          groupAs = @GroupAs(name = "examples", inJson = JsonGroupAsBehavior.LIST))
       private List<Example> _examples;
 
       /**
-       * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyModel.ChoiceGroup.DefineAssembly} instance with no metadata.
+       * Constructs a new
+       * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyModel.ChoiceGroup.DefineAssembly}
+       * instance with no metadata.
        */
       public DefineAssembly() {
         this(null);
       }
 
       /**
-       * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyModel.ChoiceGroup.DefineAssembly} instance with the specified metadata.
+       * Constructs a new
+       * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyModel.ChoiceGroup.DefineAssembly}
+       * instance with the specified metadata.
        *
        * @param data
-       *           the metaschema data, or {@code null} if none
+       *          the metaschema data, or {@code null} if none
        */
       public DefineAssembly(IMetaschemaData data) {
         this.__metaschemaData = data;
@@ -973,7 +994,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the inline Assembly Name.
        *
        * @param value
-       *           the name value to set
+       *          the name value to set
        */
       public void setName(@NonNull String value) {
         _name = value;
@@ -993,7 +1014,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the inline Assembly Binary Name.
        *
        * @param value
-       *           the index value to set
+       *          the index value to set, or {@code null} to clear
        */
       public void setIndex(@Nullable BigInteger value) {
         _index = value;
@@ -1013,7 +1034,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the deprecated Version.
        *
        * @param value
-       *           the deprecated value to set
+       *          the deprecated value to set, or {@code null} to clear
        */
       public void setDeprecated(@Nullable String value) {
         _deprecated = value;
@@ -1039,7 +1060,7 @@ public class AssemblyModel implements IBoundObject {
        * A formal name for the data construct, to be presented in documentation.
        *
        * @param value
-       *           the formal-name value to set
+       *          the formal-name value to set, or {@code null} to clear
        */
       public void setFormalName(@Nullable String value) {
         _formalName = value;
@@ -1049,7 +1070,8 @@ public class AssemblyModel implements IBoundObject {
        * Get the description.
        *
        * <p>
-       * A short description of the data construct's purpose, describing the constructs semantics.
+       * A short description of the data construct's purpose, describing the
+       * constructs semantics.
        *
        * @return the description value, or {@code null} if not set
        */
@@ -1062,10 +1084,11 @@ public class AssemblyModel implements IBoundObject {
        * Set the description.
        *
        * <p>
-       * A short description of the data construct's purpose, describing the constructs semantics.
+       * A short description of the data construct's purpose, describing the
+       * constructs semantics.
        *
        * @param value
-       *           the description value to set
+       *          the description value to set, or {@code null} to clear
        */
       public void setDescription(@Nullable MarkupLine value) {
         _description = value;
@@ -1088,7 +1111,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the property.
        *
        * @param value
-       *           the prop value to set
+       *          the prop value to set
        */
       public void setProps(@NonNull List<Property> value) {
         _props = value;
@@ -1096,11 +1119,13 @@ public class AssemblyModel implements IBoundObject {
 
       /**
        * Add a new {@link Property} item to the underlying collection.
-       * @param item the item to add
+       *
+       * @param item
+       *          the item to add
        * @return {@code true}
        */
       public boolean addProp(Property item) {
-        Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+        Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
         if (_props == null) {
           _props = new LinkedList<>();
         }
@@ -1108,12 +1133,15 @@ public class AssemblyModel implements IBoundObject {
       }
 
       /**
-       * Remove the first matching {@link Property} item from the underlying collection.
-       * @param item the item to remove
+       * Remove the first matching {@link Property} item from the underlying
+       * collection.
+       *
+       * @param item
+       *          the item to remove
        * @return {@code true} if the item was removed or {@code false} otherwise
        */
       public boolean removeProp(Property item) {
-        Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+        Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
         return _props != null && _props.remove(value);
       }
 
@@ -1131,7 +1159,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the grouping Discriminator Value.
        *
        * @param value
-       *           the discriminator-value value to set
+       *          the discriminator-value value to set, or {@code null} to clear
        */
       public void setDiscriminatorValue(@Nullable String value) {
         _discriminatorValue = value;
@@ -1154,7 +1182,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the {@code flags} choice group items.
        *
        * @param value
-       *           the flags items to set
+       *          the flags items to set
        */
       public void setFlags(@NonNull List<Object> value) {
         _flags = value;
@@ -1174,7 +1202,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the {@code model} property.
        *
        * @param value
-       *           the model value to set
+       *          the model value to set, or {@code null} to clear
        */
       public void setModel(@Nullable AssemblyModel value) {
         _model = value;
@@ -1194,7 +1222,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the {@code constraint} property.
        *
        * @param value
-       *           the constraint value to set
+       *          the constraint value to set, or {@code null} to clear
        */
       public void setConstraint(@Nullable AssemblyConstraints value) {
         _constraint = value;
@@ -1204,7 +1232,8 @@ public class AssemblyModel implements IBoundObject {
        * Get the remarks.
        *
        * <p>
-       * Any explanatory or helpful information to be provided about the remarks parent.
+       * Any explanatory or helpful information to be provided about the remarks
+       * parent.
        *
        * @return the remarks value, or {@code null} if not set
        */
@@ -1217,10 +1246,11 @@ public class AssemblyModel implements IBoundObject {
        * Set the remarks.
        *
        * <p>
-       * Any explanatory or helpful information to be provided about the remarks parent.
+       * Any explanatory or helpful information to be provided about the remarks
+       * parent.
        *
        * @param value
-       *           the remarks value to set
+       *          the remarks value to set, or {@code null} to clear
        */
       public void setRemarks(@Nullable Remarks value) {
         _remarks = value;
@@ -1243,7 +1273,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the example.
        *
        * @param value
-       *           the example value to set
+       *          the example value to set
        */
       public void setExamples(@NonNull List<Example> value) {
         _examples = value;
@@ -1251,11 +1281,13 @@ public class AssemblyModel implements IBoundObject {
 
       /**
        * Add a new {@link Example} item to the underlying collection.
-       * @param item the item to add
+       *
+       * @param item
+       *          the item to add
        * @return {@code true}
        */
       public boolean addExample(Example item) {
-        Example value = ObjectUtils.requireNonNull(item,"item cannot be null");
+        Example value = ObjectUtils.requireNonNull(item, "item cannot be null");
         if (_examples == null) {
           _examples = new LinkedList<>();
         }
@@ -1263,12 +1295,15 @@ public class AssemblyModel implements IBoundObject {
       }
 
       /**
-       * Remove the first matching {@link Example} item from the underlying collection.
-       * @param item the item to remove
+       * Remove the first matching {@link Example} item from the underlying
+       * collection.
+       *
+       * @param item
+       *          the item to remove
        * @return {@code true} if the item was removed or {@code false} otherwise
        */
       public boolean removeExample(Example item) {
-        Example value = ObjectUtils.requireNonNull(item,"item cannot be null");
+        Example value = ObjectUtils.requireNonNull(item, "item cannot be null");
         return _examples != null && _examples.remove(value);
       }
 
@@ -1281,8 +1316,7 @@ public class AssemblyModel implements IBoundObject {
     @MetaschemaAssembly(
         formalName = "Grouping Field Reference",
         name = "field",
-        moduleClass = MetaschemaModelModule.class
-    )
+        moduleClass = MetaschemaModelModule.class)
     public static class Field implements IBoundObject {
       private final IMetaschemaData __metaschemaData;
 
@@ -1290,29 +1324,25 @@ public class AssemblyModel implements IBoundObject {
           formalName = "Global Field Reference",
           name = "ref",
           required = true,
-          typeAdapter = TokenAdapter.class
-      )
+          typeAdapter = TokenAdapter.class)
       private String _ref;
 
       @BoundFlag(
           formalName = "Field Reference Binary Name",
           name = "index",
-          typeAdapter = PositiveIntegerAdapter.class
-      )
+          typeAdapter = PositiveIntegerAdapter.class)
       private BigInteger _index;
 
       @BoundFlag(
           formalName = "Deprecated Version",
           name = "deprecated",
-          typeAdapter = StringAdapter.class
-      )
+          typeAdapter = StringAdapter.class)
       private String _deprecated;
 
       @BoundFlag(
           formalName = "Default Field Value",
           name = "default",
-          typeAdapter = StringAdapter.class
-      )
+          typeAdapter = StringAdapter.class)
       private String _default;
 
       @BoundFlag(
@@ -1320,8 +1350,13 @@ public class AssemblyModel implements IBoundObject {
           name = "in-xml",
           defaultValue = "WRAPPED",
           typeAdapter = TokenAdapter.class,
-          valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "WRAPPED", description = "Block contents of a markup-multiline field will be represented with a containing (wrapper) element in the XML."), @AllowedValue(value = "UNWRAPPED", description = "Block contents of a markup-multiline will be represented in the XML with no wrapper, making the field implicit. Among sibling fields in a given model, only one of them may be designated as UNWRAPPED."), @AllowedValue(value = "WITH_WRAPPER", description = "Alias for WRAPPED.", deprecatedVersion = "0.9.0")}))
-      )
+          valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR,
+              values = { @AllowedValue(value = "WRAPPED",
+                  description = "Block contents of a markup-multiline field will be represented with a containing (wrapper) element in the XML."),
+                  @AllowedValue(value = "UNWRAPPED",
+                      description = "Block contents of a markup-multiline will be represented in the XML with no wrapper, making the field implicit. Among sibling fields in a given model, only one of them may be designated as UNWRAPPED."),
+                  @AllowedValue(value = "WITH_WRAPPER", description = "Alias for WRAPPED.",
+                      deprecatedVersion = "0.9.0") })))
       private String _inXml;
 
       /**
@@ -1331,27 +1366,25 @@ public class AssemblyModel implements IBoundObject {
           formalName = "Formal Name",
           description = "A formal name for the data construct, to be presented in documentation.",
           useName = "formal-name",
-          typeAdapter = StringAdapter.class
-      )
+          typeAdapter = StringAdapter.class)
       private String _formalName;
 
       /**
-       * A short description of the data construct's purpose, describing the constructs semantics.
+       * A short description of the data construct's purpose, describing the
+       * constructs semantics.
        */
       @BoundField(
           formalName = "Description",
           description = "A short description of the data construct's purpose, describing the constructs semantics.",
           useName = "description",
-          typeAdapter = MarkupLineAdapter.class
-      )
+          typeAdapter = MarkupLineAdapter.class)
       private MarkupLine _description;
 
       @BoundAssembly(
           formalName = "Property",
           useName = "prop",
           maxOccurs = -1,
-          groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST)
-      )
+          groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST))
       private List<Property> _props;
 
       /**
@@ -1360,39 +1393,41 @@ public class AssemblyModel implements IBoundObject {
       @BoundField(
           formalName = "Use Name",
           description = "Allows the name of the definition to be overridden.",
-          useName = "use-name"
-      )
+          useName = "use-name")
       private UseName _useName;
 
       @BoundField(
           formalName = "Grouping Discriminator Value",
           useName = "discriminator-value",
-          typeAdapter = TokenAdapter.class
-      )
+          typeAdapter = TokenAdapter.class)
       private String _discriminatorValue;
 
       /**
-       * Any explanatory or helpful information to be provided about the remarks parent.
+       * Any explanatory or helpful information to be provided about the remarks
+       * parent.
        */
       @BoundField(
           formalName = "Remarks",
           description = "Any explanatory or helpful information to be provided about the remarks parent.",
-          useName = "remarks"
-      )
+          useName = "remarks")
       private Remarks _remarks;
 
       /**
-       * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyModel.ChoiceGroup.Field} instance with no metadata.
+       * Constructs a new
+       * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyModel.ChoiceGroup.Field}
+       * instance with no metadata.
        */
       public Field() {
         this(null);
       }
 
       /**
-       * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyModel.ChoiceGroup.Field} instance with the specified metadata.
+       * Constructs a new
+       * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyModel.ChoiceGroup.Field}
+       * instance with the specified metadata.
        *
        * @param data
-       *           the metaschema data, or {@code null} if none
+       *          the metaschema data, or {@code null} if none
        */
       public Field(IMetaschemaData data) {
         this.__metaschemaData = data;
@@ -1417,7 +1452,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the global Field Reference.
        *
        * @param value
-       *           the ref value to set
+       *          the ref value to set
        */
       public void setRef(@NonNull String value) {
         _ref = value;
@@ -1437,7 +1472,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the field Reference Binary Name.
        *
        * @param value
-       *           the index value to set
+       *          the index value to set, or {@code null} to clear
        */
       public void setIndex(@Nullable BigInteger value) {
         _index = value;
@@ -1457,7 +1492,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the deprecated Version.
        *
        * @param value
-       *           the deprecated value to set
+       *          the deprecated value to set, or {@code null} to clear
        */
       public void setDeprecated(@Nullable String value) {
         _deprecated = value;
@@ -1477,7 +1512,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the default Field Value.
        *
        * @param value
-       *           the default value to set
+       *          the default value to set, or {@code null} to clear
        */
       public void setDefault(@Nullable String value) {
         _default = value;
@@ -1497,7 +1532,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the field In XML.
        *
        * @param value
-       *           the in-xml value to set
+       *          the in-xml value to set, or {@code null} to clear
        */
       public void setInXml(@Nullable String value) {
         _inXml = value;
@@ -1523,7 +1558,7 @@ public class AssemblyModel implements IBoundObject {
        * A formal name for the data construct, to be presented in documentation.
        *
        * @param value
-       *           the formal-name value to set
+       *          the formal-name value to set, or {@code null} to clear
        */
       public void setFormalName(@Nullable String value) {
         _formalName = value;
@@ -1533,7 +1568,8 @@ public class AssemblyModel implements IBoundObject {
        * Get the description.
        *
        * <p>
-       * A short description of the data construct's purpose, describing the constructs semantics.
+       * A short description of the data construct's purpose, describing the
+       * constructs semantics.
        *
        * @return the description value, or {@code null} if not set
        */
@@ -1546,10 +1582,11 @@ public class AssemblyModel implements IBoundObject {
        * Set the description.
        *
        * <p>
-       * A short description of the data construct's purpose, describing the constructs semantics.
+       * A short description of the data construct's purpose, describing the
+       * constructs semantics.
        *
        * @param value
-       *           the description value to set
+       *          the description value to set, or {@code null} to clear
        */
       public void setDescription(@Nullable MarkupLine value) {
         _description = value;
@@ -1572,7 +1609,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the property.
        *
        * @param value
-       *           the prop value to set
+       *          the prop value to set
        */
       public void setProps(@NonNull List<Property> value) {
         _props = value;
@@ -1580,11 +1617,13 @@ public class AssemblyModel implements IBoundObject {
 
       /**
        * Add a new {@link Property} item to the underlying collection.
-       * @param item the item to add
+       *
+       * @param item
+       *          the item to add
        * @return {@code true}
        */
       public boolean addProp(Property item) {
-        Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+        Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
         if (_props == null) {
           _props = new LinkedList<>();
         }
@@ -1592,12 +1631,15 @@ public class AssemblyModel implements IBoundObject {
       }
 
       /**
-       * Remove the first matching {@link Property} item from the underlying collection.
-       * @param item the item to remove
+       * Remove the first matching {@link Property} item from the underlying
+       * collection.
+       *
+       * @param item
+       *          the item to remove
        * @return {@code true} if the item was removed or {@code false} otherwise
        */
       public boolean removeProp(Property item) {
-        Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+        Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
         return _props != null && _props.remove(value);
       }
 
@@ -1621,7 +1663,7 @@ public class AssemblyModel implements IBoundObject {
        * Allows the name of the definition to be overridden.
        *
        * @param value
-       *           the use-name value to set
+       *          the use-name value to set, or {@code null} to clear
        */
       public void setUseName(@Nullable UseName value) {
         _useName = value;
@@ -1641,7 +1683,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the grouping Discriminator Value.
        *
        * @param value
-       *           the discriminator-value value to set
+       *          the discriminator-value value to set, or {@code null} to clear
        */
       public void setDiscriminatorValue(@Nullable String value) {
         _discriminatorValue = value;
@@ -1651,7 +1693,8 @@ public class AssemblyModel implements IBoundObject {
        * Get the remarks.
        *
        * <p>
-       * Any explanatory or helpful information to be provided about the remarks parent.
+       * Any explanatory or helpful information to be provided about the remarks
+       * parent.
        *
        * @return the remarks value, or {@code null} if not set
        */
@@ -1664,10 +1707,11 @@ public class AssemblyModel implements IBoundObject {
        * Set the remarks.
        *
        * <p>
-       * Any explanatory or helpful information to be provided about the remarks parent.
+       * Any explanatory or helpful information to be provided about the remarks
+       * parent.
        *
        * @param value
-       *           the remarks value to set
+       *          the remarks value to set, or {@code null} to clear
        */
       public void setRemarks(@Nullable Remarks value) {
         _remarks = value;
@@ -1682,8 +1726,7 @@ public class AssemblyModel implements IBoundObject {
     @MetaschemaAssembly(
         formalName = "Inline Field Definition",
         name = "define-field",
-        moduleClass = MetaschemaModelModule.class
-    )
+        moduleClass = MetaschemaModelModule.class)
     public static class DefineField implements IBoundObject {
       private final IMetaschemaData __metaschemaData;
 
@@ -1691,22 +1734,19 @@ public class AssemblyModel implements IBoundObject {
           formalName = "Inline Field Name",
           name = "name",
           required = true,
-          typeAdapter = TokenAdapter.class
-      )
+          typeAdapter = TokenAdapter.class)
       private String _name;
 
       @BoundFlag(
           formalName = "Inline Field Binary Name",
           name = "index",
-          typeAdapter = PositiveIntegerAdapter.class
-      )
+          typeAdapter = PositiveIntegerAdapter.class)
       private BigInteger _index;
 
       @BoundFlag(
           formalName = "Deprecated Version",
           name = "deprecated",
-          typeAdapter = StringAdapter.class
-      )
+          typeAdapter = StringAdapter.class)
       private String _deprecated;
 
       @BoundFlag(
@@ -1714,15 +1754,76 @@ public class AssemblyModel implements IBoundObject {
           name = "as-type",
           defaultValue = "string",
           typeAdapter = TokenAdapter.class,
-          valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, allowOthers = true, values = {@AllowedValue(value = "markup-line", description = "The [markup-line](https://framework.metaschema.dev/specification/datatypes/#markup-line) data type."), @AllowedValue(value = "markup-multiline", description = "The [markup-multiline](https://framework.metaschema.dev/specification/datatypes/#markup-multiline) data type."), @AllowedValue(value = "base64", description = "The [base64](https://framework.metaschema.dev/specification/datatypes/#base64) data type."), @AllowedValue(value = "boolean", description = "The [boolean](https://framework.metaschema.dev/specification/datatypes/#boolean) data type."), @AllowedValue(value = "date", description = "The [date](https://framework.metaschema.dev/specification/datatypes/#date) data type."), @AllowedValue(value = "date-time", description = "The [date-time](https://framework.metaschema.dev/specification/datatypes/#date-time) data type."), @AllowedValue(value = "date-time-with-timezone", description = "The [date-time-with-timezone](https://framework.metaschema.dev/specification/datatypes/#date-time-with-timezone) data type."), @AllowedValue(value = "date-with-timezone", description = "The [date-with-timezone](https://framework.metaschema.dev/specification/datatypes/#date-with-timezone) data type."), @AllowedValue(value = "day-time-duration", description = "The [day-time-duration](https://framework.metaschema.dev/specification/datatypes/#day-time-duration) data type."), @AllowedValue(value = "decimal", description = "The [decimal](https://framework.metaschema.dev/specification/datatypes/#decimal) data type."), @AllowedValue(value = "email-address", description = "The [email-address](https://framework.metaschema.dev/specification/datatypes/#email-address) data type."), @AllowedValue(value = "hostname", description = "The [hostname](https://framework.metaschema.dev/specification/datatypes/#hostname) data type."), @AllowedValue(value = "integer", description = "The [integer](https://framework.metaschema.dev/specification/datatypes/#integer) data type."), @AllowedValue(value = "ip-v4-address", description = "The [ip-v4-address](https://framework.metaschema.dev/specification/datatypes/#ip-v4-address) data type."), @AllowedValue(value = "ip-v6-address", description = "The [ip-v6-address](https://framework.metaschema.dev/specification/datatypes/#ip-v6-address) data type."), @AllowedValue(value = "non-negative-integer", description = "The [non-negative-integer](https://framework.metaschema.dev/specification/datatypes/#non-negative-integer) data type."), @AllowedValue(value = "positive-integer", description = "The [positive-integer](https://framework.metaschema.dev/specification/datatypes/#positive-integer) data type."), @AllowedValue(value = "string", description = "The [string](https://framework.metaschema.dev/specification/datatypes/#string) data type."), @AllowedValue(value = "token", description = "The [token](https://framework.metaschema.dev/specification/datatypes/#token) data type."), @AllowedValue(value = "uri", description = "The [uri](https://framework.metaschema.dev/specification/datatypes/#uri) data type."), @AllowedValue(value = "uri-reference", description = "The [uri-reference](https://framework.metaschema.dev/specification/datatypes/#uri-reference) data type."), @AllowedValue(value = "uuid", description = "The [uuid](https://framework.metaschema.dev/specification/datatypes/#uuid) data type."), @AllowedValue(value = "base64Binary", description = "An old name which is deprecated for use in favor of the 'base64' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "dateTime", description = "An old name which is deprecated for use in favor of the 'date-time' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "dateTime-with-timezone", description = "An old name which is deprecated for use in favor of the 'date-time-with-timezone' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "email", description = "An old name which is deprecated for use in favor of the 'email-address' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "nonNegativeInteger", description = "An old name which is deprecated for use in favor of the 'non-negative-integer' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "positiveInteger", description = "An old name which is deprecated for use in favor of the 'positive-integer' data type.", deprecatedVersion = "1.0.0")}))
-      )
+          valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR,
+              allowOthers = true,
+              values = { @AllowedValue(value = "markup-line",
+                  description = "The [markup-line](https://framework.metaschema.dev/specification/datatypes/#markup-line) data type."),
+                  @AllowedValue(value = "markup-multiline",
+                      description = "The [markup-multiline](https://framework.metaschema.dev/specification/datatypes/#markup-multiline) data type."),
+                  @AllowedValue(value = "base64",
+                      description = "The [base64](https://framework.metaschema.dev/specification/datatypes/#base64) data type."),
+                  @AllowedValue(value = "boolean",
+                      description = "The [boolean](https://framework.metaschema.dev/specification/datatypes/#boolean) data type."),
+                  @AllowedValue(value = "date",
+                      description = "The [date](https://framework.metaschema.dev/specification/datatypes/#date) data type."),
+                  @AllowedValue(value = "date-time",
+                      description = "The [date-time](https://framework.metaschema.dev/specification/datatypes/#date-time) data type."),
+                  @AllowedValue(value = "date-time-with-timezone",
+                      description = "The [date-time-with-timezone](https://framework.metaschema.dev/specification/datatypes/#date-time-with-timezone) data type."),
+                  @AllowedValue(value = "date-with-timezone",
+                      description = "The [date-with-timezone](https://framework.metaschema.dev/specification/datatypes/#date-with-timezone) data type."),
+                  @AllowedValue(value = "day-time-duration",
+                      description = "The [day-time-duration](https://framework.metaschema.dev/specification/datatypes/#day-time-duration) data type."),
+                  @AllowedValue(value = "decimal",
+                      description = "The [decimal](https://framework.metaschema.dev/specification/datatypes/#decimal) data type."),
+                  @AllowedValue(value = "email-address",
+                      description = "The [email-address](https://framework.metaschema.dev/specification/datatypes/#email-address) data type."),
+                  @AllowedValue(value = "hostname",
+                      description = "The [hostname](https://framework.metaschema.dev/specification/datatypes/#hostname) data type."),
+                  @AllowedValue(value = "integer",
+                      description = "The [integer](https://framework.metaschema.dev/specification/datatypes/#integer) data type."),
+                  @AllowedValue(value = "ip-v4-address",
+                      description = "The [ip-v4-address](https://framework.metaschema.dev/specification/datatypes/#ip-v4-address) data type."),
+                  @AllowedValue(value = "ip-v6-address",
+                      description = "The [ip-v6-address](https://framework.metaschema.dev/specification/datatypes/#ip-v6-address) data type."),
+                  @AllowedValue(value = "non-negative-integer",
+                      description = "The [non-negative-integer](https://framework.metaschema.dev/specification/datatypes/#non-negative-integer) data type."),
+                  @AllowedValue(value = "positive-integer",
+                      description = "The [positive-integer](https://framework.metaschema.dev/specification/datatypes/#positive-integer) data type."),
+                  @AllowedValue(value = "string",
+                      description = "The [string](https://framework.metaschema.dev/specification/datatypes/#string) data type."),
+                  @AllowedValue(value = "token",
+                      description = "The [token](https://framework.metaschema.dev/specification/datatypes/#token) data type."),
+                  @AllowedValue(value = "uri",
+                      description = "The [uri](https://framework.metaschema.dev/specification/datatypes/#uri) data type."),
+                  @AllowedValue(value = "uri-reference",
+                      description = "The [uri-reference](https://framework.metaschema.dev/specification/datatypes/#uri-reference) data type."),
+                  @AllowedValue(value = "uuid",
+                      description = "The [uuid](https://framework.metaschema.dev/specification/datatypes/#uuid) data type."),
+                  @AllowedValue(value = "base64Binary",
+                      description = "An old name which is deprecated for use in favor of the 'base64' data type.",
+                      deprecatedVersion = "1.0.0"),
+                  @AllowedValue(value = "dateTime",
+                      description = "An old name which is deprecated for use in favor of the 'date-time' data type.",
+                      deprecatedVersion = "1.0.0"),
+                  @AllowedValue(value = "dateTime-with-timezone",
+                      description = "An old name which is deprecated for use in favor of the 'date-time-with-timezone' data type.",
+                      deprecatedVersion = "1.0.0"),
+                  @AllowedValue(value = "email",
+                      description = "An old name which is deprecated for use in favor of the 'email-address' data type.",
+                      deprecatedVersion = "1.0.0"),
+                  @AllowedValue(value = "nonNegativeInteger",
+                      description = "An old name which is deprecated for use in favor of the 'non-negative-integer' data type.",
+                      deprecatedVersion = "1.0.0"),
+                  @AllowedValue(value = "positiveInteger",
+                      description = "An old name which is deprecated for use in favor of the 'positive-integer' data type.",
+                      deprecatedVersion = "1.0.0") })))
       private String _asType;
 
       @BoundFlag(
           formalName = "Default Field Value",
           name = "default",
-          typeAdapter = StringAdapter.class
-      )
+          typeAdapter = StringAdapter.class)
       private String _default;
 
       /**
@@ -1732,100 +1833,96 @@ public class AssemblyModel implements IBoundObject {
           formalName = "Formal Name",
           description = "A formal name for the data construct, to be presented in documentation.",
           useName = "formal-name",
-          typeAdapter = StringAdapter.class
-      )
+          typeAdapter = StringAdapter.class)
       private String _formalName;
 
       /**
-       * A short description of the data construct's purpose, describing the constructs semantics.
+       * A short description of the data construct's purpose, describing the
+       * constructs semantics.
        */
       @BoundField(
           formalName = "Description",
           description = "A short description of the data construct's purpose, describing the constructs semantics.",
           useName = "description",
-          typeAdapter = MarkupLineAdapter.class
-      )
+          typeAdapter = MarkupLineAdapter.class)
       private MarkupLine _description;
 
       @BoundAssembly(
           formalName = "Property",
           useName = "prop",
           maxOccurs = -1,
-          groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST)
-      )
+          groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST))
       private List<Property> _props;
 
       @BoundField(
           formalName = "Grouping Discriminator Value",
           useName = "discriminator-value",
-          typeAdapter = TokenAdapter.class
-      )
+          typeAdapter = TokenAdapter.class)
       private String _discriminatorValue;
 
       @BoundField(
           formalName = "Field Value JSON Property Name",
           useName = "json-value-key",
-          typeAdapter = TokenAdapter.class
-      )
+          typeAdapter = TokenAdapter.class)
       @BoundChoice(
-          choiceId = "choice-1"
-      )
+          choiceId = "choice-1")
       private String _jsonValueKey;
 
       @BoundAssembly(
           formalName = "Flag Used as the Field Value's JSON Property Name",
-          useName = "json-value-key-flag"
-      )
+          useName = "json-value-key-flag")
       @BoundChoice(
-          choiceId = "choice-1"
-      )
+          choiceId = "choice-1")
       private JsonValueKeyFlag _jsonValueKeyFlag;
 
       @BoundChoiceGroup(
           maxOccurs = -1,
           groupAs = @GroupAs(name = "flags", inJson = JsonGroupAsBehavior.LIST),
           assemblies = {
-              @BoundGroupedAssembly(formalName = "Inline Flag Definition", useName = "define-flag", discriminatorValue = "flag", binding = InlineDefineFlag.class),
-              @BoundGroupedAssembly(formalName = "Flag Reference", useName = "flag", discriminatorValue = "flag-ref", binding = FlagReference.class)
-          }
-      )
+              @BoundGroupedAssembly(formalName = "Inline Flag Definition", useName = "define-flag",
+                  discriminatorValue = "flag", binding = InlineDefineFlag.class),
+              @BoundGroupedAssembly(formalName = "Flag Reference", useName = "flag", discriminatorValue = "flag-ref",
+                  binding = FlagReference.class)
+          })
       private List<Object> _flags;
 
       @BoundAssembly(
-          useName = "constraint"
-      )
+          useName = "constraint")
       private FieldConstraints _constraint;
 
       /**
-       * Any explanatory or helpful information to be provided about the remarks parent.
+       * Any explanatory or helpful information to be provided about the remarks
+       * parent.
        */
       @BoundField(
           formalName = "Remarks",
           description = "Any explanatory or helpful information to be provided about the remarks parent.",
-          useName = "remarks"
-      )
+          useName = "remarks")
       private Remarks _remarks;
 
       @BoundAssembly(
           formalName = "Example",
           useName = "example",
           maxOccurs = -1,
-          groupAs = @GroupAs(name = "examples", inJson = JsonGroupAsBehavior.LIST)
-      )
+          groupAs = @GroupAs(name = "examples", inJson = JsonGroupAsBehavior.LIST))
       private List<Example> _examples;
 
       /**
-       * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyModel.ChoiceGroup.DefineField} instance with no metadata.
+       * Constructs a new
+       * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyModel.ChoiceGroup.DefineField}
+       * instance with no metadata.
        */
       public DefineField() {
         this(null);
       }
 
       /**
-       * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyModel.ChoiceGroup.DefineField} instance with the specified metadata.
+       * Constructs a new
+       * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyModel.ChoiceGroup.DefineField}
+       * instance with the specified metadata.
        *
        * @param data
-       *           the metaschema data, or {@code null} if none
+       *          the metaschema data, or {@code null} if none
        */
       public DefineField(IMetaschemaData data) {
         this.__metaschemaData = data;
@@ -1850,7 +1947,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the inline Field Name.
        *
        * @param value
-       *           the name value to set
+       *          the name value to set
        */
       public void setName(@NonNull String value) {
         _name = value;
@@ -1870,7 +1967,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the inline Field Binary Name.
        *
        * @param value
-       *           the index value to set
+       *          the index value to set, or {@code null} to clear
        */
       public void setIndex(@Nullable BigInteger value) {
         _index = value;
@@ -1890,7 +1987,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the deprecated Version.
        *
        * @param value
-       *           the deprecated value to set
+       *          the deprecated value to set, or {@code null} to clear
        */
       public void setDeprecated(@Nullable String value) {
         _deprecated = value;
@@ -1910,7 +2007,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the field Value Data Type.
        *
        * @param value
-       *           the as-type value to set
+       *          the as-type value to set, or {@code null} to clear
        */
       public void setAsType(@Nullable String value) {
         _asType = value;
@@ -1930,7 +2027,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the default Field Value.
        *
        * @param value
-       *           the default value to set
+       *          the default value to set, or {@code null} to clear
        */
       public void setDefault(@Nullable String value) {
         _default = value;
@@ -1956,7 +2053,7 @@ public class AssemblyModel implements IBoundObject {
        * A formal name for the data construct, to be presented in documentation.
        *
        * @param value
-       *           the formal-name value to set
+       *          the formal-name value to set, or {@code null} to clear
        */
       public void setFormalName(@Nullable String value) {
         _formalName = value;
@@ -1966,7 +2063,8 @@ public class AssemblyModel implements IBoundObject {
        * Get the description.
        *
        * <p>
-       * A short description of the data construct's purpose, describing the constructs semantics.
+       * A short description of the data construct's purpose, describing the
+       * constructs semantics.
        *
        * @return the description value, or {@code null} if not set
        */
@@ -1979,10 +2077,11 @@ public class AssemblyModel implements IBoundObject {
        * Set the description.
        *
        * <p>
-       * A short description of the data construct's purpose, describing the constructs semantics.
+       * A short description of the data construct's purpose, describing the
+       * constructs semantics.
        *
        * @param value
-       *           the description value to set
+       *          the description value to set, or {@code null} to clear
        */
       public void setDescription(@Nullable MarkupLine value) {
         _description = value;
@@ -2005,7 +2104,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the property.
        *
        * @param value
-       *           the prop value to set
+       *          the prop value to set
        */
       public void setProps(@NonNull List<Property> value) {
         _props = value;
@@ -2013,11 +2112,13 @@ public class AssemblyModel implements IBoundObject {
 
       /**
        * Add a new {@link Property} item to the underlying collection.
-       * @param item the item to add
+       *
+       * @param item
+       *          the item to add
        * @return {@code true}
        */
       public boolean addProp(Property item) {
-        Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+        Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
         if (_props == null) {
           _props = new LinkedList<>();
         }
@@ -2025,12 +2126,15 @@ public class AssemblyModel implements IBoundObject {
       }
 
       /**
-       * Remove the first matching {@link Property} item from the underlying collection.
-       * @param item the item to remove
+       * Remove the first matching {@link Property} item from the underlying
+       * collection.
+       *
+       * @param item
+       *          the item to remove
        * @return {@code true} if the item was removed or {@code false} otherwise
        */
       public boolean removeProp(Property item) {
-        Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+        Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
         return _props != null && _props.remove(value);
       }
 
@@ -2048,7 +2152,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the grouping Discriminator Value.
        *
        * @param value
-       *           the discriminator-value value to set
+       *          the discriminator-value value to set, or {@code null} to clear
        */
       public void setDiscriminatorValue(@Nullable String value) {
         _discriminatorValue = value;
@@ -2068,7 +2172,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the field Value JSON Property Name.
        *
        * @param value
-       *           the json-value-key value to set
+       *          the json-value-key value to set, or {@code null} to clear
        */
       public void setJsonValueKey(@Nullable String value) {
         _jsonValueKey = value;
@@ -2088,7 +2192,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the flag Used as the Field Value's JSON Property Name.
        *
        * @param value
-       *           the json-value-key-flag value to set
+       *          the json-value-key-flag value to set, or {@code null} to clear
        */
       public void setJsonValueKeyFlag(@Nullable JsonValueKeyFlag value) {
         _jsonValueKeyFlag = value;
@@ -2111,7 +2215,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the {@code flags} choice group items.
        *
        * @param value
-       *           the flags items to set
+       *          the flags items to set
        */
       public void setFlags(@NonNull List<Object> value) {
         _flags = value;
@@ -2131,7 +2235,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the {@code constraint} property.
        *
        * @param value
-       *           the constraint value to set
+       *          the constraint value to set, or {@code null} to clear
        */
       public void setConstraint(@Nullable FieldConstraints value) {
         _constraint = value;
@@ -2141,7 +2245,8 @@ public class AssemblyModel implements IBoundObject {
        * Get the remarks.
        *
        * <p>
-       * Any explanatory or helpful information to be provided about the remarks parent.
+       * Any explanatory or helpful information to be provided about the remarks
+       * parent.
        *
        * @return the remarks value, or {@code null} if not set
        */
@@ -2154,10 +2259,11 @@ public class AssemblyModel implements IBoundObject {
        * Set the remarks.
        *
        * <p>
-       * Any explanatory or helpful information to be provided about the remarks parent.
+       * Any explanatory or helpful information to be provided about the remarks
+       * parent.
        *
        * @param value
-       *           the remarks value to set
+       *          the remarks value to set, or {@code null} to clear
        */
       public void setRemarks(@Nullable Remarks value) {
         _remarks = value;
@@ -2180,7 +2286,7 @@ public class AssemblyModel implements IBoundObject {
        * Set the example.
        *
        * @param value
-       *           the example value to set
+       *          the example value to set
        */
       public void setExamples(@NonNull List<Example> value) {
         _examples = value;
@@ -2188,11 +2294,13 @@ public class AssemblyModel implements IBoundObject {
 
       /**
        * Add a new {@link Example} item to the underlying collection.
-       * @param item the item to add
+       *
+       * @param item
+       *          the item to add
        * @return {@code true}
        */
       public boolean addExample(Example item) {
-        Example value = ObjectUtils.requireNonNull(item,"item cannot be null");
+        Example value = ObjectUtils.requireNonNull(item, "item cannot be null");
         if (_examples == null) {
           _examples = new LinkedList<>();
         }
@@ -2200,12 +2308,15 @@ public class AssemblyModel implements IBoundObject {
       }
 
       /**
-       * Remove the first matching {@link Example} item from the underlying collection.
-       * @param item the item to remove
+       * Remove the first matching {@link Example} item from the underlying
+       * collection.
+       *
+       * @param item
+       *          the item to remove
        * @return {@code true} if the item was removed or {@code false} otherwise
        */
       public boolean removeExample(Example item) {
-        Example value = ObjectUtils.requireNonNull(item,"item cannot be null");
+        Example value = ObjectUtils.requireNonNull(item, "item cannot be null");
         return _examples != null && _examples.remove(value);
       }
 

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/AssemblyReference.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/AssemblyReference.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -35,8 +36,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @MetaschemaAssembly(
     formalName = "Assembly Reference",
     name = "assembly-reference",
-    moduleClass = MetaschemaModelModule.class
-)
+    moduleClass = MetaschemaModelModule.class)
 public class AssemblyReference implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
@@ -44,30 +44,26 @@ public class AssemblyReference implements IBoundObject {
       formalName = "Global Assembly Reference",
       name = "ref",
       required = true,
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _ref;
 
   @BoundFlag(
       formalName = "Assembly Reference Binary Name",
       name = "index",
-      typeAdapter = PositiveIntegerAdapter.class
-  )
+      typeAdapter = PositiveIntegerAdapter.class)
   private BigInteger _index;
 
   @BoundFlag(
       formalName = "Deprecated Version",
       name = "deprecated",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _deprecated;
 
   @BoundFlag(
       formalName = "Minimum Occurrence",
       name = "min-occurs",
       defaultValue = "0",
-      typeAdapter = NonNegativeIntegerAdapter.class
-  )
+      typeAdapter = NonNegativeIntegerAdapter.class)
   private BigInteger _minOccurs;
 
   @BoundFlag(
@@ -75,8 +71,8 @@ public class AssemblyReference implements IBoundObject {
       name = "max-occurs",
       defaultValue = "1",
       typeAdapter = StringAdapter.class,
-      valueConstraints = @ValueConstraints(matches = @Matches(level = IConstraint.Level.ERROR, pattern = "^[1-9][0-9]*|unbounded$"))
-  )
+      valueConstraints = @ValueConstraints(
+          matches = @Matches(level = IConstraint.Level.ERROR, pattern = "^[1-9][0-9]*|unbounded$")))
   private String _maxOccurs;
 
   /**
@@ -86,27 +82,25 @@ public class AssemblyReference implements IBoundObject {
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
       useName = "formal-name",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   /**
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    */
   @BoundField(
       formalName = "Description",
       description = "A short description of the data construct's purpose, describing the constructs semantics.",
       useName = "description",
-      typeAdapter = MarkupLineAdapter.class
-  )
+      typeAdapter = MarkupLineAdapter.class)
   private MarkupLine _description;
 
   @BoundAssembly(
       formalName = "Property",
       useName = "prop",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST))
   private List<Property> _props;
 
   /**
@@ -115,38 +109,40 @@ public class AssemblyReference implements IBoundObject {
   @BoundField(
       formalName = "Use Name",
       description = "Allows the name of the definition to be overridden.",
-      useName = "use-name"
-  )
+      useName = "use-name")
   private UseName _useName;
 
   @BoundAssembly(
       formalName = "Group As",
-      useName = "group-as"
-  )
+      useName = "group-as")
   private GroupingAs _groupAs;
 
   /**
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    */
   @BoundField(
       formalName = "Remarks",
       description = "Any explanatory or helpful information to be provided about the remarks parent.",
-      useName = "remarks"
-  )
+      useName = "remarks")
   private Remarks _remarks;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyReference} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyReference}
+   * instance with no metadata.
    */
   public AssemblyReference() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyReference} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.AssemblyReference}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public AssemblyReference(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -171,7 +167,7 @@ public class AssemblyReference implements IBoundObject {
    * Set the global Assembly Reference.
    *
    * @param value
-   *           the ref value to set
+   *          the ref value to set
    */
   public void setRef(@NonNull String value) {
     _ref = value;
@@ -191,7 +187,7 @@ public class AssemblyReference implements IBoundObject {
    * Set the assembly Reference Binary Name.
    *
    * @param value
-   *           the index value to set
+   *          the index value to set, or {@code null} to clear
    */
   public void setIndex(@Nullable BigInteger value) {
     _index = value;
@@ -211,7 +207,7 @@ public class AssemblyReference implements IBoundObject {
    * Set the deprecated Version.
    *
    * @param value
-   *           the deprecated value to set
+   *          the deprecated value to set, or {@code null} to clear
    */
   public void setDeprecated(@Nullable String value) {
     _deprecated = value;
@@ -231,7 +227,7 @@ public class AssemblyReference implements IBoundObject {
    * Set the minimum Occurrence.
    *
    * @param value
-   *           the min-occurs value to set
+   *          the min-occurs value to set, or {@code null} to clear
    */
   public void setMinOccurs(@Nullable BigInteger value) {
     _minOccurs = value;
@@ -251,7 +247,7 @@ public class AssemblyReference implements IBoundObject {
    * Set the maximum Occurrence.
    *
    * @param value
-   *           the max-occurs value to set
+   *          the max-occurs value to set, or {@code null} to clear
    */
   public void setMaxOccurs(@Nullable String value) {
     _maxOccurs = value;
@@ -277,7 +273,7 @@ public class AssemblyReference implements IBoundObject {
    * A formal name for the data construct, to be presented in documentation.
    *
    * @param value
-   *           the formal-name value to set
+   *          the formal-name value to set, or {@code null} to clear
    */
   public void setFormalName(@Nullable String value) {
     _formalName = value;
@@ -287,7 +283,8 @@ public class AssemblyReference implements IBoundObject {
    * Get the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @return the description value, or {@code null} if not set
    */
@@ -300,10 +297,11 @@ public class AssemblyReference implements IBoundObject {
    * Set the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @param value
-   *           the description value to set
+   *          the description value to set, or {@code null} to clear
    */
   public void setDescription(@Nullable MarkupLine value) {
     _description = value;
@@ -326,7 +324,7 @@ public class AssemblyReference implements IBoundObject {
    * Set the property.
    *
    * @param value
-   *           the prop value to set
+   *          the prop value to set
    */
   public void setProps(@NonNull List<Property> value) {
     _props = value;
@@ -334,11 +332,13 @@ public class AssemblyReference implements IBoundObject {
 
   /**
    * Add a new {@link Property} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_props == null) {
       _props = new LinkedList<>();
     }
@@ -346,12 +346,15 @@ public class AssemblyReference implements IBoundObject {
   }
 
   /**
-   * Remove the first matching {@link Property} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link Property} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _props != null && _props.remove(value);
   }
 
@@ -375,7 +378,7 @@ public class AssemblyReference implements IBoundObject {
    * Allows the name of the definition to be overridden.
    *
    * @param value
-   *           the use-name value to set
+   *          the use-name value to set, or {@code null} to clear
    */
   public void setUseName(@Nullable UseName value) {
     _useName = value;
@@ -395,7 +398,7 @@ public class AssemblyReference implements IBoundObject {
    * Set the group As.
    *
    * @param value
-   *           the group-as value to set
+   *          the group-as value to set, or {@code null} to clear
    */
   public void setGroupAs(@Nullable GroupingAs value) {
     _groupAs = value;
@@ -405,7 +408,8 @@ public class AssemblyReference implements IBoundObject {
    * Get the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @return the remarks value, or {@code null} if not set
    */
@@ -418,10 +422,11 @@ public class AssemblyReference implements IBoundObject {
    * Set the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @param value
-   *           the remarks value to set
+   *          the remarks value to set, or {@code null} to clear
    */
   public void setRemarks(@Nullable Remarks value) {
     _remarks = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/ConstraintLetExpression.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/ConstraintLetExpression.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -22,8 +23,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @MetaschemaAssembly(
     formalName = "Constraint Let Expression",
     name = "constraint-let-expression",
-    moduleClass = MetaschemaModelModule.class
-)
+    moduleClass = MetaschemaModelModule.class)
 public class ConstraintLetExpression implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
@@ -31,40 +31,42 @@ public class ConstraintLetExpression implements IBoundObject {
       formalName = "Let Variable Name",
       name = "var",
       required = true,
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _var;
 
   @BoundFlag(
       formalName = "Let Value Metapath Expression",
       name = "expression",
       required = true,
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _expression;
 
   /**
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    */
   @BoundField(
       formalName = "Remarks",
       description = "Any explanatory or helpful information to be provided about the remarks parent.",
-      useName = "remarks"
-  )
+      useName = "remarks")
   private Remarks _remarks;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.ConstraintLetExpression} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.ConstraintLetExpression}
+   * instance with no metadata.
    */
   public ConstraintLetExpression() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.ConstraintLetExpression} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.ConstraintLetExpression}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public ConstraintLetExpression(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -89,7 +91,7 @@ public class ConstraintLetExpression implements IBoundObject {
    * Set the let Variable Name.
    *
    * @param value
-   *           the var value to set
+   *          the var value to set
    */
   public void setVar(@NonNull String value) {
     _var = value;
@@ -109,7 +111,7 @@ public class ConstraintLetExpression implements IBoundObject {
    * Set the let Value Metapath Expression.
    *
    * @param value
-   *           the expression value to set
+   *          the expression value to set
    */
   public void setExpression(@NonNull String value) {
     _expression = value;
@@ -119,7 +121,8 @@ public class ConstraintLetExpression implements IBoundObject {
    * Get the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @return the remarks value, or {@code null} if not set
    */
@@ -132,10 +135,11 @@ public class ConstraintLetExpression implements IBoundObject {
    * Set the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @param value
-   *           the remarks value to set
+   *          the remarks value to set, or {@code null} to clear
    */
   public void setRemarks(@Nullable Remarks value) {
     _remarks = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/ConstraintValueEnum.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/ConstraintValueEnum.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -24,44 +25,46 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @MetaschemaField(
     formalName = "Allowed Value Enumeration",
     name = "constraint-value-enum",
-    moduleClass = MetaschemaModelModule.class
-)
-public class ConstraintValueEnum extends AbstractAllowedValue implements IBoundObject {
+    moduleClass = MetaschemaModelModule.class)
+public class ConstraintValueEnum
+    extends AbstractAllowedValue
+    implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
   @BoundFlag(
       formalName = "Allowed Value Enumeration Value",
       name = "value",
       required = true,
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _value;
 
   @BoundFlag(
       formalName = "Allowed Value Deprecation Version",
       name = "deprecated",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _deprecated;
 
   @BoundFieldValue(
       valueKeyName = "remark",
-      typeAdapter = MarkupLineAdapter.class
-  )
+      typeAdapter = MarkupLineAdapter.class)
   private MarkupLine _remark;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.ConstraintValueEnum} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.ConstraintValueEnum}
+   * instance with no metadata.
    */
   public ConstraintValueEnum() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.ConstraintValueEnum} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.ConstraintValueEnum}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public ConstraintValueEnum(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -87,7 +90,7 @@ public class ConstraintValueEnum extends AbstractAllowedValue implements IBoundO
    * Set the allowed Value Enumeration Value.
    *
    * @param value
-   *           the value value to set
+   *          the value value to set
    */
   public void setValue(@NonNull String value) {
     _value = value;
@@ -108,7 +111,7 @@ public class ConstraintValueEnum extends AbstractAllowedValue implements IBoundO
    * Set the allowed Value Deprecation Version.
    *
    * @param value
-   *           the deprecated value to set
+   *          the deprecated value to set, or {@code null} to clear
    */
   public void setDeprecated(@Nullable String value) {
     _deprecated = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/Example.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/Example.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -24,53 +25,53 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @MetaschemaAssembly(
     formalName = "Example",
     name = "example",
-    moduleClass = MetaschemaModelModule.class
-)
+    moduleClass = MetaschemaModelModule.class)
 public class Example implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
   @BoundFlag(
       formalName = "Example Reference",
       name = "ref",
-      typeAdapter = UriReferenceAdapter.class
-  )
+      typeAdapter = UriReferenceAdapter.class)
   private URI _ref;
 
   @BoundFlag(
       name = "path",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _path;
 
   @BoundField(
       formalName = "Example Description",
       useName = "description",
-      typeAdapter = MarkupLineAdapter.class
-  )
+      typeAdapter = MarkupLineAdapter.class)
   private MarkupLine _description;
 
   /**
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    */
   @BoundField(
       formalName = "Remarks",
       description = "Any explanatory or helpful information to be provided about the remarks parent.",
-      useName = "remarks"
-  )
+      useName = "remarks")
   private Remarks _remarks;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.Example} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.Example}
+   * instance with no metadata.
    */
   public Example() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.Example} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.Example}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public Example(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -95,7 +96,7 @@ public class Example implements IBoundObject {
    * Set the example Reference.
    *
    * @param value
-   *           the ref value to set
+   *          the ref value to set, or {@code null} to clear
    */
   public void setRef(@Nullable URI value) {
     _ref = value;
@@ -115,7 +116,7 @@ public class Example implements IBoundObject {
    * Set the {@code path} property.
    *
    * @param value
-   *           the path value to set
+   *          the path value to set, or {@code null} to clear
    */
   public void setPath(@Nullable String value) {
     _path = value;
@@ -135,7 +136,7 @@ public class Example implements IBoundObject {
    * Set the example Description.
    *
    * @param value
-   *           the description value to set
+   *          the description value to set, or {@code null} to clear
    */
   public void setDescription(@Nullable MarkupLine value) {
     _description = value;
@@ -145,7 +146,8 @@ public class Example implements IBoundObject {
    * Get the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @return the remarks value, or {@code null} if not set
    */
@@ -158,10 +160,11 @@ public class Example implements IBoundObject {
    * Set the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @param value
-   *           the remarks value to set
+   *          the remarks value to set, or {@code null} to clear
    */
   public void setRemarks(@Nullable Remarks value) {
     _remarks = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FieldConstraints.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FieldConstraints.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -24,8 +25,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 
 @MetaschemaAssembly(
     name = "field-constraints",
-    moduleClass = MetaschemaModelModule.class
-)
+    moduleClass = MetaschemaModelModule.class)
 public class FieldConstraints implements IValueTargetedConstraintsBase {
   private final IMetaschemaData __metaschemaData;
 
@@ -33,8 +33,7 @@ public class FieldConstraints implements IValueTargetedConstraintsBase {
       formalName = "Constraint Let Expression",
       useName = "let",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "lets", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "lets", inJson = JsonGroupAsBehavior.LIST))
   private List<ConstraintLetExpression> _lets;
 
   @BoundChoiceGroup(
@@ -42,27 +41,35 @@ public class FieldConstraints implements IValueTargetedConstraintsBase {
       maxOccurs = -1,
       groupAs = @GroupAs(name = "rules", inJson = JsonGroupAsBehavior.LIST),
       assemblies = {
-          @BoundGroupedAssembly(formalName = "Allowed Values Constraint", useName = "allowed-values", binding = TargetedAllowedValuesConstraint.class),
-          @BoundGroupedAssembly(formalName = "Expect Condition Constraint", useName = "expect", binding = TargetedExpectConstraint.class),
-          @BoundGroupedAssembly(formalName = "Targeted Index Has Key Constraint", useName = "index-has-key", binding = TargetedIndexHasKeyConstraint.class),
-          @BoundGroupedAssembly(formalName = "Value Matches Constraint", useName = "matches", binding = TargetedMatchesConstraint.class),
-          @BoundGroupedAssembly(formalName = "Report Condition Constraint", useName = "report", binding = TargetedReportConstraint.class)
-      }
-  )
+          @BoundGroupedAssembly(formalName = "Allowed Values Constraint", useName = "allowed-values",
+              binding = TargetedAllowedValuesConstraint.class),
+          @BoundGroupedAssembly(formalName = "Expect Condition Constraint", useName = "expect",
+              binding = TargetedExpectConstraint.class),
+          @BoundGroupedAssembly(formalName = "Targeted Index Has Key Constraint", useName = "index-has-key",
+              binding = TargetedIndexHasKeyConstraint.class),
+          @BoundGroupedAssembly(formalName = "Value Matches Constraint", useName = "matches",
+              binding = TargetedMatchesConstraint.class),
+          @BoundGroupedAssembly(formalName = "Report Condition Constraint", useName = "report",
+              binding = TargetedReportConstraint.class)
+      })
   private List<? extends ITargetedConstraintBase> _rules;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FieldConstraints} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FieldConstraints}
+   * instance with no metadata.
    */
   public FieldConstraints() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FieldConstraints} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FieldConstraints}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public FieldConstraints(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -91,7 +98,7 @@ public class FieldConstraints implements IValueTargetedConstraintsBase {
    * Set the constraint Let Expression.
    *
    * @param value
-   *           the let value to set
+   *          the let value to set
    */
   public void setLets(@NonNull List<ConstraintLetExpression> value) {
     _lets = value;
@@ -99,11 +106,13 @@ public class FieldConstraints implements IValueTargetedConstraintsBase {
 
   /**
    * Add a new {@link ConstraintLetExpression} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addLet(ConstraintLetExpression item) {
-    ConstraintLetExpression value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    ConstraintLetExpression value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_lets == null) {
       _lets = new LinkedList<>();
     }
@@ -111,12 +120,15 @@ public class FieldConstraints implements IValueTargetedConstraintsBase {
   }
 
   /**
-   * Remove the first matching {@link ConstraintLetExpression} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link ConstraintLetExpression} item from the
+   * underlying collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeLet(ConstraintLetExpression item) {
-    ConstraintLetExpression value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    ConstraintLetExpression value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _lets != null && _lets.remove(value);
   }
 
@@ -144,7 +156,7 @@ public class FieldConstraints implements IValueTargetedConstraintsBase {
    * Items in this collection must implement {@link ITargetedConstraintBase}.
    *
    * @param value
-   *           the rules items to set
+   *          the rules items to set
    */
   public void setRules(@NonNull List<? extends ITargetedConstraintBase> value) {
     _rules = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FieldReference.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FieldReference.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -37,8 +38,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @MetaschemaAssembly(
     formalName = "Field Reference",
     name = "field-reference",
-    moduleClass = MetaschemaModelModule.class
-)
+    moduleClass = MetaschemaModelModule.class)
 public class FieldReference implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
@@ -46,37 +46,32 @@ public class FieldReference implements IBoundObject {
       formalName = "Global Field Reference",
       name = "ref",
       required = true,
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _ref;
 
   @BoundFlag(
       formalName = "Field Reference Binary Name",
       name = "index",
-      typeAdapter = PositiveIntegerAdapter.class
-  )
+      typeAdapter = PositiveIntegerAdapter.class)
   private BigInteger _index;
 
   @BoundFlag(
       formalName = "Deprecated Version",
       name = "deprecated",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _deprecated;
 
   @BoundFlag(
       formalName = "Default Field Value",
       name = "default",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _default;
 
   @BoundFlag(
       formalName = "Minimum Occurrence",
       name = "min-occurs",
       defaultValue = "0",
-      typeAdapter = NonNegativeIntegerAdapter.class
-  )
+      typeAdapter = NonNegativeIntegerAdapter.class)
   private BigInteger _minOccurs;
 
   @BoundFlag(
@@ -84,8 +79,8 @@ public class FieldReference implements IBoundObject {
       name = "max-occurs",
       defaultValue = "1",
       typeAdapter = StringAdapter.class,
-      valueConstraints = @ValueConstraints(matches = @Matches(level = IConstraint.Level.ERROR, pattern = "^[1-9][0-9]*|unbounded$"))
-  )
+      valueConstraints = @ValueConstraints(
+          matches = @Matches(level = IConstraint.Level.ERROR, pattern = "^[1-9][0-9]*|unbounded$")))
   private String _maxOccurs;
 
   @BoundFlag(
@@ -93,8 +88,12 @@ public class FieldReference implements IBoundObject {
       name = "in-xml",
       defaultValue = "WRAPPED",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "WRAPPED", description = "Block contents of a markup-multiline field will be represented with a containing (wrapper) element in the XML."), @AllowedValue(value = "UNWRAPPED", description = "Block contents of a markup-multiline will be represented in the XML with no wrapper, making the field implicit. Among sibling fields in a given model, only one of them may be designated as UNWRAPPED."), @AllowedValue(value = "WITH_WRAPPER", description = "Alias for WRAPPED.", deprecatedVersion = "0.9.0")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {
+          @AllowedValue(value = "WRAPPED",
+              description = "Block contents of a markup-multiline field will be represented with a containing (wrapper) element in the XML."),
+          @AllowedValue(value = "UNWRAPPED",
+              description = "Block contents of a markup-multiline will be represented in the XML with no wrapper, making the field implicit. Among sibling fields in a given model, only one of them may be designated as UNWRAPPED."),
+          @AllowedValue(value = "WITH_WRAPPER", description = "Alias for WRAPPED.", deprecatedVersion = "0.9.0") })))
   private String _inXml;
 
   /**
@@ -104,27 +103,25 @@ public class FieldReference implements IBoundObject {
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
       useName = "formal-name",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   /**
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    */
   @BoundField(
       formalName = "Description",
       description = "A short description of the data construct's purpose, describing the constructs semantics.",
       useName = "description",
-      typeAdapter = MarkupLineAdapter.class
-  )
+      typeAdapter = MarkupLineAdapter.class)
   private MarkupLine _description;
 
   @BoundAssembly(
       formalName = "Property",
       useName = "prop",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST))
   private List<Property> _props;
 
   /**
@@ -133,38 +130,40 @@ public class FieldReference implements IBoundObject {
   @BoundField(
       formalName = "Use Name",
       description = "Allows the name of the definition to be overridden.",
-      useName = "use-name"
-  )
+      useName = "use-name")
   private UseName _useName;
 
   @BoundAssembly(
       formalName = "Group As",
-      useName = "group-as"
-  )
+      useName = "group-as")
   private GroupingAs _groupAs;
 
   /**
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    */
   @BoundField(
       formalName = "Remarks",
       description = "Any explanatory or helpful information to be provided about the remarks parent.",
-      useName = "remarks"
-  )
+      useName = "remarks")
   private Remarks _remarks;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FieldReference} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FieldReference}
+   * instance with no metadata.
    */
   public FieldReference() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FieldReference} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FieldReference}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public FieldReference(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -189,7 +188,7 @@ public class FieldReference implements IBoundObject {
    * Set the global Field Reference.
    *
    * @param value
-   *           the ref value to set
+   *          the ref value to set
    */
   public void setRef(@NonNull String value) {
     _ref = value;
@@ -209,7 +208,7 @@ public class FieldReference implements IBoundObject {
    * Set the field Reference Binary Name.
    *
    * @param value
-   *           the index value to set
+   *          the index value to set, or {@code null} to clear
    */
   public void setIndex(@Nullable BigInteger value) {
     _index = value;
@@ -229,7 +228,7 @@ public class FieldReference implements IBoundObject {
    * Set the deprecated Version.
    *
    * @param value
-   *           the deprecated value to set
+   *          the deprecated value to set, or {@code null} to clear
    */
   public void setDeprecated(@Nullable String value) {
     _deprecated = value;
@@ -249,7 +248,7 @@ public class FieldReference implements IBoundObject {
    * Set the default Field Value.
    *
    * @param value
-   *           the default value to set
+   *          the default value to set, or {@code null} to clear
    */
   public void setDefault(@Nullable String value) {
     _default = value;
@@ -269,7 +268,7 @@ public class FieldReference implements IBoundObject {
    * Set the minimum Occurrence.
    *
    * @param value
-   *           the min-occurs value to set
+   *          the min-occurs value to set, or {@code null} to clear
    */
   public void setMinOccurs(@Nullable BigInteger value) {
     _minOccurs = value;
@@ -289,7 +288,7 @@ public class FieldReference implements IBoundObject {
    * Set the maximum Occurrence.
    *
    * @param value
-   *           the max-occurs value to set
+   *          the max-occurs value to set, or {@code null} to clear
    */
   public void setMaxOccurs(@Nullable String value) {
     _maxOccurs = value;
@@ -309,7 +308,7 @@ public class FieldReference implements IBoundObject {
    * Set the field In XML.
    *
    * @param value
-   *           the in-xml value to set
+   *          the in-xml value to set, or {@code null} to clear
    */
   public void setInXml(@Nullable String value) {
     _inXml = value;
@@ -335,7 +334,7 @@ public class FieldReference implements IBoundObject {
    * A formal name for the data construct, to be presented in documentation.
    *
    * @param value
-   *           the formal-name value to set
+   *          the formal-name value to set, or {@code null} to clear
    */
   public void setFormalName(@Nullable String value) {
     _formalName = value;
@@ -345,7 +344,8 @@ public class FieldReference implements IBoundObject {
    * Get the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @return the description value, or {@code null} if not set
    */
@@ -358,10 +358,11 @@ public class FieldReference implements IBoundObject {
    * Set the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @param value
-   *           the description value to set
+   *          the description value to set, or {@code null} to clear
    */
   public void setDescription(@Nullable MarkupLine value) {
     _description = value;
@@ -384,7 +385,7 @@ public class FieldReference implements IBoundObject {
    * Set the property.
    *
    * @param value
-   *           the prop value to set
+   *          the prop value to set
    */
   public void setProps(@NonNull List<Property> value) {
     _props = value;
@@ -392,11 +393,13 @@ public class FieldReference implements IBoundObject {
 
   /**
    * Add a new {@link Property} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_props == null) {
       _props = new LinkedList<>();
     }
@@ -404,12 +407,15 @@ public class FieldReference implements IBoundObject {
   }
 
   /**
-   * Remove the first matching {@link Property} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link Property} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _props != null && _props.remove(value);
   }
 
@@ -433,7 +439,7 @@ public class FieldReference implements IBoundObject {
    * Allows the name of the definition to be overridden.
    *
    * @param value
-   *           the use-name value to set
+   *          the use-name value to set, or {@code null} to clear
    */
   public void setUseName(@Nullable UseName value) {
     _useName = value;
@@ -453,7 +459,7 @@ public class FieldReference implements IBoundObject {
    * Set the group As.
    *
    * @param value
-   *           the group-as value to set
+   *          the group-as value to set, or {@code null} to clear
    */
   public void setGroupAs(@Nullable GroupingAs value) {
     _groupAs = value;
@@ -463,7 +469,8 @@ public class FieldReference implements IBoundObject {
    * Get the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @return the remarks value, or {@code null} if not set
    */
@@ -476,10 +483,11 @@ public class FieldReference implements IBoundObject {
    * Set the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @param value
-   *           the remarks value to set
+   *          the remarks value to set, or {@code null} to clear
    */
   public void setRemarks(@Nullable Remarks value) {
     _remarks = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FlagAllowedValues.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FlagAllowedValues.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -34,16 +35,14 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @MetaschemaAssembly(
     formalName = "Allowed Values Constraint",
     name = "flag-allowed-values",
-    moduleClass = MetaschemaModelModule.class
-)
+    moduleClass = MetaschemaModelModule.class)
 public class FlagAllowedValues implements IBoundObject, IConstraintBase {
   private final IMetaschemaData __metaschemaData;
 
   @BoundFlag(
       formalName = "Constraint Identifier",
       name = "id",
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _id;
 
   @BoundFlag(
@@ -51,8 +50,17 @@ public class FlagAllowedValues implements IBoundObject, IConstraintBase {
       name = "level",
       defaultValue = "ERROR",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "CRITICAL", description = "A violation of the constraint represents a serious fault in the content that will prevent typical use of the content."), @AllowedValue(value = "ERROR", description = "A violation of the constraint represents a fault in the content. This may include issues around compatibility, integrity, consistency, etc."), @AllowedValue(value = "WARNING", description = "A violation of the constraint represents a potential issue with the content."), @AllowedValue(value = "INFORMATIONAL", description = "A violation of the constraint represents a point of interest."), @AllowedValue(value = "DEBUG", description = "A violation of the constraint represents a fault in the content that may warrant review by a developer when performing model or tool development.")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {
+          @AllowedValue(value = "CRITICAL",
+              description = "A violation of the constraint represents a serious fault in the content that will prevent typical use of the content."),
+          @AllowedValue(value = "ERROR",
+              description = "A violation of the constraint represents a fault in the content. This may include issues around compatibility, integrity, consistency, etc."),
+          @AllowedValue(value = "WARNING",
+              description = "A violation of the constraint represents a potential issue with the content."),
+          @AllowedValue(value = "INFORMATIONAL",
+              description = "A violation of the constraint represents a point of interest."),
+          @AllowedValue(value = "DEBUG",
+              description = "A violation of the constraint represents a fault in the content that may warrant review by a developer when performing model or tool development.") })))
   private String _level;
 
   @BoundFlag(
@@ -60,12 +68,14 @@ public class FlagAllowedValues implements IBoundObject, IConstraintBase {
       name = "allow-other",
       defaultValue = "no",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "no", description = "Other value are not allowed."), @AllowedValue(value = "yes", description = "Other values are allowed.")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR,
+          values = { @AllowedValue(value = "no", description = "Other value are not allowed."),
+              @AllowedValue(value = "yes", description = "Other values are allowed.") })))
   private String _allowOther;
 
   /**
-   * Determines if the given enumerated values may be extended by other allowed value constraints.
+   * Determines if the given enumerated values may be extended by other allowed
+   * value constraints.
    */
   @BoundFlag(
       formalName = "Allow Extension?",
@@ -73,8 +83,11 @@ public class FlagAllowedValues implements IBoundObject, IConstraintBase {
       name = "extensible",
       defaultValue = "external",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "model", description = "Can be extended by constraints within the same module."), @AllowedValue(value = "external", description = "Can be extended by external constraints."), @AllowedValue(value = "none", description = "Cannot be extended.")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR,
+          values = {
+              @AllowedValue(value = "model", description = "Can be extended by constraints within the same module."),
+              @AllowedValue(value = "external", description = "Can be extended by external constraints."),
+              @AllowedValue(value = "none", description = "Cannot be extended.") })))
   private String _extensible;
 
   /**
@@ -84,27 +97,25 @@ public class FlagAllowedValues implements IBoundObject, IConstraintBase {
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
       useName = "formal-name",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   /**
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    */
   @BoundField(
       formalName = "Description",
       description = "A short description of the data construct's purpose, describing the constructs semantics.",
       useName = "description",
-      typeAdapter = MarkupLineAdapter.class
-  )
+      typeAdapter = MarkupLineAdapter.class)
   private MarkupLine _description;
 
   @BoundAssembly(
       formalName = "Property",
       useName = "prop",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST))
   private List<Property> _props;
 
   @BoundField(
@@ -112,32 +123,35 @@ public class FlagAllowedValues implements IBoundObject, IConstraintBase {
       useName = "enum",
       minOccurs = 1,
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "enums", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "enums", inJson = JsonGroupAsBehavior.LIST))
   private List<ConstraintValueEnum> _enums;
 
   /**
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    */
   @BoundField(
       formalName = "Remarks",
       description = "Any explanatory or helpful information to be provided about the remarks parent.",
-      useName = "remarks"
-  )
+      useName = "remarks")
   private Remarks _remarks;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FlagAllowedValues} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FlagAllowedValues}
+   * instance with no metadata.
    */
   public FlagAllowedValues() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FlagAllowedValues} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FlagAllowedValues}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public FlagAllowedValues(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -163,7 +177,7 @@ public class FlagAllowedValues implements IBoundObject, IConstraintBase {
    * Set the constraint Identifier.
    *
    * @param value
-   *           the id value to set
+   *          the id value to set, or {@code null} to clear
    */
   public void setId(@Nullable String value) {
     _id = value;
@@ -184,7 +198,7 @@ public class FlagAllowedValues implements IBoundObject, IConstraintBase {
    * Set the constraint Severity Level.
    *
    * @param value
-   *           the level value to set
+   *          the level value to set, or {@code null} to clear
    */
   public void setLevel(@Nullable String value) {
     _level = value;
@@ -204,7 +218,7 @@ public class FlagAllowedValues implements IBoundObject, IConstraintBase {
    * Set the allow Non-Enumerated Values?.
    *
    * @param value
-   *           the allow-other value to set
+   *          the allow-other value to set, or {@code null} to clear
    */
   public void setAllowOther(@Nullable String value) {
     _allowOther = value;
@@ -214,7 +228,8 @@ public class FlagAllowedValues implements IBoundObject, IConstraintBase {
    * Get the allow Extension?.
    *
    * <p>
-   * Determines if the given enumerated values may be extended by other allowed value constraints.
+   * Determines if the given enumerated values may be extended by other allowed
+   * value constraints.
    *
    * @return the extensible value, or {@code null} if not set
    */
@@ -227,10 +242,11 @@ public class FlagAllowedValues implements IBoundObject, IConstraintBase {
    * Set the allow Extension?.
    *
    * <p>
-   * Determines if the given enumerated values may be extended by other allowed value constraints.
+   * Determines if the given enumerated values may be extended by other allowed
+   * value constraints.
    *
    * @param value
-   *           the extensible value to set
+   *          the extensible value to set, or {@code null} to clear
    */
   public void setExtensible(@Nullable String value) {
     _extensible = value;
@@ -257,7 +273,7 @@ public class FlagAllowedValues implements IBoundObject, IConstraintBase {
    * A formal name for the data construct, to be presented in documentation.
    *
    * @param value
-   *           the formal-name value to set
+   *          the formal-name value to set, or {@code null} to clear
    */
   public void setFormalName(@Nullable String value) {
     _formalName = value;
@@ -267,7 +283,8 @@ public class FlagAllowedValues implements IBoundObject, IConstraintBase {
    * Get the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @return the description value, or {@code null} if not set
    */
@@ -281,10 +298,11 @@ public class FlagAllowedValues implements IBoundObject, IConstraintBase {
    * Set the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @param value
-   *           the description value to set
+   *          the description value to set, or {@code null} to clear
    */
   public void setDescription(@Nullable MarkupLine value) {
     _description = value;
@@ -308,7 +326,7 @@ public class FlagAllowedValues implements IBoundObject, IConstraintBase {
    * Set the property.
    *
    * @param value
-   *           the prop value to set
+   *          the prop value to set
    */
   public void setProps(@NonNull List<Property> value) {
     _props = value;
@@ -316,11 +334,13 @@ public class FlagAllowedValues implements IBoundObject, IConstraintBase {
 
   /**
    * Add a new {@link Property} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_props == null) {
       _props = new LinkedList<>();
     }
@@ -328,12 +348,15 @@ public class FlagAllowedValues implements IBoundObject, IConstraintBase {
   }
 
   /**
-   * Remove the first matching {@link Property} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link Property} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _props != null && _props.remove(value);
   }
 
@@ -354,7 +377,7 @@ public class FlagAllowedValues implements IBoundObject, IConstraintBase {
    * Set the allowed Value Enumeration.
    *
    * @param value
-   *           the enum value to set
+   *          the enum value to set
    */
   public void setEnums(@NonNull List<ConstraintValueEnum> value) {
     _enums = value;
@@ -362,11 +385,13 @@ public class FlagAllowedValues implements IBoundObject, IConstraintBase {
 
   /**
    * Add a new {@link ConstraintValueEnum} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addEnum(ConstraintValueEnum item) {
-    ConstraintValueEnum value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    ConstraintValueEnum value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_enums == null) {
       _enums = new LinkedList<>();
     }
@@ -374,12 +399,15 @@ public class FlagAllowedValues implements IBoundObject, IConstraintBase {
   }
 
   /**
-   * Remove the first matching {@link ConstraintValueEnum} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link ConstraintValueEnum} item from the
+   * underlying collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeEnum(ConstraintValueEnum item) {
-    ConstraintValueEnum value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    ConstraintValueEnum value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _enums != null && _enums.remove(value);
   }
 
@@ -387,7 +415,8 @@ public class FlagAllowedValues implements IBoundObject, IConstraintBase {
    * Get the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @return the remarks value, or {@code null} if not set
    */
@@ -401,10 +430,11 @@ public class FlagAllowedValues implements IBoundObject, IConstraintBase {
    * Set the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @param value
-   *           the remarks value to set
+   *          the remarks value to set, or {@code null} to clear
    */
   public void setRemarks(@Nullable Remarks value) {
     _remarks = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FlagConstraints.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FlagConstraints.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -24,8 +25,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 
 @MetaschemaAssembly(
     name = "flag-constraints",
-    moduleClass = MetaschemaModelModule.class
-)
+    moduleClass = MetaschemaModelModule.class)
 public class FlagConstraints implements IValueConstraintsBase {
   private final IMetaschemaData __metaschemaData;
 
@@ -33,8 +33,7 @@ public class FlagConstraints implements IValueConstraintsBase {
       formalName = "Constraint Let Expression",
       useName = "let",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "lets", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "lets", inJson = JsonGroupAsBehavior.LIST))
   private List<ConstraintLetExpression> _lets;
 
   @BoundChoiceGroup(
@@ -42,27 +41,35 @@ public class FlagConstraints implements IValueConstraintsBase {
       maxOccurs = -1,
       groupAs = @GroupAs(name = "rules", inJson = JsonGroupAsBehavior.LIST),
       assemblies = {
-          @BoundGroupedAssembly(formalName = "Allowed Values Constraint", useName = "allowed-values", binding = FlagAllowedValues.class),
-          @BoundGroupedAssembly(formalName = "Expect Condition Constraint", useName = "expect", binding = FlagExpect.class),
-          @BoundGroupedAssembly(formalName = "Index Has Key Constraint", useName = "index-has-key", binding = FlagIndexHasKey.class),
-          @BoundGroupedAssembly(formalName = "Value Matches Constraint", useName = "matches", binding = FlagMatches.class),
-          @BoundGroupedAssembly(formalName = "Report Condition Constraint", useName = "report", binding = FlagReport.class)
-      }
-  )
+          @BoundGroupedAssembly(formalName = "Allowed Values Constraint", useName = "allowed-values",
+              binding = FlagAllowedValues.class),
+          @BoundGroupedAssembly(formalName = "Expect Condition Constraint", useName = "expect",
+              binding = FlagExpect.class),
+          @BoundGroupedAssembly(formalName = "Index Has Key Constraint", useName = "index-has-key",
+              binding = FlagIndexHasKey.class),
+          @BoundGroupedAssembly(formalName = "Value Matches Constraint", useName = "matches",
+              binding = FlagMatches.class),
+          @BoundGroupedAssembly(formalName = "Report Condition Constraint", useName = "report",
+              binding = FlagReport.class)
+      })
   private List<? extends IConstraintBase> _rules;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FlagConstraints} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FlagConstraints}
+   * instance with no metadata.
    */
   public FlagConstraints() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FlagConstraints} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FlagConstraints}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public FlagConstraints(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -91,7 +98,7 @@ public class FlagConstraints implements IValueConstraintsBase {
    * Set the constraint Let Expression.
    *
    * @param value
-   *           the let value to set
+   *          the let value to set
    */
   public void setLets(@NonNull List<ConstraintLetExpression> value) {
     _lets = value;
@@ -99,11 +106,13 @@ public class FlagConstraints implements IValueConstraintsBase {
 
   /**
    * Add a new {@link ConstraintLetExpression} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addLet(ConstraintLetExpression item) {
-    ConstraintLetExpression value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    ConstraintLetExpression value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_lets == null) {
       _lets = new LinkedList<>();
     }
@@ -111,12 +120,15 @@ public class FlagConstraints implements IValueConstraintsBase {
   }
 
   /**
-   * Remove the first matching {@link ConstraintLetExpression} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link ConstraintLetExpression} item from the
+   * underlying collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeLet(ConstraintLetExpression item) {
-    ConstraintLetExpression value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    ConstraintLetExpression value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _lets != null && _lets.remove(value);
   }
 
@@ -144,7 +156,7 @@ public class FlagConstraints implements IValueConstraintsBase {
    * Items in this collection must implement {@link IConstraintBase}.
    *
    * @param value
-   *           the rules items to set
+   *          the rules items to set
    */
   public void setRules(@NonNull List<? extends IConstraintBase> value) {
     _rules = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FlagExpect.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FlagExpect.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -34,16 +35,14 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @MetaschemaAssembly(
     formalName = "Expect Condition Constraint",
     name = "flag-expect",
-    moduleClass = MetaschemaModelModule.class
-)
+    moduleClass = MetaschemaModelModule.class)
 public class FlagExpect implements IBoundObject, IConfigurableMessageConstraintBase {
   private final IMetaschemaData __metaschemaData;
 
   @BoundFlag(
       formalName = "Constraint Identifier",
       name = "id",
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _id;
 
   @BoundFlag(
@@ -51,16 +50,24 @@ public class FlagExpect implements IBoundObject, IConfigurableMessageConstraintB
       name = "level",
       defaultValue = "ERROR",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "CRITICAL", description = "A violation of the constraint represents a serious fault in the content that will prevent typical use of the content."), @AllowedValue(value = "ERROR", description = "A violation of the constraint represents a fault in the content. This may include issues around compatibility, integrity, consistency, etc."), @AllowedValue(value = "WARNING", description = "A violation of the constraint represents a potential issue with the content."), @AllowedValue(value = "INFORMATIONAL", description = "A violation of the constraint represents a point of interest."), @AllowedValue(value = "DEBUG", description = "A violation of the constraint represents a fault in the content that may warrant review by a developer when performing model or tool development.")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {
+          @AllowedValue(value = "CRITICAL",
+              description = "A violation of the constraint represents a serious fault in the content that will prevent typical use of the content."),
+          @AllowedValue(value = "ERROR",
+              description = "A violation of the constraint represents a fault in the content. This may include issues around compatibility, integrity, consistency, etc."),
+          @AllowedValue(value = "WARNING",
+              description = "A violation of the constraint represents a potential issue with the content."),
+          @AllowedValue(value = "INFORMATIONAL",
+              description = "A violation of the constraint represents a point of interest."),
+          @AllowedValue(value = "DEBUG",
+              description = "A violation of the constraint represents a fault in the content that may warrant review by a developer when performing model or tool development.") })))
   private String _level;
 
   @BoundFlag(
       formalName = "Expect Test Condition",
       name = "test",
       required = true,
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _test;
 
   /**
@@ -70,58 +77,59 @@ public class FlagExpect implements IBoundObject, IConfigurableMessageConstraintB
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
       useName = "formal-name",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   /**
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    */
   @BoundField(
       formalName = "Description",
       description = "A short description of the data construct's purpose, describing the constructs semantics.",
       useName = "description",
-      typeAdapter = MarkupLineAdapter.class
-  )
+      typeAdapter = MarkupLineAdapter.class)
   private MarkupLine _description;
 
   @BoundAssembly(
       formalName = "Property",
       useName = "prop",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST))
   private List<Property> _props;
 
   @BoundField(
       formalName = "Constraint Condition Violation Message",
       useName = "message",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _message;
 
   /**
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    */
   @BoundField(
       formalName = "Remarks",
       description = "Any explanatory or helpful information to be provided about the remarks parent.",
-      useName = "remarks"
-  )
+      useName = "remarks")
   private Remarks _remarks;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FlagExpect} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FlagExpect}
+   * instance with no metadata.
    */
   public FlagExpect() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FlagExpect} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FlagExpect}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public FlagExpect(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -147,7 +155,7 @@ public class FlagExpect implements IBoundObject, IConfigurableMessageConstraintB
    * Set the constraint Identifier.
    *
    * @param value
-   *           the id value to set
+   *          the id value to set, or {@code null} to clear
    */
   public void setId(@Nullable String value) {
     _id = value;
@@ -168,7 +176,7 @@ public class FlagExpect implements IBoundObject, IConfigurableMessageConstraintB
    * Set the constraint Severity Level.
    *
    * @param value
-   *           the level value to set
+   *          the level value to set, or {@code null} to clear
    */
   public void setLevel(@Nullable String value) {
     _level = value;
@@ -188,7 +196,7 @@ public class FlagExpect implements IBoundObject, IConfigurableMessageConstraintB
    * Set the expect Test Condition.
    *
    * @param value
-   *           the test value to set
+   *          the test value to set
    */
   public void setTest(@NonNull String value) {
     _test = value;
@@ -215,7 +223,7 @@ public class FlagExpect implements IBoundObject, IConfigurableMessageConstraintB
    * A formal name for the data construct, to be presented in documentation.
    *
    * @param value
-   *           the formal-name value to set
+   *          the formal-name value to set, or {@code null} to clear
    */
   public void setFormalName(@Nullable String value) {
     _formalName = value;
@@ -225,7 +233,8 @@ public class FlagExpect implements IBoundObject, IConfigurableMessageConstraintB
    * Get the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @return the description value, or {@code null} if not set
    */
@@ -239,10 +248,11 @@ public class FlagExpect implements IBoundObject, IConfigurableMessageConstraintB
    * Set the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @param value
-   *           the description value to set
+   *          the description value to set, or {@code null} to clear
    */
   public void setDescription(@Nullable MarkupLine value) {
     _description = value;
@@ -266,7 +276,7 @@ public class FlagExpect implements IBoundObject, IConfigurableMessageConstraintB
    * Set the property.
    *
    * @param value
-   *           the prop value to set
+   *          the prop value to set
    */
   public void setProps(@NonNull List<Property> value) {
     _props = value;
@@ -274,11 +284,13 @@ public class FlagExpect implements IBoundObject, IConfigurableMessageConstraintB
 
   /**
    * Add a new {@link Property} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_props == null) {
       _props = new LinkedList<>();
     }
@@ -286,12 +298,15 @@ public class FlagExpect implements IBoundObject, IConfigurableMessageConstraintB
   }
 
   /**
-   * Remove the first matching {@link Property} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link Property} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _props != null && _props.remove(value);
   }
 
@@ -310,7 +325,7 @@ public class FlagExpect implements IBoundObject, IConfigurableMessageConstraintB
    * Set the constraint Condition Violation Message.
    *
    * @param value
-   *           the message value to set
+   *          the message value to set, or {@code null} to clear
    */
   public void setMessage(@Nullable String value) {
     _message = value;
@@ -320,7 +335,8 @@ public class FlagExpect implements IBoundObject, IConfigurableMessageConstraintB
    * Get the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @return the remarks value, or {@code null} if not set
    */
@@ -334,10 +350,11 @@ public class FlagExpect implements IBoundObject, IConfigurableMessageConstraintB
    * Set the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @param value
-   *           the remarks value to set
+   *          the remarks value to set, or {@code null} to clear
    */
   public void setRemarks(@Nullable Remarks value) {
     _remarks = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FlagIndexHasKey.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FlagIndexHasKey.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -34,16 +35,14 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @MetaschemaAssembly(
     formalName = "Index Has Key Constraint",
     name = "flag-index-has-key",
-    moduleClass = MetaschemaModelModule.class
-)
+    moduleClass = MetaschemaModelModule.class)
 public class FlagIndexHasKey implements IBoundObject, IConfigurableMessageConstraintBase {
   private final IMetaschemaData __metaschemaData;
 
   @BoundFlag(
       formalName = "Constraint Identifier",
       name = "id",
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _id;
 
   @BoundFlag(
@@ -51,16 +50,24 @@ public class FlagIndexHasKey implements IBoundObject, IConfigurableMessageConstr
       name = "level",
       defaultValue = "ERROR",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "CRITICAL", description = "A violation of the constraint represents a serious fault in the content that will prevent typical use of the content."), @AllowedValue(value = "ERROR", description = "A violation of the constraint represents a fault in the content. This may include issues around compatibility, integrity, consistency, etc."), @AllowedValue(value = "WARNING", description = "A violation of the constraint represents a potential issue with the content."), @AllowedValue(value = "INFORMATIONAL", description = "A violation of the constraint represents a point of interest."), @AllowedValue(value = "DEBUG", description = "A violation of the constraint represents a fault in the content that may warrant review by a developer when performing model or tool development.")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {
+          @AllowedValue(value = "CRITICAL",
+              description = "A violation of the constraint represents a serious fault in the content that will prevent typical use of the content."),
+          @AllowedValue(value = "ERROR",
+              description = "A violation of the constraint represents a fault in the content. This may include issues around compatibility, integrity, consistency, etc."),
+          @AllowedValue(value = "WARNING",
+              description = "A violation of the constraint represents a potential issue with the content."),
+          @AllowedValue(value = "INFORMATIONAL",
+              description = "A violation of the constraint represents a point of interest."),
+          @AllowedValue(value = "DEBUG",
+              description = "A violation of the constraint represents a fault in the content that may warrant review by a developer when performing model or tool development.") })))
   private String _level;
 
   @BoundFlag(
       formalName = "Index Name",
       name = "name",
       required = true,
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _name;
 
   /**
@@ -70,27 +77,25 @@ public class FlagIndexHasKey implements IBoundObject, IConfigurableMessageConstr
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
       useName = "formal-name",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   /**
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    */
   @BoundField(
       formalName = "Description",
       description = "A short description of the data construct's purpose, describing the constructs semantics.",
       useName = "description",
-      typeAdapter = MarkupLineAdapter.class
-  )
+      typeAdapter = MarkupLineAdapter.class)
   private MarkupLine _description;
 
   @BoundAssembly(
       formalName = "Property",
       useName = "prop",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST))
   private List<Property> _props;
 
   @BoundAssembly(
@@ -98,39 +103,41 @@ public class FlagIndexHasKey implements IBoundObject, IConfigurableMessageConstr
       useName = "key-field",
       minOccurs = 1,
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "key-fields", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "key-fields", inJson = JsonGroupAsBehavior.LIST))
   private List<KeyConstraintField> _keyFields;
 
   @BoundField(
       formalName = "Constraint Condition Violation Message",
       useName = "message",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _message;
 
   /**
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    */
   @BoundField(
       formalName = "Remarks",
       description = "Any explanatory or helpful information to be provided about the remarks parent.",
-      useName = "remarks"
-  )
+      useName = "remarks")
   private Remarks _remarks;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FlagIndexHasKey} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FlagIndexHasKey}
+   * instance with no metadata.
    */
   public FlagIndexHasKey() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FlagIndexHasKey} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FlagIndexHasKey}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public FlagIndexHasKey(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -156,7 +163,7 @@ public class FlagIndexHasKey implements IBoundObject, IConfigurableMessageConstr
    * Set the constraint Identifier.
    *
    * @param value
-   *           the id value to set
+   *          the id value to set, or {@code null} to clear
    */
   public void setId(@Nullable String value) {
     _id = value;
@@ -177,7 +184,7 @@ public class FlagIndexHasKey implements IBoundObject, IConfigurableMessageConstr
    * Set the constraint Severity Level.
    *
    * @param value
-   *           the level value to set
+   *          the level value to set, or {@code null} to clear
    */
   public void setLevel(@Nullable String value) {
     _level = value;
@@ -197,7 +204,7 @@ public class FlagIndexHasKey implements IBoundObject, IConfigurableMessageConstr
    * Set the index Name.
    *
    * @param value
-   *           the name value to set
+   *          the name value to set
    */
   public void setName(@NonNull String value) {
     _name = value;
@@ -224,7 +231,7 @@ public class FlagIndexHasKey implements IBoundObject, IConfigurableMessageConstr
    * A formal name for the data construct, to be presented in documentation.
    *
    * @param value
-   *           the formal-name value to set
+   *          the formal-name value to set, or {@code null} to clear
    */
   public void setFormalName(@Nullable String value) {
     _formalName = value;
@@ -234,7 +241,8 @@ public class FlagIndexHasKey implements IBoundObject, IConfigurableMessageConstr
    * Get the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @return the description value, or {@code null} if not set
    */
@@ -248,10 +256,11 @@ public class FlagIndexHasKey implements IBoundObject, IConfigurableMessageConstr
    * Set the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @param value
-   *           the description value to set
+   *          the description value to set, or {@code null} to clear
    */
   public void setDescription(@Nullable MarkupLine value) {
     _description = value;
@@ -275,7 +284,7 @@ public class FlagIndexHasKey implements IBoundObject, IConfigurableMessageConstr
    * Set the property.
    *
    * @param value
-   *           the prop value to set
+   *          the prop value to set
    */
   public void setProps(@NonNull List<Property> value) {
     _props = value;
@@ -283,11 +292,13 @@ public class FlagIndexHasKey implements IBoundObject, IConfigurableMessageConstr
 
   /**
    * Add a new {@link Property} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_props == null) {
       _props = new LinkedList<>();
     }
@@ -295,12 +306,15 @@ public class FlagIndexHasKey implements IBoundObject, IConfigurableMessageConstr
   }
 
   /**
-   * Remove the first matching {@link Property} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link Property} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _props != null && _props.remove(value);
   }
 
@@ -321,7 +335,7 @@ public class FlagIndexHasKey implements IBoundObject, IConfigurableMessageConstr
    * Set the key Constraint Field.
    *
    * @param value
-   *           the key-field value to set
+   *          the key-field value to set
    */
   public void setKeyFields(@NonNull List<KeyConstraintField> value) {
     _keyFields = value;
@@ -329,11 +343,13 @@ public class FlagIndexHasKey implements IBoundObject, IConfigurableMessageConstr
 
   /**
    * Add a new {@link KeyConstraintField} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addKeyField(KeyConstraintField item) {
-    KeyConstraintField value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    KeyConstraintField value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_keyFields == null) {
       _keyFields = new LinkedList<>();
     }
@@ -341,12 +357,15 @@ public class FlagIndexHasKey implements IBoundObject, IConfigurableMessageConstr
   }
 
   /**
-   * Remove the first matching {@link KeyConstraintField} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link KeyConstraintField} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeKeyField(KeyConstraintField item) {
-    KeyConstraintField value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    KeyConstraintField value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _keyFields != null && _keyFields.remove(value);
   }
 
@@ -365,7 +384,7 @@ public class FlagIndexHasKey implements IBoundObject, IConfigurableMessageConstr
    * Set the constraint Condition Violation Message.
    *
    * @param value
-   *           the message value to set
+   *          the message value to set, or {@code null} to clear
    */
   public void setMessage(@Nullable String value) {
     _message = value;
@@ -375,7 +394,8 @@ public class FlagIndexHasKey implements IBoundObject, IConfigurableMessageConstr
    * Get the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @return the remarks value, or {@code null} if not set
    */
@@ -389,10 +409,11 @@ public class FlagIndexHasKey implements IBoundObject, IConfigurableMessageConstr
    * Set the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @param value
-   *           the remarks value to set
+   *          the remarks value to set, or {@code null} to clear
    */
   public void setRemarks(@Nullable Remarks value) {
     _remarks = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FlagMatches.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FlagMatches.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -34,16 +35,14 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @MetaschemaAssembly(
     formalName = "Value Matches Constraint",
     name = "flag-matches",
-    moduleClass = MetaschemaModelModule.class
-)
+    moduleClass = MetaschemaModelModule.class)
 public class FlagMatches implements IBoundObject, IConfigurableMessageConstraintBase {
   private final IMetaschemaData __metaschemaData;
 
   @BoundFlag(
       formalName = "Constraint Identifier",
       name = "id",
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _id;
 
   @BoundFlag(
@@ -51,23 +50,89 @@ public class FlagMatches implements IBoundObject, IConfigurableMessageConstraint
       name = "level",
       defaultValue = "ERROR",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "CRITICAL", description = "A violation of the constraint represents a serious fault in the content that will prevent typical use of the content."), @AllowedValue(value = "ERROR", description = "A violation of the constraint represents a fault in the content. This may include issues around compatibility, integrity, consistency, etc."), @AllowedValue(value = "WARNING", description = "A violation of the constraint represents a potential issue with the content."), @AllowedValue(value = "INFORMATIONAL", description = "A violation of the constraint represents a point of interest."), @AllowedValue(value = "DEBUG", description = "A violation of the constraint represents a fault in the content that may warrant review by a developer when performing model or tool development.")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {
+          @AllowedValue(value = "CRITICAL",
+              description = "A violation of the constraint represents a serious fault in the content that will prevent typical use of the content."),
+          @AllowedValue(value = "ERROR",
+              description = "A violation of the constraint represents a fault in the content. This may include issues around compatibility, integrity, consistency, etc."),
+          @AllowedValue(value = "WARNING",
+              description = "A violation of the constraint represents a potential issue with the content."),
+          @AllowedValue(value = "INFORMATIONAL",
+              description = "A violation of the constraint represents a point of interest."),
+          @AllowedValue(value = "DEBUG",
+              description = "A violation of the constraint represents a fault in the content that may warrant review by a developer when performing model or tool development.") })))
   private String _level;
 
   @BoundFlag(
       formalName = "Matches Regular Expression",
       name = "regex",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _regex;
 
   @BoundFlag(
       formalName = "Matches Data Type",
       name = "datatype",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, allowOthers = true, values = {@AllowedValue(value = "base64", description = "The [base64](https://framework.metaschema.dev/specification/datatypes/#base64) data type."), @AllowedValue(value = "boolean", description = "The [boolean](https://framework.metaschema.dev/specification/datatypes/#boolean) data type."), @AllowedValue(value = "date", description = "The [date](https://framework.metaschema.dev/specification/datatypes/#date) data type."), @AllowedValue(value = "date-time", description = "The [date-time](https://framework.metaschema.dev/specification/datatypes/#date-time) data type."), @AllowedValue(value = "date-time-with-timezone", description = "The [date-time-with-timezone](https://framework.metaschema.dev/specification/datatypes/#date-time-with-timezone) data type."), @AllowedValue(value = "date-with-timezone", description = "The [date-with-timezone](https://framework.metaschema.dev/specification/datatypes/#date-with-timezone) data type."), @AllowedValue(value = "day-time-duration", description = "The [day-time-duration](https://framework.metaschema.dev/specification/datatypes/#day-time-duration) data type."), @AllowedValue(value = "decimal", description = "The [decimal](https://framework.metaschema.dev/specification/datatypes/#decimal) data type."), @AllowedValue(value = "email-address", description = "The [email-address](https://framework.metaschema.dev/specification/datatypes/#email-address) data type."), @AllowedValue(value = "hostname", description = "The [hostname](https://framework.metaschema.dev/specification/datatypes/#hostname) data type."), @AllowedValue(value = "integer", description = "The [integer](https://framework.metaschema.dev/specification/datatypes/#integer) data type."), @AllowedValue(value = "ip-v4-address", description = "The [ip-v4-address](https://framework.metaschema.dev/specification/datatypes/#ip-v4-address) data type."), @AllowedValue(value = "ip-v6-address", description = "The [ip-v6-address](https://framework.metaschema.dev/specification/datatypes/#ip-v6-address) data type."), @AllowedValue(value = "non-negative-integer", description = "The [non-negative-integer](https://framework.metaschema.dev/specification/datatypes/#non-negative-integer) data type."), @AllowedValue(value = "positive-integer", description = "The [positive-integer](https://framework.metaschema.dev/specification/datatypes/#positive-integer) data type."), @AllowedValue(value = "string", description = "The [string](https://framework.metaschema.dev/specification/datatypes/#string) data type."), @AllowedValue(value = "token", description = "The [token](https://framework.metaschema.dev/specification/datatypes/#token) data type."), @AllowedValue(value = "uri", description = "The [uri](https://framework.metaschema.dev/specification/datatypes/#uri) data type."), @AllowedValue(value = "uri-reference", description = "The [uri-reference](https://framework.metaschema.dev/specification/datatypes/#uri-reference) data type."), @AllowedValue(value = "uuid", description = "The [uuid](https://framework.metaschema.dev/specification/datatypes/#uuid) data type."), @AllowedValue(value = "base64Binary", description = "An old name which is deprecated for use in favor of the 'base64' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "dateTime", description = "An old name which is deprecated for use in favor of the 'date-time' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "dateTime-with-timezone", description = "An old name which is deprecated for use in favor of the 'date-time-with-timezone' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "email", description = "An old name which is deprecated for use in favor of the 'email-address' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "nonNegativeInteger", description = "An old name which is deprecated for use in favor of the 'non-negative-integer' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "positiveInteger", description = "An old name which is deprecated for use in favor of the 'positive-integer' data type.", deprecatedVersion = "1.0.0")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR,
+          allowOthers = true,
+          values = { @AllowedValue(value = "base64",
+              description = "The [base64](https://framework.metaschema.dev/specification/datatypes/#base64) data type."),
+              @AllowedValue(value = "boolean",
+                  description = "The [boolean](https://framework.metaschema.dev/specification/datatypes/#boolean) data type."),
+              @AllowedValue(value = "date",
+                  description = "The [date](https://framework.metaschema.dev/specification/datatypes/#date) data type."),
+              @AllowedValue(value = "date-time",
+                  description = "The [date-time](https://framework.metaschema.dev/specification/datatypes/#date-time) data type."),
+              @AllowedValue(value = "date-time-with-timezone",
+                  description = "The [date-time-with-timezone](https://framework.metaschema.dev/specification/datatypes/#date-time-with-timezone) data type."),
+              @AllowedValue(value = "date-with-timezone",
+                  description = "The [date-with-timezone](https://framework.metaschema.dev/specification/datatypes/#date-with-timezone) data type."),
+              @AllowedValue(value = "day-time-duration",
+                  description = "The [day-time-duration](https://framework.metaschema.dev/specification/datatypes/#day-time-duration) data type."),
+              @AllowedValue(value = "decimal",
+                  description = "The [decimal](https://framework.metaschema.dev/specification/datatypes/#decimal) data type."),
+              @AllowedValue(value = "email-address",
+                  description = "The [email-address](https://framework.metaschema.dev/specification/datatypes/#email-address) data type."),
+              @AllowedValue(value = "hostname",
+                  description = "The [hostname](https://framework.metaschema.dev/specification/datatypes/#hostname) data type."),
+              @AllowedValue(value = "integer",
+                  description = "The [integer](https://framework.metaschema.dev/specification/datatypes/#integer) data type."),
+              @AllowedValue(value = "ip-v4-address",
+                  description = "The [ip-v4-address](https://framework.metaschema.dev/specification/datatypes/#ip-v4-address) data type."),
+              @AllowedValue(value = "ip-v6-address",
+                  description = "The [ip-v6-address](https://framework.metaschema.dev/specification/datatypes/#ip-v6-address) data type."),
+              @AllowedValue(value = "non-negative-integer",
+                  description = "The [non-negative-integer](https://framework.metaschema.dev/specification/datatypes/#non-negative-integer) data type."),
+              @AllowedValue(value = "positive-integer",
+                  description = "The [positive-integer](https://framework.metaschema.dev/specification/datatypes/#positive-integer) data type."),
+              @AllowedValue(value = "string",
+                  description = "The [string](https://framework.metaschema.dev/specification/datatypes/#string) data type."),
+              @AllowedValue(value = "token",
+                  description = "The [token](https://framework.metaschema.dev/specification/datatypes/#token) data type."),
+              @AllowedValue(value = "uri",
+                  description = "The [uri](https://framework.metaschema.dev/specification/datatypes/#uri) data type."),
+              @AllowedValue(value = "uri-reference",
+                  description = "The [uri-reference](https://framework.metaschema.dev/specification/datatypes/#uri-reference) data type."),
+              @AllowedValue(value = "uuid",
+                  description = "The [uuid](https://framework.metaschema.dev/specification/datatypes/#uuid) data type."),
+              @AllowedValue(value = "base64Binary",
+                  description = "An old name which is deprecated for use in favor of the 'base64' data type.",
+                  deprecatedVersion = "1.0.0"),
+              @AllowedValue(value = "dateTime",
+                  description = "An old name which is deprecated for use in favor of the 'date-time' data type.",
+                  deprecatedVersion = "1.0.0"),
+              @AllowedValue(value = "dateTime-with-timezone",
+                  description = "An old name which is deprecated for use in favor of the 'date-time-with-timezone' data type.",
+                  deprecatedVersion = "1.0.0"),
+              @AllowedValue(value = "email",
+                  description = "An old name which is deprecated for use in favor of the 'email-address' data type.",
+                  deprecatedVersion = "1.0.0"),
+              @AllowedValue(value = "nonNegativeInteger",
+                  description = "An old name which is deprecated for use in favor of the 'non-negative-integer' data type.",
+                  deprecatedVersion = "1.0.0"),
+              @AllowedValue(value = "positiveInteger",
+                  description = "An old name which is deprecated for use in favor of the 'positive-integer' data type.",
+                  deprecatedVersion = "1.0.0") })))
   private String _datatype;
 
   /**
@@ -77,58 +142,59 @@ public class FlagMatches implements IBoundObject, IConfigurableMessageConstraint
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
       useName = "formal-name",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   /**
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    */
   @BoundField(
       formalName = "Description",
       description = "A short description of the data construct's purpose, describing the constructs semantics.",
       useName = "description",
-      typeAdapter = MarkupLineAdapter.class
-  )
+      typeAdapter = MarkupLineAdapter.class)
   private MarkupLine _description;
 
   @BoundAssembly(
       formalName = "Property",
       useName = "prop",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST))
   private List<Property> _props;
 
   @BoundField(
       formalName = "Constraint Condition Violation Message",
       useName = "message",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _message;
 
   /**
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    */
   @BoundField(
       formalName = "Remarks",
       description = "Any explanatory or helpful information to be provided about the remarks parent.",
-      useName = "remarks"
-  )
+      useName = "remarks")
   private Remarks _remarks;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FlagMatches} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FlagMatches}
+   * instance with no metadata.
    */
   public FlagMatches() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FlagMatches} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FlagMatches}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public FlagMatches(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -154,7 +220,7 @@ public class FlagMatches implements IBoundObject, IConfigurableMessageConstraint
    * Set the constraint Identifier.
    *
    * @param value
-   *           the id value to set
+   *          the id value to set, or {@code null} to clear
    */
   public void setId(@Nullable String value) {
     _id = value;
@@ -175,7 +241,7 @@ public class FlagMatches implements IBoundObject, IConfigurableMessageConstraint
    * Set the constraint Severity Level.
    *
    * @param value
-   *           the level value to set
+   *          the level value to set, or {@code null} to clear
    */
   public void setLevel(@Nullable String value) {
     _level = value;
@@ -195,7 +261,7 @@ public class FlagMatches implements IBoundObject, IConfigurableMessageConstraint
    * Set the matches Regular Expression.
    *
    * @param value
-   *           the regex value to set
+   *          the regex value to set, or {@code null} to clear
    */
   public void setRegex(@Nullable String value) {
     _regex = value;
@@ -215,7 +281,7 @@ public class FlagMatches implements IBoundObject, IConfigurableMessageConstraint
    * Set the matches Data Type.
    *
    * @param value
-   *           the datatype value to set
+   *          the datatype value to set, or {@code null} to clear
    */
   public void setDatatype(@Nullable String value) {
     _datatype = value;
@@ -242,7 +308,7 @@ public class FlagMatches implements IBoundObject, IConfigurableMessageConstraint
    * A formal name for the data construct, to be presented in documentation.
    *
    * @param value
-   *           the formal-name value to set
+   *          the formal-name value to set, or {@code null} to clear
    */
   public void setFormalName(@Nullable String value) {
     _formalName = value;
@@ -252,7 +318,8 @@ public class FlagMatches implements IBoundObject, IConfigurableMessageConstraint
    * Get the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @return the description value, or {@code null} if not set
    */
@@ -266,10 +333,11 @@ public class FlagMatches implements IBoundObject, IConfigurableMessageConstraint
    * Set the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @param value
-   *           the description value to set
+   *          the description value to set, or {@code null} to clear
    */
   public void setDescription(@Nullable MarkupLine value) {
     _description = value;
@@ -293,7 +361,7 @@ public class FlagMatches implements IBoundObject, IConfigurableMessageConstraint
    * Set the property.
    *
    * @param value
-   *           the prop value to set
+   *          the prop value to set
    */
   public void setProps(@NonNull List<Property> value) {
     _props = value;
@@ -301,11 +369,13 @@ public class FlagMatches implements IBoundObject, IConfigurableMessageConstraint
 
   /**
    * Add a new {@link Property} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_props == null) {
       _props = new LinkedList<>();
     }
@@ -313,12 +383,15 @@ public class FlagMatches implements IBoundObject, IConfigurableMessageConstraint
   }
 
   /**
-   * Remove the first matching {@link Property} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link Property} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _props != null && _props.remove(value);
   }
 
@@ -337,7 +410,7 @@ public class FlagMatches implements IBoundObject, IConfigurableMessageConstraint
    * Set the constraint Condition Violation Message.
    *
    * @param value
-   *           the message value to set
+   *          the message value to set, or {@code null} to clear
    */
   public void setMessage(@Nullable String value) {
     _message = value;
@@ -347,7 +420,8 @@ public class FlagMatches implements IBoundObject, IConfigurableMessageConstraint
    * Get the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @return the remarks value, or {@code null} if not set
    */
@@ -361,10 +435,11 @@ public class FlagMatches implements IBoundObject, IConfigurableMessageConstraint
    * Set the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @param value
-   *           the remarks value to set
+   *          the remarks value to set, or {@code null} to clear
    */
   public void setRemarks(@Nullable Remarks value) {
     _remarks = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FlagReference.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FlagReference.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -35,8 +36,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @MetaschemaAssembly(
     formalName = "Flag Reference",
     name = "flag-reference",
-    moduleClass = MetaschemaModelModule.class
-)
+    moduleClass = MetaschemaModelModule.class)
 public class FlagReference implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
@@ -44,29 +44,25 @@ public class FlagReference implements IBoundObject {
       formalName = "Global Flag Reference",
       name = "ref",
       required = true,
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _ref;
 
   @BoundFlag(
       formalName = "Flag Reference Binary Name",
       name = "index",
-      typeAdapter = PositiveIntegerAdapter.class
-  )
+      typeAdapter = PositiveIntegerAdapter.class)
   private BigInteger _index;
 
   @BoundFlag(
       formalName = "Deprecated Version",
       name = "deprecated",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _deprecated;
 
   @BoundFlag(
       formalName = "Default Flag Value",
       name = "default",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _default;
 
   @BoundFlag(
@@ -74,8 +70,9 @@ public class FlagReference implements IBoundObject {
       name = "required",
       defaultValue = "no",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "yes", description = "The flag is required."), @AllowedValue(value = "no", description = "The flag is optional.")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR,
+          values = { @AllowedValue(value = "yes", description = "The flag is required."),
+              @AllowedValue(value = "no", description = "The flag is optional.") })))
   private String _required;
 
   /**
@@ -85,27 +82,25 @@ public class FlagReference implements IBoundObject {
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
       useName = "formal-name",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   /**
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    */
   @BoundField(
       formalName = "Description",
       description = "A short description of the data construct's purpose, describing the constructs semantics.",
       useName = "description",
-      typeAdapter = MarkupLineAdapter.class
-  )
+      typeAdapter = MarkupLineAdapter.class)
   private MarkupLine _description;
 
   @BoundAssembly(
       formalName = "Property",
       useName = "prop",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST))
   private List<Property> _props;
 
   /**
@@ -114,32 +109,35 @@ public class FlagReference implements IBoundObject {
   @BoundField(
       formalName = "Use Name",
       description = "Allows the name of the definition to be overridden.",
-      useName = "use-name"
-  )
+      useName = "use-name")
   private UseName _useName;
 
   /**
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    */
   @BoundField(
       formalName = "Remarks",
       description = "Any explanatory or helpful information to be provided about the remarks parent.",
-      useName = "remarks"
-  )
+      useName = "remarks")
   private Remarks _remarks;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FlagReference} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FlagReference}
+   * instance with no metadata.
    */
   public FlagReference() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FlagReference} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FlagReference}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public FlagReference(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -164,7 +162,7 @@ public class FlagReference implements IBoundObject {
    * Set the global Flag Reference.
    *
    * @param value
-   *           the ref value to set
+   *          the ref value to set
    */
   public void setRef(@NonNull String value) {
     _ref = value;
@@ -184,7 +182,7 @@ public class FlagReference implements IBoundObject {
    * Set the flag Reference Binary Name.
    *
    * @param value
-   *           the index value to set
+   *          the index value to set, or {@code null} to clear
    */
   public void setIndex(@Nullable BigInteger value) {
     _index = value;
@@ -204,7 +202,7 @@ public class FlagReference implements IBoundObject {
    * Set the deprecated Version.
    *
    * @param value
-   *           the deprecated value to set
+   *          the deprecated value to set, or {@code null} to clear
    */
   public void setDeprecated(@Nullable String value) {
     _deprecated = value;
@@ -224,7 +222,7 @@ public class FlagReference implements IBoundObject {
    * Set the default Flag Value.
    *
    * @param value
-   *           the default value to set
+   *          the default value to set, or {@code null} to clear
    */
   public void setDefault(@Nullable String value) {
     _default = value;
@@ -244,7 +242,7 @@ public class FlagReference implements IBoundObject {
    * Set the is Flag Required?.
    *
    * @param value
-   *           the required value to set
+   *          the required value to set, or {@code null} to clear
    */
   public void setRequired(@Nullable String value) {
     _required = value;
@@ -270,7 +268,7 @@ public class FlagReference implements IBoundObject {
    * A formal name for the data construct, to be presented in documentation.
    *
    * @param value
-   *           the formal-name value to set
+   *          the formal-name value to set, or {@code null} to clear
    */
   public void setFormalName(@Nullable String value) {
     _formalName = value;
@@ -280,7 +278,8 @@ public class FlagReference implements IBoundObject {
    * Get the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @return the description value, or {@code null} if not set
    */
@@ -293,10 +292,11 @@ public class FlagReference implements IBoundObject {
    * Set the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @param value
-   *           the description value to set
+   *          the description value to set, or {@code null} to clear
    */
   public void setDescription(@Nullable MarkupLine value) {
     _description = value;
@@ -319,7 +319,7 @@ public class FlagReference implements IBoundObject {
    * Set the property.
    *
    * @param value
-   *           the prop value to set
+   *          the prop value to set
    */
   public void setProps(@NonNull List<Property> value) {
     _props = value;
@@ -327,11 +327,13 @@ public class FlagReference implements IBoundObject {
 
   /**
    * Add a new {@link Property} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_props == null) {
       _props = new LinkedList<>();
     }
@@ -339,12 +341,15 @@ public class FlagReference implements IBoundObject {
   }
 
   /**
-   * Remove the first matching {@link Property} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link Property} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _props != null && _props.remove(value);
   }
 
@@ -368,7 +373,7 @@ public class FlagReference implements IBoundObject {
    * Allows the name of the definition to be overridden.
    *
    * @param value
-   *           the use-name value to set
+   *          the use-name value to set, or {@code null} to clear
    */
   public void setUseName(@Nullable UseName value) {
     _useName = value;
@@ -378,7 +383,8 @@ public class FlagReference implements IBoundObject {
    * Get the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @return the remarks value, or {@code null} if not set
    */
@@ -391,10 +397,11 @@ public class FlagReference implements IBoundObject {
    * Set the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @param value
-   *           the remarks value to set
+   *          the remarks value to set, or {@code null} to clear
    */
   public void setRemarks(@Nullable Remarks value) {
     _remarks = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FlagReport.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/FlagReport.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -34,16 +35,14 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @MetaschemaAssembly(
     formalName = "Report Condition Constraint",
     name = "flag-report",
-    moduleClass = MetaschemaModelModule.class
-)
+    moduleClass = MetaschemaModelModule.class)
 public class FlagReport implements IBoundObject, IConfigurableMessageConstraintBase {
   private final IMetaschemaData __metaschemaData;
 
   @BoundFlag(
       formalName = "Constraint Identifier",
       name = "id",
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _id;
 
   @BoundFlag(
@@ -51,16 +50,24 @@ public class FlagReport implements IBoundObject, IConfigurableMessageConstraintB
       name = "level",
       defaultValue = "ERROR",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "CRITICAL", description = "A violation of the constraint represents a serious fault in the content that will prevent typical use of the content."), @AllowedValue(value = "ERROR", description = "A violation of the constraint represents a fault in the content. This may include issues around compatibility, integrity, consistency, etc."), @AllowedValue(value = "WARNING", description = "A violation of the constraint represents a potential issue with the content."), @AllowedValue(value = "INFORMATIONAL", description = "A violation of the constraint represents a point of interest."), @AllowedValue(value = "DEBUG", description = "A violation of the constraint represents a fault in the content that may warrant review by a developer when performing model or tool development.")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {
+          @AllowedValue(value = "CRITICAL",
+              description = "A violation of the constraint represents a serious fault in the content that will prevent typical use of the content."),
+          @AllowedValue(value = "ERROR",
+              description = "A violation of the constraint represents a fault in the content. This may include issues around compatibility, integrity, consistency, etc."),
+          @AllowedValue(value = "WARNING",
+              description = "A violation of the constraint represents a potential issue with the content."),
+          @AllowedValue(value = "INFORMATIONAL",
+              description = "A violation of the constraint represents a point of interest."),
+          @AllowedValue(value = "DEBUG",
+              description = "A violation of the constraint represents a fault in the content that may warrant review by a developer when performing model or tool development.") })))
   private String _level;
 
   @BoundFlag(
       formalName = "Report Test Condition",
       name = "test",
       required = true,
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _test;
 
   /**
@@ -70,58 +77,59 @@ public class FlagReport implements IBoundObject, IConfigurableMessageConstraintB
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
       useName = "formal-name",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   /**
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    */
   @BoundField(
       formalName = "Description",
       description = "A short description of the data construct's purpose, describing the constructs semantics.",
       useName = "description",
-      typeAdapter = MarkupLineAdapter.class
-  )
+      typeAdapter = MarkupLineAdapter.class)
   private MarkupLine _description;
 
   @BoundAssembly(
       formalName = "Property",
       useName = "prop",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST))
   private List<Property> _props;
 
   @BoundField(
       formalName = "Constraint Condition Violation Message",
       useName = "message",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _message;
 
   /**
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    */
   @BoundField(
       formalName = "Remarks",
       description = "Any explanatory or helpful information to be provided about the remarks parent.",
-      useName = "remarks"
-  )
+      useName = "remarks")
   private Remarks _remarks;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FlagReport} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FlagReport}
+   * instance with no metadata.
    */
   public FlagReport() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FlagReport} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.FlagReport}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public FlagReport(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -147,7 +155,7 @@ public class FlagReport implements IBoundObject, IConfigurableMessageConstraintB
    * Set the constraint Identifier.
    *
    * @param value
-   *           the id value to set
+   *          the id value to set, or {@code null} to clear
    */
   public void setId(@Nullable String value) {
     _id = value;
@@ -168,7 +176,7 @@ public class FlagReport implements IBoundObject, IConfigurableMessageConstraintB
    * Set the constraint Severity Level.
    *
    * @param value
-   *           the level value to set
+   *          the level value to set, or {@code null} to clear
    */
   public void setLevel(@Nullable String value) {
     _level = value;
@@ -188,7 +196,7 @@ public class FlagReport implements IBoundObject, IConfigurableMessageConstraintB
    * Set the report Test Condition.
    *
    * @param value
-   *           the test value to set
+   *          the test value to set
    */
   public void setTest(@NonNull String value) {
     _test = value;
@@ -215,7 +223,7 @@ public class FlagReport implements IBoundObject, IConfigurableMessageConstraintB
    * A formal name for the data construct, to be presented in documentation.
    *
    * @param value
-   *           the formal-name value to set
+   *          the formal-name value to set, or {@code null} to clear
    */
   public void setFormalName(@Nullable String value) {
     _formalName = value;
@@ -225,7 +233,8 @@ public class FlagReport implements IBoundObject, IConfigurableMessageConstraintB
    * Get the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @return the description value, or {@code null} if not set
    */
@@ -239,10 +248,11 @@ public class FlagReport implements IBoundObject, IConfigurableMessageConstraintB
    * Set the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @param value
-   *           the description value to set
+   *          the description value to set, or {@code null} to clear
    */
   public void setDescription(@Nullable MarkupLine value) {
     _description = value;
@@ -266,7 +276,7 @@ public class FlagReport implements IBoundObject, IConfigurableMessageConstraintB
    * Set the property.
    *
    * @param value
-   *           the prop value to set
+   *          the prop value to set
    */
   public void setProps(@NonNull List<Property> value) {
     _props = value;
@@ -274,11 +284,13 @@ public class FlagReport implements IBoundObject, IConfigurableMessageConstraintB
 
   /**
    * Add a new {@link Property} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_props == null) {
       _props = new LinkedList<>();
     }
@@ -286,12 +298,15 @@ public class FlagReport implements IBoundObject, IConfigurableMessageConstraintB
   }
 
   /**
-   * Remove the first matching {@link Property} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link Property} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _props != null && _props.remove(value);
   }
 
@@ -310,7 +325,7 @@ public class FlagReport implements IBoundObject, IConfigurableMessageConstraintB
    * Set the constraint Condition Violation Message.
    *
    * @param value
-   *           the message value to set
+   *          the message value to set, or {@code null} to clear
    */
   public void setMessage(@Nullable String value) {
     _message = value;
@@ -320,7 +335,8 @@ public class FlagReport implements IBoundObject, IConfigurableMessageConstraintB
    * Get the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @return the remarks value, or {@code null} if not set
    */
@@ -334,10 +350,11 @@ public class FlagReport implements IBoundObject, IConfigurableMessageConstraintB
    * Set the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @param value
-   *           the remarks value to set
+   *          the remarks value to set, or {@code null} to clear
    */
   public void setRemarks(@Nullable Remarks value) {
     _remarks = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/GroupingAs.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/GroupingAs.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -24,8 +25,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @MetaschemaAssembly(
     formalName = "Group As",
     name = "group-as",
-    moduleClass = MetaschemaModelModule.class
-)
+    moduleClass = MetaschemaModelModule.class)
 public class GroupingAs implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
@@ -33,8 +33,7 @@ public class GroupingAs implements IBoundObject {
       formalName = "Grouping Name",
       name = "name",
       required = true,
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _name;
 
   @BoundFlag(
@@ -42,8 +41,12 @@ public class GroupingAs implements IBoundObject {
       name = "in-json",
       defaultValue = "SINGLETON_OR_ARRAY",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "ARRAY", description = "Always use an array."), @AllowedValue(value = "SINGLETON_OR_ARRAY", description = "Produce a singleton for a single member or an array for multiple members."), @AllowedValue(value = "BY_KEY", description = "For any group of one or more members, produce an object with properties for each member, using a designated flag for their property name values, which must be distinct.")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {
+          @AllowedValue(value = "ARRAY", description = "Always use an array."),
+          @AllowedValue(value = "SINGLETON_OR_ARRAY",
+              description = "Produce a singleton for a single member or an array for multiple members."),
+          @AllowedValue(value = "BY_KEY",
+              description = "For any group of one or more members, produce an object with properties for each member, using a designated flag for their property name values, which must be distinct.") })))
   private String _inJson;
 
   @BoundFlag(
@@ -51,22 +54,27 @@ public class GroupingAs implements IBoundObject {
       name = "in-xml",
       defaultValue = "UNGROUPED",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "GROUPED", description = "Use a wrapper element."), @AllowedValue(value = "UNGROUPED", description = "Do not use a wrapper element.")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR,
+          values = { @AllowedValue(value = "GROUPED", description = "Use a wrapper element."),
+              @AllowedValue(value = "UNGROUPED", description = "Do not use a wrapper element.") })))
   private String _inXml;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.GroupingAs} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.GroupingAs}
+   * instance with no metadata.
    */
   public GroupingAs() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.GroupingAs} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.GroupingAs}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public GroupingAs(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -91,7 +99,7 @@ public class GroupingAs implements IBoundObject {
    * Set the grouping Name.
    *
    * @param value
-   *           the name value to set
+   *          the name value to set
    */
   public void setName(@NonNull String value) {
     _name = value;
@@ -111,7 +119,7 @@ public class GroupingAs implements IBoundObject {
    * Set the in JSON Grouping Syntax.
    *
    * @param value
-   *           the in-json value to set
+   *          the in-json value to set, or {@code null} to clear
    */
   public void setInJson(@Nullable String value) {
     _inJson = value;
@@ -131,7 +139,7 @@ public class GroupingAs implements IBoundObject {
    * Set the in XML Grouping Syntax.
    *
    * @param value
-   *           the in-xml value to set
+   *          the in-xml value to set, or {@code null} to clear
    */
   public void setInXml(@Nullable String value) {
     _inXml = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/InlineDefineAssembly.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/InlineDefineAssembly.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -37,8 +38,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @MetaschemaAssembly(
     formalName = "Inline Assembly Definition",
     name = "inline-define-assembly",
-    moduleClass = MetaschemaModelModule.class
-)
+    moduleClass = MetaschemaModelModule.class)
 public class InlineDefineAssembly implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
@@ -46,30 +46,26 @@ public class InlineDefineAssembly implements IBoundObject {
       formalName = "Inline Assembly Name",
       name = "name",
       required = true,
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _name;
 
   @BoundFlag(
       formalName = "Inline Assembly Binary Name",
       name = "index",
-      typeAdapter = PositiveIntegerAdapter.class
-  )
+      typeAdapter = PositiveIntegerAdapter.class)
   private BigInteger _index;
 
   @BoundFlag(
       formalName = "Deprecated Version",
       name = "deprecated",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _deprecated;
 
   @BoundFlag(
       formalName = "Minimum Occurrence",
       name = "min-occurs",
       defaultValue = "0",
-      typeAdapter = NonNegativeIntegerAdapter.class
-  )
+      typeAdapter = NonNegativeIntegerAdapter.class)
   private BigInteger _minOccurs;
 
   @BoundFlag(
@@ -77,8 +73,8 @@ public class InlineDefineAssembly implements IBoundObject {
       name = "max-occurs",
       defaultValue = "1",
       typeAdapter = StringAdapter.class,
-      valueConstraints = @ValueConstraints(matches = @Matches(level = IConstraint.Level.ERROR, pattern = "^[1-9][0-9]*|unbounded$"))
-  )
+      valueConstraints = @ValueConstraints(
+          matches = @Matches(level = IConstraint.Level.ERROR, pattern = "^[1-9][0-9]*|unbounded$")))
   private String _maxOccurs;
 
   /**
@@ -88,95 +84,95 @@ public class InlineDefineAssembly implements IBoundObject {
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
       useName = "formal-name",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   /**
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    */
   @BoundField(
       formalName = "Description",
       description = "A short description of the data construct's purpose, describing the constructs semantics.",
       useName = "description",
-      typeAdapter = MarkupLineAdapter.class
-  )
+      typeAdapter = MarkupLineAdapter.class)
   private MarkupLine _description;
 
   @BoundAssembly(
       formalName = "Property",
       useName = "prop",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST))
   private List<Property> _props;
 
   /**
-   * Used in JSON (and similar formats) to identify a flag that will be used as the property name in an object hold a collection of sibling objects. Requires that siblings must never share <code>json-key</code> values.
+   * Used in JSON (and similar formats) to identify a flag that will be used as
+   * the property name in an object hold a collection of sibling objects. Requires
+   * that siblings must never share <code>json-key</code> values.
    */
   @BoundAssembly(
       formalName = "JSON Key",
       description = "Used in JSON (and similar formats) to identify a flag that will be used as the property name in an object hold a collection of sibling objects. Requires that siblings must never share `json-key` values.",
-      useName = "json-key"
-  )
+      useName = "json-key")
   private JsonKey _jsonKey;
 
   @BoundAssembly(
       formalName = "Group As",
-      useName = "group-as"
-  )
+      useName = "group-as")
   private GroupingAs _groupAs;
 
   @BoundChoiceGroup(
       maxOccurs = -1,
       groupAs = @GroupAs(name = "flags", inJson = JsonGroupAsBehavior.LIST),
       assemblies = {
-          @BoundGroupedAssembly(formalName = "Inline Flag Definition", useName = "define-flag", discriminatorValue = "flag", binding = InlineDefineFlag.class),
-          @BoundGroupedAssembly(formalName = "Flag Reference", useName = "flag", discriminatorValue = "flag-ref", binding = FlagReference.class)
-      }
-  )
+          @BoundGroupedAssembly(formalName = "Inline Flag Definition", useName = "define-flag",
+              discriminatorValue = "flag", binding = InlineDefineFlag.class),
+          @BoundGroupedAssembly(formalName = "Flag Reference", useName = "flag", discriminatorValue = "flag-ref",
+              binding = FlagReference.class)
+      })
   private List<Object> _flags;
 
   @BoundAssembly(
-      useName = "model"
-  )
+      useName = "model")
   private AssemblyModel _model;
 
   @BoundAssembly(
-      useName = "constraint"
-  )
+      useName = "constraint")
   private AssemblyConstraints _constraint;
 
   /**
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    */
   @BoundField(
       formalName = "Remarks",
       description = "Any explanatory or helpful information to be provided about the remarks parent.",
-      useName = "remarks"
-  )
+      useName = "remarks")
   private Remarks _remarks;
 
   @BoundAssembly(
       formalName = "Example",
       useName = "example",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "examples", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "examples", inJson = JsonGroupAsBehavior.LIST))
   private List<Example> _examples;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.InlineDefineAssembly} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.InlineDefineAssembly}
+   * instance with no metadata.
    */
   public InlineDefineAssembly() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.InlineDefineAssembly} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.InlineDefineAssembly}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public InlineDefineAssembly(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -201,7 +197,7 @@ public class InlineDefineAssembly implements IBoundObject {
    * Set the inline Assembly Name.
    *
    * @param value
-   *           the name value to set
+   *          the name value to set
    */
   public void setName(@NonNull String value) {
     _name = value;
@@ -221,7 +217,7 @@ public class InlineDefineAssembly implements IBoundObject {
    * Set the inline Assembly Binary Name.
    *
    * @param value
-   *           the index value to set
+   *          the index value to set, or {@code null} to clear
    */
   public void setIndex(@Nullable BigInteger value) {
     _index = value;
@@ -241,7 +237,7 @@ public class InlineDefineAssembly implements IBoundObject {
    * Set the deprecated Version.
    *
    * @param value
-   *           the deprecated value to set
+   *          the deprecated value to set, or {@code null} to clear
    */
   public void setDeprecated(@Nullable String value) {
     _deprecated = value;
@@ -261,7 +257,7 @@ public class InlineDefineAssembly implements IBoundObject {
    * Set the minimum Occurrence.
    *
    * @param value
-   *           the min-occurs value to set
+   *          the min-occurs value to set, or {@code null} to clear
    */
   public void setMinOccurs(@Nullable BigInteger value) {
     _minOccurs = value;
@@ -281,7 +277,7 @@ public class InlineDefineAssembly implements IBoundObject {
    * Set the maximum Occurrence.
    *
    * @param value
-   *           the max-occurs value to set
+   *          the max-occurs value to set, or {@code null} to clear
    */
   public void setMaxOccurs(@Nullable String value) {
     _maxOccurs = value;
@@ -307,7 +303,7 @@ public class InlineDefineAssembly implements IBoundObject {
    * A formal name for the data construct, to be presented in documentation.
    *
    * @param value
-   *           the formal-name value to set
+   *          the formal-name value to set, or {@code null} to clear
    */
   public void setFormalName(@Nullable String value) {
     _formalName = value;
@@ -317,7 +313,8 @@ public class InlineDefineAssembly implements IBoundObject {
    * Get the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @return the description value, or {@code null} if not set
    */
@@ -330,10 +327,11 @@ public class InlineDefineAssembly implements IBoundObject {
    * Set the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @param value
-   *           the description value to set
+   *          the description value to set, or {@code null} to clear
    */
   public void setDescription(@Nullable MarkupLine value) {
     _description = value;
@@ -356,7 +354,7 @@ public class InlineDefineAssembly implements IBoundObject {
    * Set the property.
    *
    * @param value
-   *           the prop value to set
+   *          the prop value to set
    */
   public void setProps(@NonNull List<Property> value) {
     _props = value;
@@ -364,11 +362,13 @@ public class InlineDefineAssembly implements IBoundObject {
 
   /**
    * Add a new {@link Property} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_props == null) {
       _props = new LinkedList<>();
     }
@@ -376,12 +376,15 @@ public class InlineDefineAssembly implements IBoundObject {
   }
 
   /**
-   * Remove the first matching {@link Property} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link Property} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _props != null && _props.remove(value);
   }
 
@@ -389,7 +392,9 @@ public class InlineDefineAssembly implements IBoundObject {
    * Get the jSON Key.
    *
    * <p>
-   * Used in JSON (and similar formats) to identify a flag that will be used as the property name in an object hold a collection of sibling objects. Requires that siblings must never share <code>json-key</code> values.
+   * Used in JSON (and similar formats) to identify a flag that will be used as
+   * the property name in an object hold a collection of sibling objects. Requires
+   * that siblings must never share <code>json-key</code> values.
    *
    * @return the json-key value, or {@code null} if not set
    */
@@ -402,10 +407,12 @@ public class InlineDefineAssembly implements IBoundObject {
    * Set the jSON Key.
    *
    * <p>
-   * Used in JSON (and similar formats) to identify a flag that will be used as the property name in an object hold a collection of sibling objects. Requires that siblings must never share <code>json-key</code> values.
+   * Used in JSON (and similar formats) to identify a flag that will be used as
+   * the property name in an object hold a collection of sibling objects. Requires
+   * that siblings must never share <code>json-key</code> values.
    *
    * @param value
-   *           the json-key value to set
+   *          the json-key value to set, or {@code null} to clear
    */
   public void setJsonKey(@Nullable JsonKey value) {
     _jsonKey = value;
@@ -425,7 +432,7 @@ public class InlineDefineAssembly implements IBoundObject {
    * Set the group As.
    *
    * @param value
-   *           the group-as value to set
+   *          the group-as value to set, or {@code null} to clear
    */
   public void setGroupAs(@Nullable GroupingAs value) {
     _groupAs = value;
@@ -448,7 +455,7 @@ public class InlineDefineAssembly implements IBoundObject {
    * Set the {@code flags} choice group items.
    *
    * @param value
-   *           the flags items to set
+   *          the flags items to set
    */
   public void setFlags(@NonNull List<Object> value) {
     _flags = value;
@@ -468,7 +475,7 @@ public class InlineDefineAssembly implements IBoundObject {
    * Set the {@code model} property.
    *
    * @param value
-   *           the model value to set
+   *          the model value to set, or {@code null} to clear
    */
   public void setModel(@Nullable AssemblyModel value) {
     _model = value;
@@ -488,7 +495,7 @@ public class InlineDefineAssembly implements IBoundObject {
    * Set the {@code constraint} property.
    *
    * @param value
-   *           the constraint value to set
+   *          the constraint value to set, or {@code null} to clear
    */
   public void setConstraint(@Nullable AssemblyConstraints value) {
     _constraint = value;
@@ -498,7 +505,8 @@ public class InlineDefineAssembly implements IBoundObject {
    * Get the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @return the remarks value, or {@code null} if not set
    */
@@ -511,10 +519,11 @@ public class InlineDefineAssembly implements IBoundObject {
    * Set the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @param value
-   *           the remarks value to set
+   *          the remarks value to set, or {@code null} to clear
    */
   public void setRemarks(@Nullable Remarks value) {
     _remarks = value;
@@ -537,7 +546,7 @@ public class InlineDefineAssembly implements IBoundObject {
    * Set the example.
    *
    * @param value
-   *           the example value to set
+   *          the example value to set
    */
   public void setExamples(@NonNull List<Example> value) {
     _examples = value;
@@ -545,11 +554,13 @@ public class InlineDefineAssembly implements IBoundObject {
 
   /**
    * Add a new {@link Example} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addExample(Example item) {
-    Example value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Example value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_examples == null) {
       _examples = new LinkedList<>();
     }
@@ -557,12 +568,15 @@ public class InlineDefineAssembly implements IBoundObject {
   }
 
   /**
-   * Remove the first matching {@link Example} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link Example} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeExample(Example item) {
-    Example value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Example value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _examples != null && _examples.remove(value);
   }
 

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/InlineDefineField.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/InlineDefineField.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -40,8 +41,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @MetaschemaAssembly(
     formalName = "Inline Field Definition",
     name = "inline-define-field",
-    moduleClass = MetaschemaModelModule.class
-)
+    moduleClass = MetaschemaModelModule.class)
 public class InlineDefineField implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
@@ -49,22 +49,19 @@ public class InlineDefineField implements IBoundObject {
       formalName = "Inline Field Name",
       name = "name",
       required = true,
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _name;
 
   @BoundFlag(
       formalName = "Inline Field Binary Name",
       name = "index",
-      typeAdapter = PositiveIntegerAdapter.class
-  )
+      typeAdapter = PositiveIntegerAdapter.class)
   private BigInteger _index;
 
   @BoundFlag(
       formalName = "Deprecated Version",
       name = "deprecated",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _deprecated;
 
   @BoundFlag(
@@ -72,23 +69,83 @@ public class InlineDefineField implements IBoundObject {
       name = "as-type",
       defaultValue = "string",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, allowOthers = true, values = {@AllowedValue(value = "markup-line", description = "The [markup-line](https://framework.metaschema.dev/specification/datatypes/#markup-line) data type."), @AllowedValue(value = "markup-multiline", description = "The [markup-multiline](https://framework.metaschema.dev/specification/datatypes/#markup-multiline) data type."), @AllowedValue(value = "base64", description = "The [base64](https://framework.metaschema.dev/specification/datatypes/#base64) data type."), @AllowedValue(value = "boolean", description = "The [boolean](https://framework.metaschema.dev/specification/datatypes/#boolean) data type."), @AllowedValue(value = "date", description = "The [date](https://framework.metaschema.dev/specification/datatypes/#date) data type."), @AllowedValue(value = "date-time", description = "The [date-time](https://framework.metaschema.dev/specification/datatypes/#date-time) data type."), @AllowedValue(value = "date-time-with-timezone", description = "The [date-time-with-timezone](https://framework.metaschema.dev/specification/datatypes/#date-time-with-timezone) data type."), @AllowedValue(value = "date-with-timezone", description = "The [date-with-timezone](https://framework.metaschema.dev/specification/datatypes/#date-with-timezone) data type."), @AllowedValue(value = "day-time-duration", description = "The [day-time-duration](https://framework.metaschema.dev/specification/datatypes/#day-time-duration) data type."), @AllowedValue(value = "decimal", description = "The [decimal](https://framework.metaschema.dev/specification/datatypes/#decimal) data type."), @AllowedValue(value = "email-address", description = "The [email-address](https://framework.metaschema.dev/specification/datatypes/#email-address) data type."), @AllowedValue(value = "hostname", description = "The [hostname](https://framework.metaschema.dev/specification/datatypes/#hostname) data type."), @AllowedValue(value = "integer", description = "The [integer](https://framework.metaschema.dev/specification/datatypes/#integer) data type."), @AllowedValue(value = "ip-v4-address", description = "The [ip-v4-address](https://framework.metaschema.dev/specification/datatypes/#ip-v4-address) data type."), @AllowedValue(value = "ip-v6-address", description = "The [ip-v6-address](https://framework.metaschema.dev/specification/datatypes/#ip-v6-address) data type."), @AllowedValue(value = "non-negative-integer", description = "The [non-negative-integer](https://framework.metaschema.dev/specification/datatypes/#non-negative-integer) data type."), @AllowedValue(value = "positive-integer", description = "The [positive-integer](https://framework.metaschema.dev/specification/datatypes/#positive-integer) data type."), @AllowedValue(value = "string", description = "The [string](https://framework.metaschema.dev/specification/datatypes/#string) data type."), @AllowedValue(value = "token", description = "The [token](https://framework.metaschema.dev/specification/datatypes/#token) data type."), @AllowedValue(value = "uri", description = "The [uri](https://framework.metaschema.dev/specification/datatypes/#uri) data type."), @AllowedValue(value = "uri-reference", description = "The [uri-reference](https://framework.metaschema.dev/specification/datatypes/#uri-reference) data type."), @AllowedValue(value = "uuid", description = "The [uuid](https://framework.metaschema.dev/specification/datatypes/#uuid) data type."), @AllowedValue(value = "base64Binary", description = "An old name which is deprecated for use in favor of the 'base64' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "dateTime", description = "An old name which is deprecated for use in favor of the 'date-time' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "dateTime-with-timezone", description = "An old name which is deprecated for use in favor of the 'date-time-with-timezone' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "email", description = "An old name which is deprecated for use in favor of the 'email-address' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "nonNegativeInteger", description = "An old name which is deprecated for use in favor of the 'non-negative-integer' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "positiveInteger", description = "An old name which is deprecated for use in favor of the 'positive-integer' data type.", deprecatedVersion = "1.0.0")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR,
+          allowOthers = true,
+          values = { @AllowedValue(value = "markup-line",
+              description = "The [markup-line](https://framework.metaschema.dev/specification/datatypes/#markup-line) data type."),
+              @AllowedValue(value = "markup-multiline",
+                  description = "The [markup-multiline](https://framework.metaschema.dev/specification/datatypes/#markup-multiline) data type."),
+              @AllowedValue(value = "base64",
+                  description = "The [base64](https://framework.metaschema.dev/specification/datatypes/#base64) data type."),
+              @AllowedValue(value = "boolean",
+                  description = "The [boolean](https://framework.metaschema.dev/specification/datatypes/#boolean) data type."),
+              @AllowedValue(value = "date",
+                  description = "The [date](https://framework.metaschema.dev/specification/datatypes/#date) data type."),
+              @AllowedValue(value = "date-time",
+                  description = "The [date-time](https://framework.metaschema.dev/specification/datatypes/#date-time) data type."),
+              @AllowedValue(value = "date-time-with-timezone",
+                  description = "The [date-time-with-timezone](https://framework.metaschema.dev/specification/datatypes/#date-time-with-timezone) data type."),
+              @AllowedValue(value = "date-with-timezone",
+                  description = "The [date-with-timezone](https://framework.metaschema.dev/specification/datatypes/#date-with-timezone) data type."),
+              @AllowedValue(value = "day-time-duration",
+                  description = "The [day-time-duration](https://framework.metaschema.dev/specification/datatypes/#day-time-duration) data type."),
+              @AllowedValue(value = "decimal",
+                  description = "The [decimal](https://framework.metaschema.dev/specification/datatypes/#decimal) data type."),
+              @AllowedValue(value = "email-address",
+                  description = "The [email-address](https://framework.metaschema.dev/specification/datatypes/#email-address) data type."),
+              @AllowedValue(value = "hostname",
+                  description = "The [hostname](https://framework.metaschema.dev/specification/datatypes/#hostname) data type."),
+              @AllowedValue(value = "integer",
+                  description = "The [integer](https://framework.metaschema.dev/specification/datatypes/#integer) data type."),
+              @AllowedValue(value = "ip-v4-address",
+                  description = "The [ip-v4-address](https://framework.metaschema.dev/specification/datatypes/#ip-v4-address) data type."),
+              @AllowedValue(value = "ip-v6-address",
+                  description = "The [ip-v6-address](https://framework.metaschema.dev/specification/datatypes/#ip-v6-address) data type."),
+              @AllowedValue(value = "non-negative-integer",
+                  description = "The [non-negative-integer](https://framework.metaschema.dev/specification/datatypes/#non-negative-integer) data type."),
+              @AllowedValue(value = "positive-integer",
+                  description = "The [positive-integer](https://framework.metaschema.dev/specification/datatypes/#positive-integer) data type."),
+              @AllowedValue(value = "string",
+                  description = "The [string](https://framework.metaschema.dev/specification/datatypes/#string) data type."),
+              @AllowedValue(value = "token",
+                  description = "The [token](https://framework.metaschema.dev/specification/datatypes/#token) data type."),
+              @AllowedValue(value = "uri",
+                  description = "The [uri](https://framework.metaschema.dev/specification/datatypes/#uri) data type."),
+              @AllowedValue(value = "uri-reference",
+                  description = "The [uri-reference](https://framework.metaschema.dev/specification/datatypes/#uri-reference) data type."),
+              @AllowedValue(value = "uuid",
+                  description = "The [uuid](https://framework.metaschema.dev/specification/datatypes/#uuid) data type."),
+              @AllowedValue(value = "base64Binary",
+                  description = "An old name which is deprecated for use in favor of the 'base64' data type.",
+                  deprecatedVersion = "1.0.0"),
+              @AllowedValue(value = "dateTime",
+                  description = "An old name which is deprecated for use in favor of the 'date-time' data type.",
+                  deprecatedVersion = "1.0.0"),
+              @AllowedValue(value = "dateTime-with-timezone",
+                  description = "An old name which is deprecated for use in favor of the 'date-time-with-timezone' data type.",
+                  deprecatedVersion = "1.0.0"),
+              @AllowedValue(value = "email",
+                  description = "An old name which is deprecated for use in favor of the 'email-address' data type.",
+                  deprecatedVersion = "1.0.0"),
+              @AllowedValue(value = "nonNegativeInteger",
+                  description = "An old name which is deprecated for use in favor of the 'non-negative-integer' data type.",
+                  deprecatedVersion = "1.0.0"),
+              @AllowedValue(value = "positiveInteger",
+                  description = "An old name which is deprecated for use in favor of the 'positive-integer' data type.",
+                  deprecatedVersion = "1.0.0") })))
   private String _asType;
 
   @BoundFlag(
       formalName = "Default Field Value",
       name = "default",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _default;
 
   @BoundFlag(
       formalName = "Minimum Occurrence",
       name = "min-occurs",
       defaultValue = "0",
-      typeAdapter = NonNegativeIntegerAdapter.class
-  )
+      typeAdapter = NonNegativeIntegerAdapter.class)
   private BigInteger _minOccurs;
 
   @BoundFlag(
@@ -96,8 +153,8 @@ public class InlineDefineField implements IBoundObject {
       name = "max-occurs",
       defaultValue = "1",
       typeAdapter = StringAdapter.class,
-      valueConstraints = @ValueConstraints(matches = @Matches(level = IConstraint.Level.ERROR, pattern = "^[1-9][0-9]*|unbounded$"))
-  )
+      valueConstraints = @ValueConstraints(
+          matches = @Matches(level = IConstraint.Level.ERROR, pattern = "^[1-9][0-9]*|unbounded$")))
   private String _maxOccurs;
 
   @BoundFlag(
@@ -105,8 +162,12 @@ public class InlineDefineField implements IBoundObject {
       name = "in-xml",
       defaultValue = "WRAPPED",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "WRAPPED", description = "Block contents of a markup-multiline field will be represented with a containing (wrapper) element in the XML."), @AllowedValue(value = "UNWRAPPED", description = "Block contents of a markup-multiline will be represented in the XML with no wrapper, making the field implicit. Among sibling fields in a given model, only one of them may be designated as UNWRAPPED."), @AllowedValue(value = "WITH_WRAPPER", description = "Alias for WRAPPED.", deprecatedVersion = "0.9.0")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {
+          @AllowedValue(value = "WRAPPED",
+              description = "Block contents of a markup-multiline field will be represented with a containing (wrapper) element in the XML."),
+          @AllowedValue(value = "UNWRAPPED",
+              description = "Block contents of a markup-multiline will be represented in the XML with no wrapper, making the field implicit. Among sibling fields in a given model, only one of them may be designated as UNWRAPPED."),
+          @AllowedValue(value = "WITH_WRAPPER", description = "Alias for WRAPPED.", deprecatedVersion = "0.9.0") })))
   private String _inXml;
 
   /**
@@ -116,109 +177,106 @@ public class InlineDefineField implements IBoundObject {
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
       useName = "formal-name",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   /**
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    */
   @BoundField(
       formalName = "Description",
       description = "A short description of the data construct's purpose, describing the constructs semantics.",
       useName = "description",
-      typeAdapter = MarkupLineAdapter.class
-  )
+      typeAdapter = MarkupLineAdapter.class)
   private MarkupLine _description;
 
   @BoundAssembly(
       formalName = "Property",
       useName = "prop",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST))
   private List<Property> _props;
 
   /**
-   * Used in JSON (and similar formats) to identify a flag that will be used as the property name in an object hold a collection of sibling objects. Requires that siblings must never share <code>json-key</code> values.
+   * Used in JSON (and similar formats) to identify a flag that will be used as
+   * the property name in an object hold a collection of sibling objects. Requires
+   * that siblings must never share <code>json-key</code> values.
    */
   @BoundAssembly(
       formalName = "JSON Key",
       description = "Used in JSON (and similar formats) to identify a flag that will be used as the property name in an object hold a collection of sibling objects. Requires that siblings must never share `json-key` values.",
-      useName = "json-key"
-  )
+      useName = "json-key")
   private JsonKey _jsonKey;
 
   @BoundField(
       formalName = "Field Value JSON Property Name",
       useName = "json-value-key",
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   @BoundChoice(
-      choiceId = "choice-1"
-  )
+      choiceId = "choice-1")
   private String _jsonValueKey;
 
   @BoundAssembly(
       formalName = "Flag Used as the Field Value's JSON Property Name",
-      useName = "json-value-key-flag"
-  )
+      useName = "json-value-key-flag")
   @BoundChoice(
-      choiceId = "choice-1"
-  )
+      choiceId = "choice-1")
   private JsonValueKeyFlag _jsonValueKeyFlag;
 
   @BoundAssembly(
       formalName = "Group As",
-      useName = "group-as"
-  )
+      useName = "group-as")
   private GroupingAs _groupAs;
 
   @BoundChoiceGroup(
       maxOccurs = -1,
       groupAs = @GroupAs(name = "flags", inJson = JsonGroupAsBehavior.LIST),
       assemblies = {
-          @BoundGroupedAssembly(formalName = "Inline Flag Definition", useName = "define-flag", discriminatorValue = "flag", binding = InlineDefineFlag.class),
-          @BoundGroupedAssembly(formalName = "Flag Reference", useName = "flag", discriminatorValue = "flag-ref", binding = FlagReference.class)
-      }
-  )
+          @BoundGroupedAssembly(formalName = "Inline Flag Definition", useName = "define-flag",
+              discriminatorValue = "flag", binding = InlineDefineFlag.class),
+          @BoundGroupedAssembly(formalName = "Flag Reference", useName = "flag", discriminatorValue = "flag-ref",
+              binding = FlagReference.class)
+      })
   private List<Object> _flags;
 
   @BoundAssembly(
-      useName = "constraint"
-  )
+      useName = "constraint")
   private FieldConstraints _constraint;
 
   /**
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    */
   @BoundField(
       formalName = "Remarks",
       description = "Any explanatory or helpful information to be provided about the remarks parent.",
-      useName = "remarks"
-  )
+      useName = "remarks")
   private Remarks _remarks;
 
   @BoundAssembly(
       formalName = "Example",
       useName = "example",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "examples", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "examples", inJson = JsonGroupAsBehavior.LIST))
   private List<Example> _examples;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.InlineDefineField} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.InlineDefineField}
+   * instance with no metadata.
    */
   public InlineDefineField() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.InlineDefineField} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.InlineDefineField}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public InlineDefineField(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -243,7 +301,7 @@ public class InlineDefineField implements IBoundObject {
    * Set the inline Field Name.
    *
    * @param value
-   *           the name value to set
+   *          the name value to set
    */
   public void setName(@NonNull String value) {
     _name = value;
@@ -263,7 +321,7 @@ public class InlineDefineField implements IBoundObject {
    * Set the inline Field Binary Name.
    *
    * @param value
-   *           the index value to set
+   *          the index value to set, or {@code null} to clear
    */
   public void setIndex(@Nullable BigInteger value) {
     _index = value;
@@ -283,7 +341,7 @@ public class InlineDefineField implements IBoundObject {
    * Set the deprecated Version.
    *
    * @param value
-   *           the deprecated value to set
+   *          the deprecated value to set, or {@code null} to clear
    */
   public void setDeprecated(@Nullable String value) {
     _deprecated = value;
@@ -303,7 +361,7 @@ public class InlineDefineField implements IBoundObject {
    * Set the field Value Data Type.
    *
    * @param value
-   *           the as-type value to set
+   *          the as-type value to set, or {@code null} to clear
    */
   public void setAsType(@Nullable String value) {
     _asType = value;
@@ -323,7 +381,7 @@ public class InlineDefineField implements IBoundObject {
    * Set the default Field Value.
    *
    * @param value
-   *           the default value to set
+   *          the default value to set, or {@code null} to clear
    */
   public void setDefault(@Nullable String value) {
     _default = value;
@@ -343,7 +401,7 @@ public class InlineDefineField implements IBoundObject {
    * Set the minimum Occurrence.
    *
    * @param value
-   *           the min-occurs value to set
+   *          the min-occurs value to set, or {@code null} to clear
    */
   public void setMinOccurs(@Nullable BigInteger value) {
     _minOccurs = value;
@@ -363,7 +421,7 @@ public class InlineDefineField implements IBoundObject {
    * Set the maximum Occurrence.
    *
    * @param value
-   *           the max-occurs value to set
+   *          the max-occurs value to set, or {@code null} to clear
    */
   public void setMaxOccurs(@Nullable String value) {
     _maxOccurs = value;
@@ -383,7 +441,7 @@ public class InlineDefineField implements IBoundObject {
    * Set the field In XML.
    *
    * @param value
-   *           the in-xml value to set
+   *          the in-xml value to set, or {@code null} to clear
    */
   public void setInXml(@Nullable String value) {
     _inXml = value;
@@ -409,7 +467,7 @@ public class InlineDefineField implements IBoundObject {
    * A formal name for the data construct, to be presented in documentation.
    *
    * @param value
-   *           the formal-name value to set
+   *          the formal-name value to set, or {@code null} to clear
    */
   public void setFormalName(@Nullable String value) {
     _formalName = value;
@@ -419,7 +477,8 @@ public class InlineDefineField implements IBoundObject {
    * Get the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @return the description value, or {@code null} if not set
    */
@@ -432,10 +491,11 @@ public class InlineDefineField implements IBoundObject {
    * Set the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @param value
-   *           the description value to set
+   *          the description value to set, or {@code null} to clear
    */
   public void setDescription(@Nullable MarkupLine value) {
     _description = value;
@@ -458,7 +518,7 @@ public class InlineDefineField implements IBoundObject {
    * Set the property.
    *
    * @param value
-   *           the prop value to set
+   *          the prop value to set
    */
   public void setProps(@NonNull List<Property> value) {
     _props = value;
@@ -466,11 +526,13 @@ public class InlineDefineField implements IBoundObject {
 
   /**
    * Add a new {@link Property} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_props == null) {
       _props = new LinkedList<>();
     }
@@ -478,12 +540,15 @@ public class InlineDefineField implements IBoundObject {
   }
 
   /**
-   * Remove the first matching {@link Property} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link Property} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _props != null && _props.remove(value);
   }
 
@@ -491,7 +556,9 @@ public class InlineDefineField implements IBoundObject {
    * Get the jSON Key.
    *
    * <p>
-   * Used in JSON (and similar formats) to identify a flag that will be used as the property name in an object hold a collection of sibling objects. Requires that siblings must never share <code>json-key</code> values.
+   * Used in JSON (and similar formats) to identify a flag that will be used as
+   * the property name in an object hold a collection of sibling objects. Requires
+   * that siblings must never share <code>json-key</code> values.
    *
    * @return the json-key value, or {@code null} if not set
    */
@@ -504,10 +571,12 @@ public class InlineDefineField implements IBoundObject {
    * Set the jSON Key.
    *
    * <p>
-   * Used in JSON (and similar formats) to identify a flag that will be used as the property name in an object hold a collection of sibling objects. Requires that siblings must never share <code>json-key</code> values.
+   * Used in JSON (and similar formats) to identify a flag that will be used as
+   * the property name in an object hold a collection of sibling objects. Requires
+   * that siblings must never share <code>json-key</code> values.
    *
    * @param value
-   *           the json-key value to set
+   *          the json-key value to set, or {@code null} to clear
    */
   public void setJsonKey(@Nullable JsonKey value) {
     _jsonKey = value;
@@ -527,7 +596,7 @@ public class InlineDefineField implements IBoundObject {
    * Set the field Value JSON Property Name.
    *
    * @param value
-   *           the json-value-key value to set
+   *          the json-value-key value to set, or {@code null} to clear
    */
   public void setJsonValueKey(@Nullable String value) {
     _jsonValueKey = value;
@@ -547,7 +616,7 @@ public class InlineDefineField implements IBoundObject {
    * Set the flag Used as the Field Value's JSON Property Name.
    *
    * @param value
-   *           the json-value-key-flag value to set
+   *          the json-value-key-flag value to set, or {@code null} to clear
    */
   public void setJsonValueKeyFlag(@Nullable JsonValueKeyFlag value) {
     _jsonValueKeyFlag = value;
@@ -567,7 +636,7 @@ public class InlineDefineField implements IBoundObject {
    * Set the group As.
    *
    * @param value
-   *           the group-as value to set
+   *          the group-as value to set, or {@code null} to clear
    */
   public void setGroupAs(@Nullable GroupingAs value) {
     _groupAs = value;
@@ -590,7 +659,7 @@ public class InlineDefineField implements IBoundObject {
    * Set the {@code flags} choice group items.
    *
    * @param value
-   *           the flags items to set
+   *          the flags items to set
    */
   public void setFlags(@NonNull List<Object> value) {
     _flags = value;
@@ -610,7 +679,7 @@ public class InlineDefineField implements IBoundObject {
    * Set the {@code constraint} property.
    *
    * @param value
-   *           the constraint value to set
+   *          the constraint value to set, or {@code null} to clear
    */
   public void setConstraint(@Nullable FieldConstraints value) {
     _constraint = value;
@@ -620,7 +689,8 @@ public class InlineDefineField implements IBoundObject {
    * Get the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @return the remarks value, or {@code null} if not set
    */
@@ -633,10 +703,11 @@ public class InlineDefineField implements IBoundObject {
    * Set the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @param value
-   *           the remarks value to set
+   *          the remarks value to set, or {@code null} to clear
    */
   public void setRemarks(@Nullable Remarks value) {
     _remarks = value;
@@ -659,7 +730,7 @@ public class InlineDefineField implements IBoundObject {
    * Set the example.
    *
    * @param value
-   *           the example value to set
+   *          the example value to set
    */
   public void setExamples(@NonNull List<Example> value) {
     _examples = value;
@@ -667,11 +738,13 @@ public class InlineDefineField implements IBoundObject {
 
   /**
    * Add a new {@link Example} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addExample(Example item) {
-    Example value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Example value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_examples == null) {
       _examples = new LinkedList<>();
     }
@@ -679,12 +752,15 @@ public class InlineDefineField implements IBoundObject {
   }
 
   /**
-   * Remove the first matching {@link Example} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link Example} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeExample(Example item) {
-    Example value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Example value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _examples != null && _examples.remove(value);
   }
 

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/InlineDefineFlag.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/InlineDefineFlag.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -35,8 +36,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @MetaschemaAssembly(
     formalName = "Inline Flag Definition",
     name = "inline-define-flag",
-    moduleClass = MetaschemaModelModule.class
-)
+    moduleClass = MetaschemaModelModule.class)
 public class InlineDefineFlag implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
@@ -44,22 +44,19 @@ public class InlineDefineFlag implements IBoundObject {
       formalName = "Inline Flag Name",
       name = "name",
       required = true,
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _name;
 
   @BoundFlag(
       formalName = "Inline Flag Binary Name",
       name = "index",
-      typeAdapter = PositiveIntegerAdapter.class
-  )
+      typeAdapter = PositiveIntegerAdapter.class)
   private BigInteger _index;
 
   @BoundFlag(
       formalName = "Deprecated Version",
       name = "deprecated",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _deprecated;
 
   @BoundFlag(
@@ -67,15 +64,72 @@ public class InlineDefineFlag implements IBoundObject {
       name = "as-type",
       defaultValue = "string",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, allowOthers = true, values = {@AllowedValue(value = "base64", description = "The [base64](https://framework.metaschema.dev/specification/datatypes/#base64) data type."), @AllowedValue(value = "boolean", description = "The [boolean](https://framework.metaschema.dev/specification/datatypes/#boolean) data type."), @AllowedValue(value = "date", description = "The [date](https://framework.metaschema.dev/specification/datatypes/#date) data type."), @AllowedValue(value = "date-time", description = "The [date-time](https://framework.metaschema.dev/specification/datatypes/#date-time) data type."), @AllowedValue(value = "date-time-with-timezone", description = "The [date-time-with-timezone](https://framework.metaschema.dev/specification/datatypes/#date-time-with-timezone) data type."), @AllowedValue(value = "date-with-timezone", description = "The [date-with-timezone](https://framework.metaschema.dev/specification/datatypes/#date-with-timezone) data type."), @AllowedValue(value = "day-time-duration", description = "The [day-time-duration](https://framework.metaschema.dev/specification/datatypes/#day-time-duration) data type."), @AllowedValue(value = "decimal", description = "The [decimal](https://framework.metaschema.dev/specification/datatypes/#decimal) data type."), @AllowedValue(value = "email-address", description = "The [email-address](https://framework.metaschema.dev/specification/datatypes/#email-address) data type."), @AllowedValue(value = "hostname", description = "The [hostname](https://framework.metaschema.dev/specification/datatypes/#hostname) data type."), @AllowedValue(value = "integer", description = "The [integer](https://framework.metaschema.dev/specification/datatypes/#integer) data type."), @AllowedValue(value = "ip-v4-address", description = "The [ip-v4-address](https://framework.metaschema.dev/specification/datatypes/#ip-v4-address) data type."), @AllowedValue(value = "ip-v6-address", description = "The [ip-v6-address](https://framework.metaschema.dev/specification/datatypes/#ip-v6-address) data type."), @AllowedValue(value = "non-negative-integer", description = "The [non-negative-integer](https://framework.metaschema.dev/specification/datatypes/#non-negative-integer) data type."), @AllowedValue(value = "positive-integer", description = "The [positive-integer](https://framework.metaschema.dev/specification/datatypes/#positive-integer) data type."), @AllowedValue(value = "string", description = "The [string](https://framework.metaschema.dev/specification/datatypes/#string) data type."), @AllowedValue(value = "token", description = "The [token](https://framework.metaschema.dev/specification/datatypes/#token) data type."), @AllowedValue(value = "uri", description = "The [uri](https://framework.metaschema.dev/specification/datatypes/#uri) data type."), @AllowedValue(value = "uri-reference", description = "The [uri-reference](https://framework.metaschema.dev/specification/datatypes/#uri-reference) data type."), @AllowedValue(value = "uuid", description = "The [uuid](https://framework.metaschema.dev/specification/datatypes/#uuid) data type."), @AllowedValue(value = "base64Binary", description = "An old name which is deprecated for use in favor of the 'base64' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "dateTime", description = "An old name which is deprecated for use in favor of the 'date-time' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "dateTime-with-timezone", description = "An old name which is deprecated for use in favor of the 'date-time-with-timezone' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "email", description = "An old name which is deprecated for use in favor of the 'email-address' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "nonNegativeInteger", description = "An old name which is deprecated for use in favor of the 'non-negative-integer' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "positiveInteger", description = "An old name which is deprecated for use in favor of the 'positive-integer' data type.", deprecatedVersion = "1.0.0")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR,
+          allowOthers = true,
+          values = { @AllowedValue(value = "base64",
+              description = "The [base64](https://framework.metaschema.dev/specification/datatypes/#base64) data type."),
+              @AllowedValue(value = "boolean",
+                  description = "The [boolean](https://framework.metaschema.dev/specification/datatypes/#boolean) data type."),
+              @AllowedValue(value = "date",
+                  description = "The [date](https://framework.metaschema.dev/specification/datatypes/#date) data type."),
+              @AllowedValue(value = "date-time",
+                  description = "The [date-time](https://framework.metaschema.dev/specification/datatypes/#date-time) data type."),
+              @AllowedValue(value = "date-time-with-timezone",
+                  description = "The [date-time-with-timezone](https://framework.metaschema.dev/specification/datatypes/#date-time-with-timezone) data type."),
+              @AllowedValue(value = "date-with-timezone",
+                  description = "The [date-with-timezone](https://framework.metaschema.dev/specification/datatypes/#date-with-timezone) data type."),
+              @AllowedValue(value = "day-time-duration",
+                  description = "The [day-time-duration](https://framework.metaschema.dev/specification/datatypes/#day-time-duration) data type."),
+              @AllowedValue(value = "decimal",
+                  description = "The [decimal](https://framework.metaschema.dev/specification/datatypes/#decimal) data type."),
+              @AllowedValue(value = "email-address",
+                  description = "The [email-address](https://framework.metaschema.dev/specification/datatypes/#email-address) data type."),
+              @AllowedValue(value = "hostname",
+                  description = "The [hostname](https://framework.metaschema.dev/specification/datatypes/#hostname) data type."),
+              @AllowedValue(value = "integer",
+                  description = "The [integer](https://framework.metaschema.dev/specification/datatypes/#integer) data type."),
+              @AllowedValue(value = "ip-v4-address",
+                  description = "The [ip-v4-address](https://framework.metaschema.dev/specification/datatypes/#ip-v4-address) data type."),
+              @AllowedValue(value = "ip-v6-address",
+                  description = "The [ip-v6-address](https://framework.metaschema.dev/specification/datatypes/#ip-v6-address) data type."),
+              @AllowedValue(value = "non-negative-integer",
+                  description = "The [non-negative-integer](https://framework.metaschema.dev/specification/datatypes/#non-negative-integer) data type."),
+              @AllowedValue(value = "positive-integer",
+                  description = "The [positive-integer](https://framework.metaschema.dev/specification/datatypes/#positive-integer) data type."),
+              @AllowedValue(value = "string",
+                  description = "The [string](https://framework.metaschema.dev/specification/datatypes/#string) data type."),
+              @AllowedValue(value = "token",
+                  description = "The [token](https://framework.metaschema.dev/specification/datatypes/#token) data type."),
+              @AllowedValue(value = "uri",
+                  description = "The [uri](https://framework.metaschema.dev/specification/datatypes/#uri) data type."),
+              @AllowedValue(value = "uri-reference",
+                  description = "The [uri-reference](https://framework.metaschema.dev/specification/datatypes/#uri-reference) data type."),
+              @AllowedValue(value = "uuid",
+                  description = "The [uuid](https://framework.metaschema.dev/specification/datatypes/#uuid) data type."),
+              @AllowedValue(value = "base64Binary",
+                  description = "An old name which is deprecated for use in favor of the 'base64' data type.",
+                  deprecatedVersion = "1.0.0"),
+              @AllowedValue(value = "dateTime",
+                  description = "An old name which is deprecated for use in favor of the 'date-time' data type.",
+                  deprecatedVersion = "1.0.0"),
+              @AllowedValue(value = "dateTime-with-timezone",
+                  description = "An old name which is deprecated for use in favor of the 'date-time-with-timezone' data type.",
+                  deprecatedVersion = "1.0.0"),
+              @AllowedValue(value = "email",
+                  description = "An old name which is deprecated for use in favor of the 'email-address' data type.",
+                  deprecatedVersion = "1.0.0"),
+              @AllowedValue(value = "nonNegativeInteger",
+                  description = "An old name which is deprecated for use in favor of the 'non-negative-integer' data type.",
+                  deprecatedVersion = "1.0.0"),
+              @AllowedValue(value = "positiveInteger",
+                  description = "An old name which is deprecated for use in favor of the 'positive-integer' data type.",
+                  deprecatedVersion = "1.0.0") })))
   private String _asType;
 
   @BoundFlag(
       formalName = "Default Flag Value",
       name = "default",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _default;
 
   @BoundFlag(
@@ -83,8 +137,9 @@ public class InlineDefineFlag implements IBoundObject {
       name = "required",
       defaultValue = "no",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "yes", description = "The flag is required."), @AllowedValue(value = "no", description = "The flag is optional.")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR,
+          values = { @AllowedValue(value = "yes", description = "The flag is required."),
+              @AllowedValue(value = "no", description = "The flag is optional.") })))
   private String _required;
 
   /**
@@ -94,64 +149,64 @@ public class InlineDefineFlag implements IBoundObject {
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
       useName = "formal-name",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   /**
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    */
   @BoundField(
       formalName = "Description",
       description = "A short description of the data construct's purpose, describing the constructs semantics.",
       useName = "description",
-      typeAdapter = MarkupLineAdapter.class
-  )
+      typeAdapter = MarkupLineAdapter.class)
   private MarkupLine _description;
 
   @BoundAssembly(
       formalName = "Property",
       useName = "prop",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST))
   private List<Property> _props;
 
   @BoundAssembly(
-      useName = "constraint"
-  )
+      useName = "constraint")
   private FlagConstraints _constraint;
 
   /**
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    */
   @BoundField(
       formalName = "Remarks",
       description = "Any explanatory or helpful information to be provided about the remarks parent.",
-      useName = "remarks"
-  )
+      useName = "remarks")
   private Remarks _remarks;
 
   @BoundAssembly(
       formalName = "Example",
       useName = "example",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "examples", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "examples", inJson = JsonGroupAsBehavior.LIST))
   private List<Example> _examples;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.InlineDefineFlag} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.InlineDefineFlag}
+   * instance with no metadata.
    */
   public InlineDefineFlag() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.InlineDefineFlag} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.InlineDefineFlag}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public InlineDefineFlag(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -176,7 +231,7 @@ public class InlineDefineFlag implements IBoundObject {
    * Set the inline Flag Name.
    *
    * @param value
-   *           the name value to set
+   *          the name value to set
    */
   public void setName(@NonNull String value) {
     _name = value;
@@ -196,7 +251,7 @@ public class InlineDefineFlag implements IBoundObject {
    * Set the inline Flag Binary Name.
    *
    * @param value
-   *           the index value to set
+   *          the index value to set, or {@code null} to clear
    */
   public void setIndex(@Nullable BigInteger value) {
     _index = value;
@@ -216,7 +271,7 @@ public class InlineDefineFlag implements IBoundObject {
    * Set the deprecated Version.
    *
    * @param value
-   *           the deprecated value to set
+   *          the deprecated value to set, or {@code null} to clear
    */
   public void setDeprecated(@Nullable String value) {
     _deprecated = value;
@@ -236,7 +291,7 @@ public class InlineDefineFlag implements IBoundObject {
    * Set the flag Value Data Type.
    *
    * @param value
-   *           the as-type value to set
+   *          the as-type value to set, or {@code null} to clear
    */
   public void setAsType(@Nullable String value) {
     _asType = value;
@@ -256,7 +311,7 @@ public class InlineDefineFlag implements IBoundObject {
    * Set the default Flag Value.
    *
    * @param value
-   *           the default value to set
+   *          the default value to set, or {@code null} to clear
    */
   public void setDefault(@Nullable String value) {
     _default = value;
@@ -276,7 +331,7 @@ public class InlineDefineFlag implements IBoundObject {
    * Set the is Flag Required?.
    *
    * @param value
-   *           the required value to set
+   *          the required value to set, or {@code null} to clear
    */
   public void setRequired(@Nullable String value) {
     _required = value;
@@ -302,7 +357,7 @@ public class InlineDefineFlag implements IBoundObject {
    * A formal name for the data construct, to be presented in documentation.
    *
    * @param value
-   *           the formal-name value to set
+   *          the formal-name value to set, or {@code null} to clear
    */
   public void setFormalName(@Nullable String value) {
     _formalName = value;
@@ -312,7 +367,8 @@ public class InlineDefineFlag implements IBoundObject {
    * Get the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @return the description value, or {@code null} if not set
    */
@@ -325,10 +381,11 @@ public class InlineDefineFlag implements IBoundObject {
    * Set the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @param value
-   *           the description value to set
+   *          the description value to set, or {@code null} to clear
    */
   public void setDescription(@Nullable MarkupLine value) {
     _description = value;
@@ -351,7 +408,7 @@ public class InlineDefineFlag implements IBoundObject {
    * Set the property.
    *
    * @param value
-   *           the prop value to set
+   *          the prop value to set
    */
   public void setProps(@NonNull List<Property> value) {
     _props = value;
@@ -359,11 +416,13 @@ public class InlineDefineFlag implements IBoundObject {
 
   /**
    * Add a new {@link Property} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_props == null) {
       _props = new LinkedList<>();
     }
@@ -371,12 +430,15 @@ public class InlineDefineFlag implements IBoundObject {
   }
 
   /**
-   * Remove the first matching {@link Property} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link Property} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _props != null && _props.remove(value);
   }
 
@@ -394,7 +456,7 @@ public class InlineDefineFlag implements IBoundObject {
    * Set the {@code constraint} property.
    *
    * @param value
-   *           the constraint value to set
+   *          the constraint value to set, or {@code null} to clear
    */
   public void setConstraint(@Nullable FlagConstraints value) {
     _constraint = value;
@@ -404,7 +466,8 @@ public class InlineDefineFlag implements IBoundObject {
    * Get the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @return the remarks value, or {@code null} if not set
    */
@@ -417,10 +480,11 @@ public class InlineDefineFlag implements IBoundObject {
    * Set the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @param value
-   *           the remarks value to set
+   *          the remarks value to set, or {@code null} to clear
    */
   public void setRemarks(@Nullable Remarks value) {
     _remarks = value;
@@ -443,7 +507,7 @@ public class InlineDefineFlag implements IBoundObject {
    * Set the example.
    *
    * @param value
-   *           the example value to set
+   *          the example value to set
    */
   public void setExamples(@NonNull List<Example> value) {
     _examples = value;
@@ -451,11 +515,13 @@ public class InlineDefineFlag implements IBoundObject {
 
   /**
    * Add a new {@link Example} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addExample(Example item) {
-    Example value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Example value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_examples == null) {
       _examples = new LinkedList<>();
     }
@@ -463,12 +529,15 @@ public class InlineDefineFlag implements IBoundObject {
   }
 
   /**
-   * Remove the first matching {@link Example} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link Example} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeExample(Example item) {
-    Example value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Example value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _examples != null && _examples.remove(value);
   }
 

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/JsonKey.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/JsonKey.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -17,14 +18,15 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 /**
- * Used in JSON (and similar formats) to identify a flag that will be used as the property name in an object hold a collection of sibling objects. Requires that siblings must never share <code>json-key</code> values.
+ * Used in JSON (and similar formats) to identify a flag that will be used as
+ * the property name in an object hold a collection of sibling objects. Requires
+ * that siblings must never share <code>json-key</code> values.
  */
 @MetaschemaAssembly(
     formalName = "JSON Key",
     description = "Used in JSON (and similar formats) to identify a flag that will be used as the property name in an object hold a collection of sibling objects. Requires that siblings must never share `json-key` values.",
     name = "json-key",
-    moduleClass = MetaschemaModelModule.class
-)
+    moduleClass = MetaschemaModelModule.class)
 public class JsonKey implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
@@ -36,22 +38,25 @@ public class JsonKey implements IBoundObject {
       description = "References the flag that will serve as the JSON key.",
       name = "flag-ref",
       required = true,
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _flagRef;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.JsonKey} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.JsonKey}
+   * instance with no metadata.
    */
   public JsonKey() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.JsonKey} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.JsonKey}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public JsonKey(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -82,7 +87,7 @@ public class JsonKey implements IBoundObject {
    * References the flag that will serve as the JSON key.
    *
    * @param value
-   *           the flag-ref value to set
+   *          the flag-ref value to set
    */
   public void setFlagRef(@NonNull String value) {
     _flagRef = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/JsonValueKeyFlag.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/JsonValueKeyFlag.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -19,8 +20,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @MetaschemaAssembly(
     formalName = "Flag Used as the Field Value's JSON Property Name",
     name = "json-value-key-flag",
-    moduleClass = MetaschemaModelModule.class
-)
+    moduleClass = MetaschemaModelModule.class)
 public class JsonValueKeyFlag implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
@@ -28,22 +28,25 @@ public class JsonValueKeyFlag implements IBoundObject {
       formalName = "Flag Reference",
       name = "flag-ref",
       required = true,
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _flagRef;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.JsonValueKeyFlag} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.JsonValueKeyFlag}
+   * instance with no metadata.
    */
   public JsonValueKeyFlag() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.JsonValueKeyFlag} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.JsonValueKeyFlag}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public JsonValueKeyFlag(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -68,7 +71,7 @@ public class JsonValueKeyFlag implements IBoundObject {
    * Set the flag Reference.
    *
    * @param value
-   *           the flag-ref value to set
+   *          the flag-ref value to set
    */
   public void setFlagRef(@NonNull String value) {
     _flagRef = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/KeyConstraintField.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/KeyConstraintField.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -21,8 +22,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @MetaschemaAssembly(
     formalName = "Key Constraint",
     name = "key-constraint-field",
-    moduleClass = MetaschemaModelModule.class
-)
+    moduleClass = MetaschemaModelModule.class)
 public class KeyConstraintField implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
@@ -30,39 +30,41 @@ public class KeyConstraintField implements IBoundObject {
       formalName = "Key Field Value Target",
       name = "target",
       required = true,
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _target;
 
   @BoundFlag(
       formalName = "Key Field Value Pattern",
       name = "pattern",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _pattern;
 
   /**
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    */
   @BoundField(
       formalName = "Remarks",
       description = "Any explanatory or helpful information to be provided about the remarks parent.",
-      useName = "remarks"
-  )
+      useName = "remarks")
   private Remarks _remarks;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.KeyConstraintField} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.KeyConstraintField}
+   * instance with no metadata.
    */
   public KeyConstraintField() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.KeyConstraintField} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.KeyConstraintField}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public KeyConstraintField(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -87,7 +89,7 @@ public class KeyConstraintField implements IBoundObject {
    * Set the key Field Value Target.
    *
    * @param value
-   *           the target value to set
+   *          the target value to set
    */
   public void setTarget(@NonNull String value) {
     _target = value;
@@ -107,7 +109,7 @@ public class KeyConstraintField implements IBoundObject {
    * Set the key Field Value Pattern.
    *
    * @param value
-   *           the pattern value to set
+   *          the pattern value to set, or {@code null} to clear
    */
   public void setPattern(@Nullable String value) {
     _pattern = value;
@@ -117,7 +119,8 @@ public class KeyConstraintField implements IBoundObject {
    * Get the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @return the remarks value, or {@code null} if not set
    */
@@ -130,10 +133,11 @@ public class KeyConstraintField implements IBoundObject {
    * Set the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @param value
-   *           the remarks value to set
+   *          the remarks value to set, or {@code null} to clear
    */
   public void setRemarks(@Nullable Remarks value) {
     _remarks = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/METASCHEMA.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/METASCHEMA.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -55,14 +56,58 @@ import org.apache.commons.lang3.builder.ToStringStyle;
     name = "METASCHEMA",
     moduleClass = MetaschemaModelModule.class,
     rootName = "METASCHEMA",
-    valueConstraints = @ValueConstraints(lets = {@Let(name = "all-imports", target = "recurse-depth('for $import in ./import return doc(resolve-uri($import/@href))/METASCHEMA')"), @Let(name = "deprecated-type-map", target = "map { 'base64Binary':'base64','dateTime':'date-time','dateTime-with-timezone':'date-time-with-timezone','email':'email-address','nonNegativeInteger':'non-negative-integer','positiveInteger':'positive-integer' }")}, expect = {@Expect(id = "module-top-level-version-required", formalName = "Require Schema Version for Top-Level Modules", description = "A top-level module, a module that is not marked as @abstract='yes', must have a schema version specified.", level = IConstraint.Level.WARNING, target = ".[not(@abstract) or @abstract='no']", test = "schema-version", message = "Unless marked as @abstract='yes', a Metaschema module (or an imported module) should have a schema version."), @Expect(id = "module-top-level-root-required", formalName = "Require Root Assembly for Top-Level Modules", description = "A top-level module, a module that is not marked as @abstract='yes', must have at least one assembly with a root-name.", level = IConstraint.Level.WARNING, target = ".[not(@abstract) or @abstract='no']", test = "exists($all-imports/define-assembly/root-name)", message = "Unless marked as @abstract='yes', a Metaschema module (or an imported module) should have at least one assembly with a root-name."), @Expect(id = "module-import-href-available", formalName = "Import is Resolvable", description = "Ensure each import has a resolvable @href.", level = IConstraint.Level.ERROR, target = "import", test = "doc-available(resolve-uri(@href))", message = "Unable to access a Metaschema module at '{ resolve-uri(@href) }'."), @Expect(id = "module-import-href-is-module", formalName = "Import is a Metaschema module", description = "Ensure each import is a Metaschema module.", level = IConstraint.Level.ERROR, target = "import", test = "doc(resolve-uri(@href))/METASCHEMA ! exists(.)", message = "The resource at '{ resolve-uri(@href) }' is not a Metaschema module."), @Expect(id = "module-model-group-a-invalid", formalName = "Group-As unneeded with max-occurs='1'", description = "A field or assembly instance with a max occurrence of \\`1\\` must not have a \\`group-as\\` child.", level = IConstraint.Level.ERROR, target = ".//(define-assembly|define-field|assembly|field)[@max-occurs=1]", test = ".[not(group-as)]", message = "Use of `group-as` in the location '{ path() }' requires a parent with a max-occurs that is greater than 1; otherwise the `group-as` needs to be removed."), @Expect(id = "metaschema-deprecated-types", formalName = "Avoid Deprecated Data Type Use", description = "Ensure that the data type specified is not one of the legacy Metaschema data types which have been deprecated (i.e. base64Binary, dateTime, dateTime-with-timezone, email, nonNegativeInteger, positiveInteger).", level = IConstraint.Level.WARNING, target = ".//matches/@datatype|.//(define-field|define-flag)/@as-type", test = "not(data(.)=('base64Binary','dateTime','dateTime-with-timezone','email','nonNegativeInteger','positiveInteger'))", message = "Use of the type '{ data(.) }' is deprecated. Use '{ $deprecated-type-map(data(.))}' instead.")}),
-    modelConstraints = @gov.nist.secauto.metaschema.databind.model.annotations.AssemblyConstraints(index = @Index(id = "module-short-name-unique", formalName = "Index Module Short Names", description = "Ensures that the current and all imported modules have a unique short name.", level = IConstraint.Level.ERROR, target = "(.|$all-imports)", name = "metaschema-metadata-short-name-index", keyFields = @KeyField(target = "@short-name")), unique = {@IsUnique(id = "module-namespace-unique-entry", formalName = "Require Unique Namespace Entries", description = "Ensures that all declared namespace entries are unique.", level = IConstraint.Level.ERROR, target = "namespace-binding", keyFields = {@KeyField(target = "@prefix"), @KeyField(target = "@uri")}), @IsUnique(id = "module-namespace-unique-prefix", formalName = "Require Unique Namespace Entry Prefixes", description = "Ensures that all declared namespace entries have a unique prefix.", level = IConstraint.Level.ERROR, target = "namespace-binding", keyFields = @KeyField(target = "@prefix"))})
-)
+    valueConstraints = @ValueConstraints(lets = {
+        @Let(name = "all-imports",
+            target = "recurse-depth('for $import in ./import return doc(resolve-uri($import/@href))/METASCHEMA')"),
+        @Let(name = "deprecated-type-map",
+            target = "map { 'base64Binary':'base64','dateTime':'date-time','dateTime-with-timezone':'date-time-with-timezone','email':'email-address','nonNegativeInteger':'non-negative-integer','positiveInteger':'positive-integer' }") },
+        expect = { @Expect(id = "module-top-level-version-required",
+            formalName = "Require Schema Version for Top-Level Modules",
+            description = "A top-level module, a module that is not marked as @abstract='yes', must have a schema version specified.",
+            level = IConstraint.Level.WARNING, target = ".[not(@abstract) or @abstract='no']", test = "schema-version",
+            message = "Unless marked as @abstract='yes', a Metaschema module (or an imported module) should have a schema version."),
+            @Expect(id = "module-top-level-root-required", formalName = "Require Root Assembly for Top-Level Modules",
+                description = "A top-level module, a module that is not marked as @abstract='yes', must have at least one assembly with a root-name.",
+                level = IConstraint.Level.WARNING, target = ".[not(@abstract) or @abstract='no']",
+                test = "exists($all-imports/define-assembly/root-name)",
+                message = "Unless marked as @abstract='yes', a Metaschema module (or an imported module) should have at least one assembly with a root-name."),
+            @Expect(id = "module-import-href-available", formalName = "Import is Resolvable",
+                description = "Ensure each import has a resolvable @href.", level = IConstraint.Level.ERROR,
+                target = "import", test = "doc-available(resolve-uri(@href))",
+                message = "Unable to access a Metaschema module at '{ resolve-uri(@href) }'."),
+            @Expect(id = "module-import-href-is-module", formalName = "Import is a Metaschema module",
+                description = "Ensure each import is a Metaschema module.", level = IConstraint.Level.ERROR,
+                target = "import", test = "doc(resolve-uri(@href))/METASCHEMA ! exists(.)",
+                message = "The resource at '{ resolve-uri(@href) }' is not a Metaschema module."),
+            @Expect(id = "module-model-group-a-invalid", formalName = "Group-As unneeded with max-occurs='1'",
+                description = "A field or assembly instance with a max occurrence of \\`1\\` must not have a \\`group-as\\` child.",
+                level = IConstraint.Level.ERROR,
+                target = ".//(define-assembly|define-field|assembly|field)[@max-occurs=1]", test = ".[not(group-as)]",
+                message = "Use of `group-as` in the location '{ path() }' requires a parent with a max-occurs that is greater than 1; otherwise the `group-as` needs to be removed."),
+            @Expect(id = "metaschema-deprecated-types", formalName = "Avoid Deprecated Data Type Use",
+                description = "Ensure that the data type specified is not one of the legacy Metaschema data types which have been deprecated (i.e. base64Binary, dateTime, dateTime-with-timezone, email, nonNegativeInteger, positiveInteger).",
+                level = IConstraint.Level.WARNING,
+                target = ".//matches/@datatype|.//(define-field|define-flag)/@as-type",
+                test = "not(data(.)=('base64Binary','dateTime','dateTime-with-timezone','email','nonNegativeInteger','positiveInteger'))",
+                message = "Use of the type '{ data(.) }' is deprecated. Use '{ $deprecated-type-map(data(.))}' instead.") }),
+    modelConstraints = @gov.nist.secauto.metaschema.databind.model.annotations.AssemblyConstraints(
+        index = @Index(id = "module-short-name-unique", formalName = "Index Module Short Names",
+            description = "Ensures that the current and all imported modules have a unique short name.",
+            level = IConstraint.Level.ERROR, target = "(.|$all-imports)", name = "metaschema-metadata-short-name-index",
+            keyFields = @KeyField(target = "@short-name")),
+        unique = { @IsUnique(id = "module-namespace-unique-entry", formalName = "Require Unique Namespace Entries",
+            description = "Ensures that all declared namespace entries are unique.", level = IConstraint.Level.ERROR,
+            target = "namespace-binding", keyFields = { @KeyField(target = "@prefix"), @KeyField(target = "@uri") }),
+            @IsUnique(id = "module-namespace-unique-prefix", formalName = "Require Unique Namespace Entry Prefixes",
+                description = "Ensures that all declared namespace entries have a unique prefix.",
+                level = IConstraint.Level.ERROR, target = "namespace-binding",
+                keyFields = @KeyField(target = "@prefix")) }))
 public class METASCHEMA implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
   /**
-   * Determines if the Metaschema module is abstract (&lsquo;yes&rsquo;) or not (&lsquo;no&rsquo;).
+   * Determines if the Metaschema module is abstract (&lsquo;yes&rsquo;) or not
+   * (&lsquo;no&rsquo;).
    */
   @BoundFlag(
       formalName = "Is Abstract?",
@@ -70,8 +115,9 @@ public class METASCHEMA implements IBoundObject {
       name = "abstract",
       defaultValue = "no",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "yes", description = "The module is abstract."), @AllowedValue(value = "no", description = "The module is not abstract.")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR,
+          values = { @AllowedValue(value = "yes", description = "The module is abstract."),
+              @AllowedValue(value = "no", description = "The module is not abstract.") })))
   private String _abstract;
 
   /**
@@ -82,114 +128,125 @@ public class METASCHEMA implements IBoundObject {
       description = "The name of the information model represented by this Metaschema definition.",
       useName = "schema-name",
       minOccurs = 1,
-      typeAdapter = MarkupLineAdapter.class
-  )
+      typeAdapter = MarkupLineAdapter.class)
   private MarkupLine _schemaName;
 
   /**
-   * A version string used to distinguish between multiple revisions of the same Metaschema module.
+   * A version string used to distinguish between multiple revisions of the same
+   * Metaschema module.
    */
   @BoundField(
       description = "A version string used to distinguish between multiple revisions of the same Metaschema module.",
       useName = "schema-version",
       minOccurs = 1,
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _schemaVersion;
 
   /**
-   * A short (code) name to be used for the Metaschema module. This name may be used as a constituent of names assigned to derived artifacts, such as schemas and conversion utilities.
+   * A short (code) name to be used for the Metaschema module. This name may be
+   * used as a constituent of names assigned to derived artifacts, such as schemas
+   * and conversion utilities.
    */
   @BoundField(
       formalName = "Module Short Name",
       description = "A short (code) name to be used for the Metaschema module. This name may be used as a constituent of names assigned to derived artifacts, such as schemas and conversion utilities.",
       useName = "short-name",
       minOccurs = 1,
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _shortName;
 
   /**
-   * The namespace for the collection of Metaschema module this Metaschema module belongs to. This value is also used as the XML namespace governing the names of elements in XML documents. By using this namespace, documents and document fragments used in mixed-format environments may be distinguished from neighbor XML formats using another namespaces. This value is not reflected in Metaschema JSON.
+   * The namespace for the collection of Metaschema module this Metaschema module
+   * belongs to. This value is also used as the XML namespace governing the names
+   * of elements in XML documents. By using this namespace, documents and document
+   * fragments used in mixed-format environments may be distinguished from
+   * neighbor XML formats using another namespaces. This value is not reflected in
+   * Metaschema JSON.
    */
   @BoundField(
       formalName = "Module Collection Namespace",
       description = "The namespace for the collection of Metaschema module this Metaschema module belongs to. This value is also used as the XML namespace governing the names of elements in XML documents. By using this namespace, documents and document fragments used in mixed-format environments may be distinguished from neighbor XML formats using another namespaces. This value is not reflected in Metaschema JSON.",
       useName = "namespace",
       minOccurs = 1,
-      typeAdapter = UriAdapter.class
-  )
+      typeAdapter = UriAdapter.class)
   private URI _namespace;
 
   /**
-   * The JSON Base URI is the nominal base URI assigned to a JSON Schema instance expressing the model defined by this Metaschema module.
+   * The JSON Base URI is the nominal base URI assigned to a JSON Schema instance
+   * expressing the model defined by this Metaschema module.
    */
   @BoundField(
       formalName = "JSON Base URI",
       description = "The JSON Base URI is the nominal base URI assigned to a JSON Schema instance expressing the model defined by this Metaschema module.",
       useName = "json-base-uri",
       minOccurs = 1,
-      typeAdapter = UriAdapter.class
-  )
+      typeAdapter = UriAdapter.class)
   private URI _jsonBaseUri;
 
   /**
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    */
   @BoundField(
       formalName = "Remarks",
       description = "Any explanatory or helpful information to be provided about the remarks parent.",
-      useName = "remarks"
-  )
+      useName = "remarks")
   private Remarks _remarks;
 
   /**
-   * Imports a set of Metaschema modules contained in another resource. Imports support the reuse of common information structures.
+   * Imports a set of Metaschema modules contained in another resource. Imports
+   * support the reuse of common information structures.
    */
   @BoundAssembly(
       formalName = "Module Import",
       description = "Imports a set of Metaschema modules contained in another resource. Imports support the reuse of common information structures.",
       useName = "import",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "imports", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "imports", inJson = JsonGroupAsBehavior.LIST))
   private List<Import> _imports;
 
   /**
-   * Assigns a Metapath namespace to a prefix for use in a Metapath expression in a lexical qualified name.
+   * Assigns a Metapath namespace to a prefix for use in a Metapath expression in
+   * a lexical qualified name.
    */
   @BoundAssembly(
       formalName = "Metapath Namespace Declaration",
       description = "Assigns a Metapath namespace to a prefix for use in a Metapath expression in a lexical qualified name.",
       useName = "namespace-binding",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "namespace-bindings", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "namespace-bindings", inJson = JsonGroupAsBehavior.LIST))
   private List<MetapathNamespace> _namespaceBindings;
 
   @BoundChoiceGroup(
       maxOccurs = -1,
       groupAs = @GroupAs(name = "definitions", inJson = JsonGroupAsBehavior.LIST),
       assemblies = {
-          @BoundGroupedAssembly(formalName = "Global Assembly Definition", description = "In XML, an element with structured element content. In JSON, an object with properties. Defined globally, an assembly can be assigned to appear in the `model` of any assembly (another assembly type, or itself), by `assembly` reference.", useName = "define-assembly", discriminatorValue = "assembly", binding = DefineAssembly.class),
-          @BoundGroupedAssembly(formalName = "Global Field Definition", useName = "define-field", discriminatorValue = "field", binding = DefineField.class),
-          @BoundGroupedAssembly(formalName = "Global Flag Definition", useName = "define-flag", discriminatorValue = "flag", binding = DefineFlag.class)
-      }
-  )
+          @BoundGroupedAssembly(formalName = "Global Assembly Definition",
+              description = "In XML, an element with structured element content. In JSON, an object with properties. Defined globally, an assembly can be assigned to appear in the `model` of any assembly (another assembly type, or itself), by `assembly` reference.",
+              useName = "define-assembly", discriminatorValue = "assembly", binding = DefineAssembly.class),
+          @BoundGroupedAssembly(formalName = "Global Field Definition", useName = "define-field",
+              discriminatorValue = "field", binding = DefineField.class),
+          @BoundGroupedAssembly(formalName = "Global Flag Definition", useName = "define-flag",
+              discriminatorValue = "flag", binding = DefineFlag.class)
+      })
   private List<Object> _definitions;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.METASCHEMA} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.METASCHEMA}
+   * instance with no metadata.
    */
   public METASCHEMA() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.METASCHEMA} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.METASCHEMA}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public METASCHEMA(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -204,7 +261,8 @@ public class METASCHEMA implements IBoundObject {
    * Get the is Abstract?.
    *
    * <p>
-   * Determines if the Metaschema module is abstract (&lsquo;yes&rsquo;) or not (&lsquo;no&rsquo;).
+   * Determines if the Metaschema module is abstract (&lsquo;yes&rsquo;) or not
+   * (&lsquo;no&rsquo;).
    *
    * @return the abstract value, or {@code null} if not set
    */
@@ -217,10 +275,11 @@ public class METASCHEMA implements IBoundObject {
    * Set the is Abstract?.
    *
    * <p>
-   * Determines if the Metaschema module is abstract (&lsquo;yes&rsquo;) or not (&lsquo;no&rsquo;).
+   * Determines if the Metaschema module is abstract (&lsquo;yes&rsquo;) or not
+   * (&lsquo;no&rsquo;).
    *
    * @param value
-   *           the abstract value to set
+   *          the abstract value to set, or {@code null} to clear
    */
   public void setAbstract(@Nullable String value) {
     _abstract = value;
@@ -246,7 +305,7 @@ public class METASCHEMA implements IBoundObject {
    * The name of the information model represented by this Metaschema definition.
    *
    * @param value
-   *           the schema-name value to set
+   *          the schema-name value to set
    */
   public void setSchemaName(@NonNull MarkupLine value) {
     _schemaName = value;
@@ -256,7 +315,8 @@ public class METASCHEMA implements IBoundObject {
    * Get the {@code schema-version} property.
    *
    * <p>
-   * A version string used to distinguish between multiple revisions of the same Metaschema module.
+   * A version string used to distinguish between multiple revisions of the same
+   * Metaschema module.
    *
    * @return the schema-version value
    */
@@ -269,10 +329,11 @@ public class METASCHEMA implements IBoundObject {
    * Set the {@code schema-version} property.
    *
    * <p>
-   * A version string used to distinguish between multiple revisions of the same Metaschema module.
+   * A version string used to distinguish between multiple revisions of the same
+   * Metaschema module.
    *
    * @param value
-   *           the schema-version value to set
+   *          the schema-version value to set
    */
   public void setSchemaVersion(@NonNull String value) {
     _schemaVersion = value;
@@ -282,7 +343,9 @@ public class METASCHEMA implements IBoundObject {
    * Get the module Short Name.
    *
    * <p>
-   * A short (code) name to be used for the Metaschema module. This name may be used as a constituent of names assigned to derived artifacts, such as schemas and conversion utilities.
+   * A short (code) name to be used for the Metaschema module. This name may be
+   * used as a constituent of names assigned to derived artifacts, such as schemas
+   * and conversion utilities.
    *
    * @return the short-name value
    */
@@ -295,10 +358,12 @@ public class METASCHEMA implements IBoundObject {
    * Set the module Short Name.
    *
    * <p>
-   * A short (code) name to be used for the Metaschema module. This name may be used as a constituent of names assigned to derived artifacts, such as schemas and conversion utilities.
+   * A short (code) name to be used for the Metaschema module. This name may be
+   * used as a constituent of names assigned to derived artifacts, such as schemas
+   * and conversion utilities.
    *
    * @param value
-   *           the short-name value to set
+   *          the short-name value to set
    */
   public void setShortName(@NonNull String value) {
     _shortName = value;
@@ -308,7 +373,12 @@ public class METASCHEMA implements IBoundObject {
    * Get the module Collection Namespace.
    *
    * <p>
-   * The namespace for the collection of Metaschema module this Metaschema module belongs to. This value is also used as the XML namespace governing the names of elements in XML documents. By using this namespace, documents and document fragments used in mixed-format environments may be distinguished from neighbor XML formats using another namespaces. This value is not reflected in Metaschema JSON.
+   * The namespace for the collection of Metaschema module this Metaschema module
+   * belongs to. This value is also used as the XML namespace governing the names
+   * of elements in XML documents. By using this namespace, documents and document
+   * fragments used in mixed-format environments may be distinguished from
+   * neighbor XML formats using another namespaces. This value is not reflected in
+   * Metaschema JSON.
    *
    * @return the namespace value
    */
@@ -321,10 +391,15 @@ public class METASCHEMA implements IBoundObject {
    * Set the module Collection Namespace.
    *
    * <p>
-   * The namespace for the collection of Metaschema module this Metaschema module belongs to. This value is also used as the XML namespace governing the names of elements in XML documents. By using this namespace, documents and document fragments used in mixed-format environments may be distinguished from neighbor XML formats using another namespaces. This value is not reflected in Metaschema JSON.
+   * The namespace for the collection of Metaschema module this Metaschema module
+   * belongs to. This value is also used as the XML namespace governing the names
+   * of elements in XML documents. By using this namespace, documents and document
+   * fragments used in mixed-format environments may be distinguished from
+   * neighbor XML formats using another namespaces. This value is not reflected in
+   * Metaschema JSON.
    *
    * @param value
-   *           the namespace value to set
+   *          the namespace value to set
    */
   public void setNamespace(@NonNull URI value) {
     _namespace = value;
@@ -334,7 +409,8 @@ public class METASCHEMA implements IBoundObject {
    * Get the jSON Base URI.
    *
    * <p>
-   * The JSON Base URI is the nominal base URI assigned to a JSON Schema instance expressing the model defined by this Metaschema module.
+   * The JSON Base URI is the nominal base URI assigned to a JSON Schema instance
+   * expressing the model defined by this Metaschema module.
    *
    * @return the json-base-uri value
    */
@@ -347,10 +423,11 @@ public class METASCHEMA implements IBoundObject {
    * Set the jSON Base URI.
    *
    * <p>
-   * The JSON Base URI is the nominal base URI assigned to a JSON Schema instance expressing the model defined by this Metaschema module.
+   * The JSON Base URI is the nominal base URI assigned to a JSON Schema instance
+   * expressing the model defined by this Metaschema module.
    *
    * @param value
-   *           the json-base-uri value to set
+   *          the json-base-uri value to set
    */
   public void setJsonBaseUri(@NonNull URI value) {
     _jsonBaseUri = value;
@@ -360,7 +437,8 @@ public class METASCHEMA implements IBoundObject {
    * Get the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @return the remarks value, or {@code null} if not set
    */
@@ -373,10 +451,11 @@ public class METASCHEMA implements IBoundObject {
    * Set the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @param value
-   *           the remarks value to set
+   *          the remarks value to set, or {@code null} to clear
    */
   public void setRemarks(@Nullable Remarks value) {
     _remarks = value;
@@ -386,7 +465,8 @@ public class METASCHEMA implements IBoundObject {
    * Get the module Import.
    *
    * <p>
-   * Imports a set of Metaschema modules contained in another resource. Imports support the reuse of common information structures.
+   * Imports a set of Metaschema modules contained in another resource. Imports
+   * support the reuse of common information structures.
    *
    * @return the import value
    */
@@ -402,10 +482,11 @@ public class METASCHEMA implements IBoundObject {
    * Set the module Import.
    *
    * <p>
-   * Imports a set of Metaschema modules contained in another resource. Imports support the reuse of common information structures.
+   * Imports a set of Metaschema modules contained in another resource. Imports
+   * support the reuse of common information structures.
    *
    * @param value
-   *           the import value to set
+   *          the import value to set
    */
   public void setImports(@NonNull List<Import> value) {
     _imports = value;
@@ -413,11 +494,13 @@ public class METASCHEMA implements IBoundObject {
 
   /**
    * Add a new {@link Import} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addImport(Import item) {
-    Import value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Import value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_imports == null) {
       _imports = new LinkedList<>();
     }
@@ -426,11 +509,13 @@ public class METASCHEMA implements IBoundObject {
 
   /**
    * Remove the first matching {@link Import} item from the underlying collection.
-   * @param item the item to remove
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeImport(Import item) {
-    Import value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Import value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _imports != null && _imports.remove(value);
   }
 
@@ -438,7 +523,8 @@ public class METASCHEMA implements IBoundObject {
    * Get the metapath Namespace Declaration.
    *
    * <p>
-   * Assigns a Metapath namespace to a prefix for use in a Metapath expression in a lexical qualified name.
+   * Assigns a Metapath namespace to a prefix for use in a Metapath expression in
+   * a lexical qualified name.
    *
    * @return the namespace-binding value
    */
@@ -454,10 +540,11 @@ public class METASCHEMA implements IBoundObject {
    * Set the metapath Namespace Declaration.
    *
    * <p>
-   * Assigns a Metapath namespace to a prefix for use in a Metapath expression in a lexical qualified name.
+   * Assigns a Metapath namespace to a prefix for use in a Metapath expression in
+   * a lexical qualified name.
    *
    * @param value
-   *           the namespace-binding value to set
+   *          the namespace-binding value to set
    */
   public void setNamespaceBindings(@NonNull List<MetapathNamespace> value) {
     _namespaceBindings = value;
@@ -465,11 +552,13 @@ public class METASCHEMA implements IBoundObject {
 
   /**
    * Add a new {@link MetapathNamespace} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addNamespaceBinding(MetapathNamespace item) {
-    MetapathNamespace value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    MetapathNamespace value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_namespaceBindings == null) {
       _namespaceBindings = new LinkedList<>();
     }
@@ -477,12 +566,15 @@ public class METASCHEMA implements IBoundObject {
   }
 
   /**
-   * Remove the first matching {@link MetapathNamespace} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link MetapathNamespace} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeNamespaceBinding(MetapathNamespace item) {
-    MetapathNamespace value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    MetapathNamespace value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _namespaceBindings != null && _namespaceBindings.remove(value);
   }
 
@@ -503,7 +595,7 @@ public class METASCHEMA implements IBoundObject {
    * Set the {@code definitions} choice group items.
    *
    * @param value
-   *           the definitions items to set
+   *          the definitions items to set
    */
   public void setDefinitions(@NonNull List<Object> value) {
     _definitions = value;
@@ -515,41 +607,45 @@ public class METASCHEMA implements IBoundObject {
   }
 
   /**
-   * Imports a set of Metaschema modules contained in another resource. Imports support the reuse of common information structures.
+   * Imports a set of Metaschema modules contained in another resource. Imports
+   * support the reuse of common information structures.
    */
   @MetaschemaAssembly(
       formalName = "Module Import",
       description = "Imports a set of Metaschema modules contained in another resource. Imports support the reuse of common information structures.",
       name = "import",
-      moduleClass = MetaschemaModelModule.class
-  )
+      moduleClass = MetaschemaModelModule.class)
   public static class Import implements IBoundObject {
     private final IMetaschemaData __metaschemaData;
 
     /**
-     * A relative or absolute URI for retrieving an out-of-line Metaschema definition.
+     * A relative or absolute URI for retrieving an out-of-line Metaschema
+     * definition.
      */
     @BoundFlag(
         formalName = "Import URI Reference",
         description = "A relative or absolute URI for retrieving an out-of-line Metaschema definition.",
         name = "href",
         required = true,
-        typeAdapter = UriReferenceAdapter.class
-    )
+        typeAdapter = UriReferenceAdapter.class)
     private URI _href;
 
     /**
-     * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.METASCHEMA.Import} instance with no metadata.
+     * Constructs a new
+     * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.METASCHEMA.Import}
+     * instance with no metadata.
      */
     public Import() {
       this(null);
     }
 
     /**
-     * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.METASCHEMA.Import} instance with the specified metadata.
+     * Constructs a new
+     * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.METASCHEMA.Import}
+     * instance with the specified metadata.
      *
      * @param data
-     *           the metaschema data, or {@code null} if none
+     *          the metaschema data, or {@code null} if none
      */
     public Import(IMetaschemaData data) {
       this.__metaschemaData = data;
@@ -564,7 +660,8 @@ public class METASCHEMA implements IBoundObject {
      * Get the import URI Reference.
      *
      * <p>
-     * A relative or absolute URI for retrieving an out-of-line Metaschema definition.
+     * A relative or absolute URI for retrieving an out-of-line Metaschema
+     * definition.
      *
      * @return the href value
      */
@@ -577,10 +674,11 @@ public class METASCHEMA implements IBoundObject {
      * Set the import URI Reference.
      *
      * <p>
-     * A relative or absolute URI for retrieving an out-of-line Metaschema definition.
+     * A relative or absolute URI for retrieving an out-of-line Metaschema
+     * definition.
      *
      * @param value
-     *           the href value to set
+     *          the href value to set
      */
     public void setHref(@NonNull URI value) {
       _href = value;
@@ -593,14 +691,16 @@ public class METASCHEMA implements IBoundObject {
   }
 
   /**
-   * In XML, an element with structured element content. In JSON, an object with properties. Defined globally, an assembly can be assigned to appear in the <code>model</code> of any assembly (another assembly type, or itself), by <code>assembly</code> reference.
+   * In XML, an element with structured element content. In JSON, an object with
+   * properties. Defined globally, an assembly can be assigned to appear in the
+   * <code>model</code> of any assembly (another assembly type, or itself), by
+   * <code>assembly</code> reference.
    */
   @MetaschemaAssembly(
       formalName = "Global Assembly Definition",
       description = "In XML, an element with structured element content. In JSON, an object with properties. Defined globally, an assembly can be assigned to appear in the `model` of any assembly (another assembly type, or itself), by `assembly` reference.",
       name = "define-assembly",
-      moduleClass = MetaschemaModelModule.class
-  )
+      moduleClass = MetaschemaModelModule.class)
   public static class DefineAssembly implements IBoundObject {
     private final IMetaschemaData __metaschemaData;
 
@@ -608,15 +708,13 @@ public class METASCHEMA implements IBoundObject {
         formalName = "Global Assembly Name",
         name = "name",
         required = true,
-        typeAdapter = TokenAdapter.class
-    )
+        typeAdapter = TokenAdapter.class)
     private String _name;
 
     @BoundFlag(
         formalName = "Global Assembly Binary Name",
         name = "index",
-        typeAdapter = PositiveIntegerAdapter.class
-    )
+        typeAdapter = PositiveIntegerAdapter.class)
     private BigInteger _index;
 
     @BoundFlag(
@@ -624,15 +722,17 @@ public class METASCHEMA implements IBoundObject {
         name = "scope",
         defaultValue = "global",
         typeAdapter = TokenAdapter.class,
-        valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "local", description = "This definition is only available in the context of the current Metaschema module."), @AllowedValue(value = "global", description = "This definition will be made available to any Metaschema module that includes this one either directly or indirectly through a chain of imported Metaschemas.")}))
-    )
+        valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {
+            @AllowedValue(value = "local",
+                description = "This definition is only available in the context of the current Metaschema module."),
+            @AllowedValue(value = "global",
+                description = "This definition will be made available to any Metaschema module that includes this one either directly or indirectly through a chain of imported Metaschemas.") })))
     private String _scope;
 
     @BoundFlag(
         formalName = "Deprecated Version",
         name = "deprecated",
-        typeAdapter = StringAdapter.class
-    )
+        typeAdapter = StringAdapter.class)
     private String _deprecated;
 
     /**
@@ -642,27 +742,25 @@ public class METASCHEMA implements IBoundObject {
         formalName = "Formal Name",
         description = "A formal name for the data construct, to be presented in documentation.",
         useName = "formal-name",
-        typeAdapter = StringAdapter.class
-    )
+        typeAdapter = StringAdapter.class)
     private String _formalName;
 
     /**
-     * A short description of the data construct's purpose, describing the constructs semantics.
+     * A short description of the data construct's purpose, describing the
+     * constructs semantics.
      */
     @BoundField(
         formalName = "Description",
         description = "A short description of the data construct's purpose, describing the constructs semantics.",
         useName = "description",
-        typeAdapter = MarkupLineAdapter.class
-    )
+        typeAdapter = MarkupLineAdapter.class)
     private MarkupLine _description;
 
     @BoundAssembly(
         formalName = "Property",
         useName = "prop",
         maxOccurs = -1,
-        groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST)
-    )
+        groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST))
     private List<Property> _props;
 
     /**
@@ -671,87 +769,87 @@ public class METASCHEMA implements IBoundObject {
     @BoundField(
         formalName = "Use Name",
         description = "Allows the name of the definition to be overridden.",
-        useName = "use-name"
-    )
+        useName = "use-name")
     @BoundChoice(
-        choiceId = "choice-1"
-    )
+        choiceId = "choice-1")
     private UseName _useName;
 
     /**
-     * Provides a root name, for when the definition is used as the root of a node hierarchy.
+     * Provides a root name, for when the definition is used as the root of a node
+     * hierarchy.
      */
     @BoundField(
         formalName = "Root Name",
         description = "Provides a root name, for when the definition is used as the root of a node hierarchy.",
         useName = "root-name",
-        minOccurs = 1
-    )
+        minOccurs = 1)
     @BoundChoice(
-        choiceId = "choice-1"
-    )
+        choiceId = "choice-1")
     private RootName _rootName;
 
     /**
-     * Used in JSON (and similar formats) to identify a flag that will be used as the property name in an object hold a collection of sibling objects. Requires that siblings must never share <code>json-key</code> values.
+     * Used in JSON (and similar formats) to identify a flag that will be used as
+     * the property name in an object hold a collection of sibling objects. Requires
+     * that siblings must never share <code>json-key</code> values.
      */
     @BoundAssembly(
         formalName = "JSON Key",
         description = "Used in JSON (and similar formats) to identify a flag that will be used as the property name in an object hold a collection of sibling objects. Requires that siblings must never share `json-key` values.",
-        useName = "json-key"
-    )
+        useName = "json-key")
     private JsonKey _jsonKey;
 
     @BoundChoiceGroup(
         maxOccurs = -1,
         groupAs = @GroupAs(name = "flags", inJson = JsonGroupAsBehavior.LIST),
         assemblies = {
-            @BoundGroupedAssembly(formalName = "Inline Flag Definition", useName = "define-flag", discriminatorValue = "flag", binding = InlineDefineFlag.class),
-            @BoundGroupedAssembly(formalName = "Flag Reference", useName = "flag", discriminatorValue = "flag-ref", binding = FlagReference.class)
-        }
-    )
+            @BoundGroupedAssembly(formalName = "Inline Flag Definition", useName = "define-flag",
+                discriminatorValue = "flag", binding = InlineDefineFlag.class),
+            @BoundGroupedAssembly(formalName = "Flag Reference", useName = "flag", discriminatorValue = "flag-ref",
+                binding = FlagReference.class)
+        })
     private List<Object> _flags;
 
     @BoundAssembly(
-        useName = "model"
-    )
+        useName = "model")
     private AssemblyModel _model;
 
     @BoundAssembly(
-        useName = "constraint"
-    )
+        useName = "constraint")
     private AssemblyConstraints _constraint;
 
     /**
-     * Any explanatory or helpful information to be provided about the remarks parent.
+     * Any explanatory or helpful information to be provided about the remarks
+     * parent.
      */
     @BoundField(
         formalName = "Remarks",
         description = "Any explanatory or helpful information to be provided about the remarks parent.",
-        useName = "remarks"
-    )
+        useName = "remarks")
     private Remarks _remarks;
 
     @BoundAssembly(
         formalName = "Example",
         useName = "example",
         maxOccurs = -1,
-        groupAs = @GroupAs(name = "examples", inJson = JsonGroupAsBehavior.LIST)
-    )
+        groupAs = @GroupAs(name = "examples", inJson = JsonGroupAsBehavior.LIST))
     private List<Example> _examples;
 
     /**
-     * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.METASCHEMA.DefineAssembly} instance with no metadata.
+     * Constructs a new
+     * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.METASCHEMA.DefineAssembly}
+     * instance with no metadata.
      */
     public DefineAssembly() {
       this(null);
     }
 
     /**
-     * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.METASCHEMA.DefineAssembly} instance with the specified metadata.
+     * Constructs a new
+     * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.METASCHEMA.DefineAssembly}
+     * instance with the specified metadata.
      *
      * @param data
-     *           the metaschema data, or {@code null} if none
+     *          the metaschema data, or {@code null} if none
      */
     public DefineAssembly(IMetaschemaData data) {
       this.__metaschemaData = data;
@@ -776,7 +874,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the global Assembly Name.
      *
      * @param value
-     *           the name value to set
+     *          the name value to set
      */
     public void setName(@NonNull String value) {
       _name = value;
@@ -796,7 +894,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the global Assembly Binary Name.
      *
      * @param value
-     *           the index value to set
+     *          the index value to set, or {@code null} to clear
      */
     public void setIndex(@Nullable BigInteger value) {
       _index = value;
@@ -816,7 +914,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the definition Scope.
      *
      * @param value
-     *           the scope value to set
+     *          the scope value to set, or {@code null} to clear
      */
     public void setScope(@Nullable String value) {
       _scope = value;
@@ -836,7 +934,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the deprecated Version.
      *
      * @param value
-     *           the deprecated value to set
+     *          the deprecated value to set, or {@code null} to clear
      */
     public void setDeprecated(@Nullable String value) {
       _deprecated = value;
@@ -862,7 +960,7 @@ public class METASCHEMA implements IBoundObject {
      * A formal name for the data construct, to be presented in documentation.
      *
      * @param value
-     *           the formal-name value to set
+     *          the formal-name value to set, or {@code null} to clear
      */
     public void setFormalName(@Nullable String value) {
       _formalName = value;
@@ -872,7 +970,8 @@ public class METASCHEMA implements IBoundObject {
      * Get the description.
      *
      * <p>
-     * A short description of the data construct's purpose, describing the constructs semantics.
+     * A short description of the data construct's purpose, describing the
+     * constructs semantics.
      *
      * @return the description value, or {@code null} if not set
      */
@@ -885,10 +984,11 @@ public class METASCHEMA implements IBoundObject {
      * Set the description.
      *
      * <p>
-     * A short description of the data construct's purpose, describing the constructs semantics.
+     * A short description of the data construct's purpose, describing the
+     * constructs semantics.
      *
      * @param value
-     *           the description value to set
+     *          the description value to set, or {@code null} to clear
      */
     public void setDescription(@Nullable MarkupLine value) {
       _description = value;
@@ -911,7 +1011,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the property.
      *
      * @param value
-     *           the prop value to set
+     *          the prop value to set
      */
     public void setProps(@NonNull List<Property> value) {
       _props = value;
@@ -919,11 +1019,13 @@ public class METASCHEMA implements IBoundObject {
 
     /**
      * Add a new {@link Property} item to the underlying collection.
-     * @param item the item to add
+     *
+     * @param item
+     *          the item to add
      * @return {@code true}
      */
     public boolean addProp(Property item) {
-      Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+      Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
       if (_props == null) {
         _props = new LinkedList<>();
       }
@@ -931,12 +1033,15 @@ public class METASCHEMA implements IBoundObject {
     }
 
     /**
-     * Remove the first matching {@link Property} item from the underlying collection.
-     * @param item the item to remove
+     * Remove the first matching {@link Property} item from the underlying
+     * collection.
+     *
+     * @param item
+     *          the item to remove
      * @return {@code true} if the item was removed or {@code false} otherwise
      */
     public boolean removeProp(Property item) {
-      Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+      Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
       return _props != null && _props.remove(value);
     }
 
@@ -960,7 +1065,7 @@ public class METASCHEMA implements IBoundObject {
      * Allows the name of the definition to be overridden.
      *
      * @param value
-     *           the use-name value to set
+     *          the use-name value to set, or {@code null} to clear
      */
     public void setUseName(@Nullable UseName value) {
       _useName = value;
@@ -970,11 +1075,12 @@ public class METASCHEMA implements IBoundObject {
      * Get the root Name.
      *
      * <p>
-     * Provides a root name, for when the definition is used as the root of a node hierarchy.
+     * Provides a root name, for when the definition is used as the root of a node
+     * hierarchy.
      *
-     * @return the root-name value
+     * @return the root-name value, or {@code null} if not set
      */
-    @NonNull
+    @Nullable
     public RootName getRootName() {
       return _rootName;
     }
@@ -983,12 +1089,13 @@ public class METASCHEMA implements IBoundObject {
      * Set the root Name.
      *
      * <p>
-     * Provides a root name, for when the definition is used as the root of a node hierarchy.
+     * Provides a root name, for when the definition is used as the root of a node
+     * hierarchy.
      *
      * @param value
-     *           the root-name value to set
+     *          the root-name value to set, or {@code null} to clear
      */
-    public void setRootName(@NonNull RootName value) {
+    public void setRootName(@Nullable RootName value) {
       _rootName = value;
     }
 
@@ -996,7 +1103,9 @@ public class METASCHEMA implements IBoundObject {
      * Get the jSON Key.
      *
      * <p>
-     * Used in JSON (and similar formats) to identify a flag that will be used as the property name in an object hold a collection of sibling objects. Requires that siblings must never share <code>json-key</code> values.
+     * Used in JSON (and similar formats) to identify a flag that will be used as
+     * the property name in an object hold a collection of sibling objects. Requires
+     * that siblings must never share <code>json-key</code> values.
      *
      * @return the json-key value, or {@code null} if not set
      */
@@ -1009,10 +1118,12 @@ public class METASCHEMA implements IBoundObject {
      * Set the jSON Key.
      *
      * <p>
-     * Used in JSON (and similar formats) to identify a flag that will be used as the property name in an object hold a collection of sibling objects. Requires that siblings must never share <code>json-key</code> values.
+     * Used in JSON (and similar formats) to identify a flag that will be used as
+     * the property name in an object hold a collection of sibling objects. Requires
+     * that siblings must never share <code>json-key</code> values.
      *
      * @param value
-     *           the json-key value to set
+     *          the json-key value to set, or {@code null} to clear
      */
     public void setJsonKey(@Nullable JsonKey value) {
       _jsonKey = value;
@@ -1035,7 +1146,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the {@code flags} choice group items.
      *
      * @param value
-     *           the flags items to set
+     *          the flags items to set
      */
     public void setFlags(@NonNull List<Object> value) {
       _flags = value;
@@ -1055,7 +1166,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the {@code model} property.
      *
      * @param value
-     *           the model value to set
+     *          the model value to set, or {@code null} to clear
      */
     public void setModel(@Nullable AssemblyModel value) {
       _model = value;
@@ -1075,7 +1186,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the {@code constraint} property.
      *
      * @param value
-     *           the constraint value to set
+     *          the constraint value to set, or {@code null} to clear
      */
     public void setConstraint(@Nullable AssemblyConstraints value) {
       _constraint = value;
@@ -1085,7 +1196,8 @@ public class METASCHEMA implements IBoundObject {
      * Get the remarks.
      *
      * <p>
-     * Any explanatory or helpful information to be provided about the remarks parent.
+     * Any explanatory or helpful information to be provided about the remarks
+     * parent.
      *
      * @return the remarks value, or {@code null} if not set
      */
@@ -1098,10 +1210,11 @@ public class METASCHEMA implements IBoundObject {
      * Set the remarks.
      *
      * <p>
-     * Any explanatory or helpful information to be provided about the remarks parent.
+     * Any explanatory or helpful information to be provided about the remarks
+     * parent.
      *
      * @param value
-     *           the remarks value to set
+     *          the remarks value to set, or {@code null} to clear
      */
     public void setRemarks(@Nullable Remarks value) {
       _remarks = value;
@@ -1124,7 +1237,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the example.
      *
      * @param value
-     *           the example value to set
+     *          the example value to set
      */
     public void setExamples(@NonNull List<Example> value) {
       _examples = value;
@@ -1132,11 +1245,13 @@ public class METASCHEMA implements IBoundObject {
 
     /**
      * Add a new {@link Example} item to the underlying collection.
-     * @param item the item to add
+     *
+     * @param item
+     *          the item to add
      * @return {@code true}
      */
     public boolean addExample(Example item) {
-      Example value = ObjectUtils.requireNonNull(item,"item cannot be null");
+      Example value = ObjectUtils.requireNonNull(item, "item cannot be null");
       if (_examples == null) {
         _examples = new LinkedList<>();
       }
@@ -1144,12 +1259,15 @@ public class METASCHEMA implements IBoundObject {
     }
 
     /**
-     * Remove the first matching {@link Example} item from the underlying collection.
-     * @param item the item to remove
+     * Remove the first matching {@link Example} item from the underlying
+     * collection.
+     *
+     * @param item
+     *          the item to remove
      * @return {@code true} if the item was removed or {@code false} otherwise
      */
     public boolean removeExample(Example item) {
-      Example value = ObjectUtils.requireNonNull(item,"item cannot be null");
+      Example value = ObjectUtils.requireNonNull(item, "item cannot be null");
       return _examples != null && _examples.remove(value);
     }
 
@@ -1159,14 +1277,14 @@ public class METASCHEMA implements IBoundObject {
     }
 
     /**
-     * Provides a root name, for when the definition is used as the root of a node hierarchy.
+     * Provides a root name, for when the definition is used as the root of a node
+     * hierarchy.
      */
     @MetaschemaField(
         formalName = "Root Name",
         description = "Provides a root name, for when the definition is used as the root of a node hierarchy.",
         name = "root-name",
-        moduleClass = MetaschemaModelModule.class
-    )
+        moduleClass = MetaschemaModelModule.class)
     public static class RootName implements IBoundObject {
       private final IMetaschemaData __metaschemaData;
 
@@ -1177,28 +1295,30 @@ public class METASCHEMA implements IBoundObject {
           formalName = "Numeric Index",
           description = "Used for binary formats instead of the textual name.",
           name = "index",
-          typeAdapter = NonNegativeIntegerAdapter.class
-      )
+          typeAdapter = NonNegativeIntegerAdapter.class)
       private BigInteger _index;
 
       @BoundFieldValue(
           valueKeyName = "name",
-          typeAdapter = TokenAdapter.class
-      )
+          typeAdapter = TokenAdapter.class)
       private String _name;
 
       /**
-       * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.METASCHEMA.DefineAssembly.RootName} instance with no metadata.
+       * Constructs a new
+       * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.METASCHEMA.DefineAssembly.RootName}
+       * instance with no metadata.
        */
       public RootName() {
         this(null);
       }
 
       /**
-       * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.METASCHEMA.DefineAssembly.RootName} instance with the specified metadata.
+       * Constructs a new
+       * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.METASCHEMA.DefineAssembly.RootName}
+       * instance with the specified metadata.
        *
        * @param data
-       *           the metaschema data, or {@code null} if none
+       *          the metaschema data, or {@code null} if none
        */
       public RootName(IMetaschemaData data) {
         this.__metaschemaData = data;
@@ -1229,7 +1349,7 @@ public class METASCHEMA implements IBoundObject {
        * Used for binary formats instead of the textual name.
        *
        * @param value
-       *           the index value to set
+       *          the index value to set, or {@code null} to clear
        */
       public void setIndex(@Nullable BigInteger value) {
         _index = value;
@@ -1254,8 +1374,7 @@ public class METASCHEMA implements IBoundObject {
   @MetaschemaAssembly(
       formalName = "Global Field Definition",
       name = "define-field",
-      moduleClass = MetaschemaModelModule.class
-  )
+      moduleClass = MetaschemaModelModule.class)
   public static class DefineField implements IBoundObject {
     private final IMetaschemaData __metaschemaData;
 
@@ -1263,15 +1382,13 @@ public class METASCHEMA implements IBoundObject {
         formalName = "Global Field Name",
         name = "name",
         required = true,
-        typeAdapter = TokenAdapter.class
-    )
+        typeAdapter = TokenAdapter.class)
     private String _name;
 
     @BoundFlag(
         formalName = "Global Field Binary Name",
         name = "index",
-        typeAdapter = PositiveIntegerAdapter.class
-    )
+        typeAdapter = PositiveIntegerAdapter.class)
     private BigInteger _index;
 
     @BoundFlag(
@@ -1279,15 +1396,17 @@ public class METASCHEMA implements IBoundObject {
         name = "scope",
         defaultValue = "global",
         typeAdapter = TokenAdapter.class,
-        valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "local", description = "This definition is only available in the context of the current Metaschema module."), @AllowedValue(value = "global", description = "This definition will be made available to any Metaschema module that includes this one either directly or indirectly through a chain of imported Metaschemas.")}))
-    )
+        valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {
+            @AllowedValue(value = "local",
+                description = "This definition is only available in the context of the current Metaschema module."),
+            @AllowedValue(value = "global",
+                description = "This definition will be made available to any Metaschema module that includes this one either directly or indirectly through a chain of imported Metaschemas.") })))
     private String _scope;
 
     @BoundFlag(
         formalName = "Deprecated Version",
         name = "deprecated",
-        typeAdapter = StringAdapter.class
-    )
+        typeAdapter = StringAdapter.class)
     private String _deprecated;
 
     @BoundFlag(
@@ -1295,15 +1414,76 @@ public class METASCHEMA implements IBoundObject {
         name = "as-type",
         defaultValue = "string",
         typeAdapter = TokenAdapter.class,
-        valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, allowOthers = true, values = {@AllowedValue(value = "markup-line", description = "The [markup-line](https://framework.metaschema.dev/specification/datatypes/#markup-line) data type."), @AllowedValue(value = "markup-multiline", description = "The [markup-multiline](https://framework.metaschema.dev/specification/datatypes/#markup-multiline) data type."), @AllowedValue(value = "base64", description = "The [base64](https://framework.metaschema.dev/specification/datatypes/#base64) data type."), @AllowedValue(value = "boolean", description = "The [boolean](https://framework.metaschema.dev/specification/datatypes/#boolean) data type."), @AllowedValue(value = "date", description = "The [date](https://framework.metaschema.dev/specification/datatypes/#date) data type."), @AllowedValue(value = "date-time", description = "The [date-time](https://framework.metaschema.dev/specification/datatypes/#date-time) data type."), @AllowedValue(value = "date-time-with-timezone", description = "The [date-time-with-timezone](https://framework.metaschema.dev/specification/datatypes/#date-time-with-timezone) data type."), @AllowedValue(value = "date-with-timezone", description = "The [date-with-timezone](https://framework.metaschema.dev/specification/datatypes/#date-with-timezone) data type."), @AllowedValue(value = "day-time-duration", description = "The [day-time-duration](https://framework.metaschema.dev/specification/datatypes/#day-time-duration) data type."), @AllowedValue(value = "decimal", description = "The [decimal](https://framework.metaschema.dev/specification/datatypes/#decimal) data type."), @AllowedValue(value = "email-address", description = "The [email-address](https://framework.metaschema.dev/specification/datatypes/#email-address) data type."), @AllowedValue(value = "hostname", description = "The [hostname](https://framework.metaschema.dev/specification/datatypes/#hostname) data type."), @AllowedValue(value = "integer", description = "The [integer](https://framework.metaschema.dev/specification/datatypes/#integer) data type."), @AllowedValue(value = "ip-v4-address", description = "The [ip-v4-address](https://framework.metaschema.dev/specification/datatypes/#ip-v4-address) data type."), @AllowedValue(value = "ip-v6-address", description = "The [ip-v6-address](https://framework.metaschema.dev/specification/datatypes/#ip-v6-address) data type."), @AllowedValue(value = "non-negative-integer", description = "The [non-negative-integer](https://framework.metaschema.dev/specification/datatypes/#non-negative-integer) data type."), @AllowedValue(value = "positive-integer", description = "The [positive-integer](https://framework.metaschema.dev/specification/datatypes/#positive-integer) data type."), @AllowedValue(value = "string", description = "The [string](https://framework.metaschema.dev/specification/datatypes/#string) data type."), @AllowedValue(value = "token", description = "The [token](https://framework.metaschema.dev/specification/datatypes/#token) data type."), @AllowedValue(value = "uri", description = "The [uri](https://framework.metaschema.dev/specification/datatypes/#uri) data type."), @AllowedValue(value = "uri-reference", description = "The [uri-reference](https://framework.metaschema.dev/specification/datatypes/#uri-reference) data type."), @AllowedValue(value = "uuid", description = "The [uuid](https://framework.metaschema.dev/specification/datatypes/#uuid) data type."), @AllowedValue(value = "base64Binary", description = "An old name which is deprecated for use in favor of the 'base64' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "dateTime", description = "An old name which is deprecated for use in favor of the 'date-time' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "dateTime-with-timezone", description = "An old name which is deprecated for use in favor of the 'date-time-with-timezone' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "email", description = "An old name which is deprecated for use in favor of the 'email-address' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "nonNegativeInteger", description = "An old name which is deprecated for use in favor of the 'non-negative-integer' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "positiveInteger", description = "An old name which is deprecated for use in favor of the 'positive-integer' data type.", deprecatedVersion = "1.0.0")}))
-    )
+        valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR,
+            allowOthers = true,
+            values = { @AllowedValue(value = "markup-line",
+                description = "The [markup-line](https://framework.metaschema.dev/specification/datatypes/#markup-line) data type."),
+                @AllowedValue(value = "markup-multiline",
+                    description = "The [markup-multiline](https://framework.metaschema.dev/specification/datatypes/#markup-multiline) data type."),
+                @AllowedValue(value = "base64",
+                    description = "The [base64](https://framework.metaschema.dev/specification/datatypes/#base64) data type."),
+                @AllowedValue(value = "boolean",
+                    description = "The [boolean](https://framework.metaschema.dev/specification/datatypes/#boolean) data type."),
+                @AllowedValue(value = "date",
+                    description = "The [date](https://framework.metaschema.dev/specification/datatypes/#date) data type."),
+                @AllowedValue(value = "date-time",
+                    description = "The [date-time](https://framework.metaschema.dev/specification/datatypes/#date-time) data type."),
+                @AllowedValue(value = "date-time-with-timezone",
+                    description = "The [date-time-with-timezone](https://framework.metaschema.dev/specification/datatypes/#date-time-with-timezone) data type."),
+                @AllowedValue(value = "date-with-timezone",
+                    description = "The [date-with-timezone](https://framework.metaschema.dev/specification/datatypes/#date-with-timezone) data type."),
+                @AllowedValue(value = "day-time-duration",
+                    description = "The [day-time-duration](https://framework.metaschema.dev/specification/datatypes/#day-time-duration) data type."),
+                @AllowedValue(value = "decimal",
+                    description = "The [decimal](https://framework.metaschema.dev/specification/datatypes/#decimal) data type."),
+                @AllowedValue(value = "email-address",
+                    description = "The [email-address](https://framework.metaschema.dev/specification/datatypes/#email-address) data type."),
+                @AllowedValue(value = "hostname",
+                    description = "The [hostname](https://framework.metaschema.dev/specification/datatypes/#hostname) data type."),
+                @AllowedValue(value = "integer",
+                    description = "The [integer](https://framework.metaschema.dev/specification/datatypes/#integer) data type."),
+                @AllowedValue(value = "ip-v4-address",
+                    description = "The [ip-v4-address](https://framework.metaschema.dev/specification/datatypes/#ip-v4-address) data type."),
+                @AllowedValue(value = "ip-v6-address",
+                    description = "The [ip-v6-address](https://framework.metaschema.dev/specification/datatypes/#ip-v6-address) data type."),
+                @AllowedValue(value = "non-negative-integer",
+                    description = "The [non-negative-integer](https://framework.metaschema.dev/specification/datatypes/#non-negative-integer) data type."),
+                @AllowedValue(value = "positive-integer",
+                    description = "The [positive-integer](https://framework.metaschema.dev/specification/datatypes/#positive-integer) data type."),
+                @AllowedValue(value = "string",
+                    description = "The [string](https://framework.metaschema.dev/specification/datatypes/#string) data type."),
+                @AllowedValue(value = "token",
+                    description = "The [token](https://framework.metaschema.dev/specification/datatypes/#token) data type."),
+                @AllowedValue(value = "uri",
+                    description = "The [uri](https://framework.metaschema.dev/specification/datatypes/#uri) data type."),
+                @AllowedValue(value = "uri-reference",
+                    description = "The [uri-reference](https://framework.metaschema.dev/specification/datatypes/#uri-reference) data type."),
+                @AllowedValue(value = "uuid",
+                    description = "The [uuid](https://framework.metaschema.dev/specification/datatypes/#uuid) data type."),
+                @AllowedValue(value = "base64Binary",
+                    description = "An old name which is deprecated for use in favor of the 'base64' data type.",
+                    deprecatedVersion = "1.0.0"),
+                @AllowedValue(value = "dateTime",
+                    description = "An old name which is deprecated for use in favor of the 'date-time' data type.",
+                    deprecatedVersion = "1.0.0"),
+                @AllowedValue(value = "dateTime-with-timezone",
+                    description = "An old name which is deprecated for use in favor of the 'date-time-with-timezone' data type.",
+                    deprecatedVersion = "1.0.0"),
+                @AllowedValue(value = "email",
+                    description = "An old name which is deprecated for use in favor of the 'email-address' data type.",
+                    deprecatedVersion = "1.0.0"),
+                @AllowedValue(value = "nonNegativeInteger",
+                    description = "An old name which is deprecated for use in favor of the 'non-negative-integer' data type.",
+                    deprecatedVersion = "1.0.0"),
+                @AllowedValue(value = "positiveInteger",
+                    description = "An old name which is deprecated for use in favor of the 'positive-integer' data type.",
+                    deprecatedVersion = "1.0.0") })))
     private String _asType;
 
     @BoundFlag(
         formalName = "Default Field Value",
         name = "default",
-        typeAdapter = StringAdapter.class
-    )
+        typeAdapter = StringAdapter.class)
     private String _default;
 
     /**
@@ -1313,27 +1493,25 @@ public class METASCHEMA implements IBoundObject {
         formalName = "Formal Name",
         description = "A formal name for the data construct, to be presented in documentation.",
         useName = "formal-name",
-        typeAdapter = StringAdapter.class
-    )
+        typeAdapter = StringAdapter.class)
     private String _formalName;
 
     /**
-     * A short description of the data construct's purpose, describing the constructs semantics.
+     * A short description of the data construct's purpose, describing the
+     * constructs semantics.
      */
     @BoundField(
         formalName = "Description",
         description = "A short description of the data construct's purpose, describing the constructs semantics.",
         useName = "description",
-        typeAdapter = MarkupLineAdapter.class
-    )
+        typeAdapter = MarkupLineAdapter.class)
     private MarkupLine _description;
 
     @BoundAssembly(
         formalName = "Property",
         useName = "prop",
         maxOccurs = -1,
-        groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST)
-    )
+        groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST))
     private List<Property> _props;
 
     /**
@@ -1342,84 +1520,83 @@ public class METASCHEMA implements IBoundObject {
     @BoundField(
         formalName = "Use Name",
         description = "Allows the name of the definition to be overridden.",
-        useName = "use-name"
-    )
+        useName = "use-name")
     private UseName _useName;
 
     /**
-     * Used in JSON (and similar formats) to identify a flag that will be used as the property name in an object hold a collection of sibling objects. Requires that siblings must never share <code>json-key</code> values.
+     * Used in JSON (and similar formats) to identify a flag that will be used as
+     * the property name in an object hold a collection of sibling objects. Requires
+     * that siblings must never share <code>json-key</code> values.
      */
     @BoundAssembly(
         formalName = "JSON Key",
         description = "Used in JSON (and similar formats) to identify a flag that will be used as the property name in an object hold a collection of sibling objects. Requires that siblings must never share `json-key` values.",
-        useName = "json-key"
-    )
+        useName = "json-key")
     private JsonKey _jsonKey;
 
     @BoundField(
         formalName = "Field Value JSON Property Name",
         useName = "json-value-key",
-        typeAdapter = TokenAdapter.class
-    )
+        typeAdapter = TokenAdapter.class)
     @BoundChoice(
-        choiceId = "choice-1"
-    )
+        choiceId = "choice-1")
     private String _jsonValueKey;
 
     @BoundAssembly(
         formalName = "Flag Used as the Field Value's JSON Property Name",
-        useName = "json-value-key-flag"
-    )
+        useName = "json-value-key-flag")
     @BoundChoice(
-        choiceId = "choice-1"
-    )
+        choiceId = "choice-1")
     private JsonValueKeyFlag _jsonValueKeyFlag;
 
     @BoundChoiceGroup(
         maxOccurs = -1,
         groupAs = @GroupAs(name = "flags", inJson = JsonGroupAsBehavior.LIST),
         assemblies = {
-            @BoundGroupedAssembly(formalName = "Inline Flag Definition", useName = "define-flag", discriminatorValue = "flag", binding = InlineDefineFlag.class),
-            @BoundGroupedAssembly(formalName = "Flag Reference", useName = "flag", discriminatorValue = "flag-ref", binding = FlagReference.class)
-        }
-    )
+            @BoundGroupedAssembly(formalName = "Inline Flag Definition", useName = "define-flag",
+                discriminatorValue = "flag", binding = InlineDefineFlag.class),
+            @BoundGroupedAssembly(formalName = "Flag Reference", useName = "flag", discriminatorValue = "flag-ref",
+                binding = FlagReference.class)
+        })
     private List<Object> _flags;
 
     @BoundAssembly(
-        useName = "constraint"
-    )
+        useName = "constraint")
     private FieldConstraints _constraint;
 
     /**
-     * Any explanatory or helpful information to be provided about the remarks parent.
+     * Any explanatory or helpful information to be provided about the remarks
+     * parent.
      */
     @BoundField(
         formalName = "Remarks",
         description = "Any explanatory or helpful information to be provided about the remarks parent.",
-        useName = "remarks"
-    )
+        useName = "remarks")
     private Remarks _remarks;
 
     @BoundAssembly(
         formalName = "Example",
         useName = "example",
         maxOccurs = -1,
-        groupAs = @GroupAs(name = "examples", inJson = JsonGroupAsBehavior.LIST)
-    )
+        groupAs = @GroupAs(name = "examples", inJson = JsonGroupAsBehavior.LIST))
     private List<Example> _examples;
 
     /**
-     * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.METASCHEMA.DefineField} instance with no metadata.
+     * Constructs a new
+     * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.METASCHEMA.DefineField}
+     * instance with no metadata.
      */
     public DefineField() {
       this(null);
     }
 
     /**
-     * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.METASCHEMA.DefineField} instance with the specified metadata.
+     * Constructs a new
+     * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.METASCHEMA.DefineField}
+     * instance with the specified metadata.
      *
      * @param data
-     *           the metaschema data, or {@code null} if none
+     *          the metaschema data, or {@code null} if none
      */
     public DefineField(IMetaschemaData data) {
       this.__metaschemaData = data;
@@ -1444,7 +1621,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the global Field Name.
      *
      * @param value
-     *           the name value to set
+     *          the name value to set
      */
     public void setName(@NonNull String value) {
       _name = value;
@@ -1464,7 +1641,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the global Field Binary Name.
      *
      * @param value
-     *           the index value to set
+     *          the index value to set, or {@code null} to clear
      */
     public void setIndex(@Nullable BigInteger value) {
       _index = value;
@@ -1484,7 +1661,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the definition Scope.
      *
      * @param value
-     *           the scope value to set
+     *          the scope value to set, or {@code null} to clear
      */
     public void setScope(@Nullable String value) {
       _scope = value;
@@ -1504,7 +1681,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the deprecated Version.
      *
      * @param value
-     *           the deprecated value to set
+     *          the deprecated value to set, or {@code null} to clear
      */
     public void setDeprecated(@Nullable String value) {
       _deprecated = value;
@@ -1524,7 +1701,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the field Value Data Type.
      *
      * @param value
-     *           the as-type value to set
+     *          the as-type value to set, or {@code null} to clear
      */
     public void setAsType(@Nullable String value) {
       _asType = value;
@@ -1544,7 +1721,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the default Field Value.
      *
      * @param value
-     *           the default value to set
+     *          the default value to set, or {@code null} to clear
      */
     public void setDefault(@Nullable String value) {
       _default = value;
@@ -1570,7 +1747,7 @@ public class METASCHEMA implements IBoundObject {
      * A formal name for the data construct, to be presented in documentation.
      *
      * @param value
-     *           the formal-name value to set
+     *          the formal-name value to set, or {@code null} to clear
      */
     public void setFormalName(@Nullable String value) {
       _formalName = value;
@@ -1580,7 +1757,8 @@ public class METASCHEMA implements IBoundObject {
      * Get the description.
      *
      * <p>
-     * A short description of the data construct's purpose, describing the constructs semantics.
+     * A short description of the data construct's purpose, describing the
+     * constructs semantics.
      *
      * @return the description value, or {@code null} if not set
      */
@@ -1593,10 +1771,11 @@ public class METASCHEMA implements IBoundObject {
      * Set the description.
      *
      * <p>
-     * A short description of the data construct's purpose, describing the constructs semantics.
+     * A short description of the data construct's purpose, describing the
+     * constructs semantics.
      *
      * @param value
-     *           the description value to set
+     *          the description value to set, or {@code null} to clear
      */
     public void setDescription(@Nullable MarkupLine value) {
       _description = value;
@@ -1619,7 +1798,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the property.
      *
      * @param value
-     *           the prop value to set
+     *          the prop value to set
      */
     public void setProps(@NonNull List<Property> value) {
       _props = value;
@@ -1627,11 +1806,13 @@ public class METASCHEMA implements IBoundObject {
 
     /**
      * Add a new {@link Property} item to the underlying collection.
-     * @param item the item to add
+     *
+     * @param item
+     *          the item to add
      * @return {@code true}
      */
     public boolean addProp(Property item) {
-      Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+      Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
       if (_props == null) {
         _props = new LinkedList<>();
       }
@@ -1639,12 +1820,15 @@ public class METASCHEMA implements IBoundObject {
     }
 
     /**
-     * Remove the first matching {@link Property} item from the underlying collection.
-     * @param item the item to remove
+     * Remove the first matching {@link Property} item from the underlying
+     * collection.
+     *
+     * @param item
+     *          the item to remove
      * @return {@code true} if the item was removed or {@code false} otherwise
      */
     public boolean removeProp(Property item) {
-      Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+      Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
       return _props != null && _props.remove(value);
     }
 
@@ -1668,7 +1852,7 @@ public class METASCHEMA implements IBoundObject {
      * Allows the name of the definition to be overridden.
      *
      * @param value
-     *           the use-name value to set
+     *          the use-name value to set, or {@code null} to clear
      */
     public void setUseName(@Nullable UseName value) {
       _useName = value;
@@ -1678,7 +1862,9 @@ public class METASCHEMA implements IBoundObject {
      * Get the jSON Key.
      *
      * <p>
-     * Used in JSON (and similar formats) to identify a flag that will be used as the property name in an object hold a collection of sibling objects. Requires that siblings must never share <code>json-key</code> values.
+     * Used in JSON (and similar formats) to identify a flag that will be used as
+     * the property name in an object hold a collection of sibling objects. Requires
+     * that siblings must never share <code>json-key</code> values.
      *
      * @return the json-key value, or {@code null} if not set
      */
@@ -1691,10 +1877,12 @@ public class METASCHEMA implements IBoundObject {
      * Set the jSON Key.
      *
      * <p>
-     * Used in JSON (and similar formats) to identify a flag that will be used as the property name in an object hold a collection of sibling objects. Requires that siblings must never share <code>json-key</code> values.
+     * Used in JSON (and similar formats) to identify a flag that will be used as
+     * the property name in an object hold a collection of sibling objects. Requires
+     * that siblings must never share <code>json-key</code> values.
      *
      * @param value
-     *           the json-key value to set
+     *          the json-key value to set, or {@code null} to clear
      */
     public void setJsonKey(@Nullable JsonKey value) {
       _jsonKey = value;
@@ -1714,7 +1902,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the field Value JSON Property Name.
      *
      * @param value
-     *           the json-value-key value to set
+     *          the json-value-key value to set, or {@code null} to clear
      */
     public void setJsonValueKey(@Nullable String value) {
       _jsonValueKey = value;
@@ -1734,7 +1922,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the flag Used as the Field Value's JSON Property Name.
      *
      * @param value
-     *           the json-value-key-flag value to set
+     *          the json-value-key-flag value to set, or {@code null} to clear
      */
     public void setJsonValueKeyFlag(@Nullable JsonValueKeyFlag value) {
       _jsonValueKeyFlag = value;
@@ -1757,7 +1945,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the {@code flags} choice group items.
      *
      * @param value
-     *           the flags items to set
+     *          the flags items to set
      */
     public void setFlags(@NonNull List<Object> value) {
       _flags = value;
@@ -1777,7 +1965,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the {@code constraint} property.
      *
      * @param value
-     *           the constraint value to set
+     *          the constraint value to set, or {@code null} to clear
      */
     public void setConstraint(@Nullable FieldConstraints value) {
       _constraint = value;
@@ -1787,7 +1975,8 @@ public class METASCHEMA implements IBoundObject {
      * Get the remarks.
      *
      * <p>
-     * Any explanatory or helpful information to be provided about the remarks parent.
+     * Any explanatory or helpful information to be provided about the remarks
+     * parent.
      *
      * @return the remarks value, or {@code null} if not set
      */
@@ -1800,10 +1989,11 @@ public class METASCHEMA implements IBoundObject {
      * Set the remarks.
      *
      * <p>
-     * Any explanatory or helpful information to be provided about the remarks parent.
+     * Any explanatory or helpful information to be provided about the remarks
+     * parent.
      *
      * @param value
-     *           the remarks value to set
+     *          the remarks value to set, or {@code null} to clear
      */
     public void setRemarks(@Nullable Remarks value) {
       _remarks = value;
@@ -1826,7 +2016,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the example.
      *
      * @param value
-     *           the example value to set
+     *          the example value to set
      */
     public void setExamples(@NonNull List<Example> value) {
       _examples = value;
@@ -1834,11 +2024,13 @@ public class METASCHEMA implements IBoundObject {
 
     /**
      * Add a new {@link Example} item to the underlying collection.
-     * @param item the item to add
+     *
+     * @param item
+     *          the item to add
      * @return {@code true}
      */
     public boolean addExample(Example item) {
-      Example value = ObjectUtils.requireNonNull(item,"item cannot be null");
+      Example value = ObjectUtils.requireNonNull(item, "item cannot be null");
       if (_examples == null) {
         _examples = new LinkedList<>();
       }
@@ -1846,12 +2038,15 @@ public class METASCHEMA implements IBoundObject {
     }
 
     /**
-     * Remove the first matching {@link Example} item from the underlying collection.
-     * @param item the item to remove
+     * Remove the first matching {@link Example} item from the underlying
+     * collection.
+     *
+     * @param item
+     *          the item to remove
      * @return {@code true} if the item was removed or {@code false} otherwise
      */
     public boolean removeExample(Example item) {
-      Example value = ObjectUtils.requireNonNull(item,"item cannot be null");
+      Example value = ObjectUtils.requireNonNull(item, "item cannot be null");
       return _examples != null && _examples.remove(value);
     }
 
@@ -1864,8 +2059,7 @@ public class METASCHEMA implements IBoundObject {
   @MetaschemaAssembly(
       formalName = "Global Flag Definition",
       name = "define-flag",
-      moduleClass = MetaschemaModelModule.class
-  )
+      moduleClass = MetaschemaModelModule.class)
   public static class DefineFlag implements IBoundObject {
     private final IMetaschemaData __metaschemaData;
 
@@ -1873,15 +2067,13 @@ public class METASCHEMA implements IBoundObject {
         formalName = "Global Flag Name",
         name = "name",
         required = true,
-        typeAdapter = TokenAdapter.class
-    )
+        typeAdapter = TokenAdapter.class)
     private String _name;
 
     @BoundFlag(
         formalName = "Global Flag Binary Name",
         name = "index",
-        typeAdapter = PositiveIntegerAdapter.class
-    )
+        typeAdapter = PositiveIntegerAdapter.class)
     private BigInteger _index;
 
     @BoundFlag(
@@ -1889,15 +2081,17 @@ public class METASCHEMA implements IBoundObject {
         name = "scope",
         defaultValue = "global",
         typeAdapter = TokenAdapter.class,
-        valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "local", description = "This definition is only available in the context of the current Metaschema module."), @AllowedValue(value = "global", description = "This definition will be made available to any Metaschema module that includes this one either directly or indirectly through a chain of imported Metaschemas.")}))
-    )
+        valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {
+            @AllowedValue(value = "local",
+                description = "This definition is only available in the context of the current Metaschema module."),
+            @AllowedValue(value = "global",
+                description = "This definition will be made available to any Metaschema module that includes this one either directly or indirectly through a chain of imported Metaschemas.") })))
     private String _scope;
 
     @BoundFlag(
         formalName = "Deprecated Version",
         name = "deprecated",
-        typeAdapter = StringAdapter.class
-    )
+        typeAdapter = StringAdapter.class)
     private String _deprecated;
 
     @BoundFlag(
@@ -1905,15 +2099,72 @@ public class METASCHEMA implements IBoundObject {
         name = "as-type",
         defaultValue = "string",
         typeAdapter = TokenAdapter.class,
-        valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, allowOthers = true, values = {@AllowedValue(value = "base64", description = "The [base64](https://framework.metaschema.dev/specification/datatypes/#base64) data type."), @AllowedValue(value = "boolean", description = "The [boolean](https://framework.metaschema.dev/specification/datatypes/#boolean) data type."), @AllowedValue(value = "date", description = "The [date](https://framework.metaschema.dev/specification/datatypes/#date) data type."), @AllowedValue(value = "date-time", description = "The [date-time](https://framework.metaschema.dev/specification/datatypes/#date-time) data type."), @AllowedValue(value = "date-time-with-timezone", description = "The [date-time-with-timezone](https://framework.metaschema.dev/specification/datatypes/#date-time-with-timezone) data type."), @AllowedValue(value = "date-with-timezone", description = "The [date-with-timezone](https://framework.metaschema.dev/specification/datatypes/#date-with-timezone) data type."), @AllowedValue(value = "day-time-duration", description = "The [day-time-duration](https://framework.metaschema.dev/specification/datatypes/#day-time-duration) data type."), @AllowedValue(value = "decimal", description = "The [decimal](https://framework.metaschema.dev/specification/datatypes/#decimal) data type."), @AllowedValue(value = "email-address", description = "The [email-address](https://framework.metaschema.dev/specification/datatypes/#email-address) data type."), @AllowedValue(value = "hostname", description = "The [hostname](https://framework.metaschema.dev/specification/datatypes/#hostname) data type."), @AllowedValue(value = "integer", description = "The [integer](https://framework.metaschema.dev/specification/datatypes/#integer) data type."), @AllowedValue(value = "ip-v4-address", description = "The [ip-v4-address](https://framework.metaschema.dev/specification/datatypes/#ip-v4-address) data type."), @AllowedValue(value = "ip-v6-address", description = "The [ip-v6-address](https://framework.metaschema.dev/specification/datatypes/#ip-v6-address) data type."), @AllowedValue(value = "non-negative-integer", description = "The [non-negative-integer](https://framework.metaschema.dev/specification/datatypes/#non-negative-integer) data type."), @AllowedValue(value = "positive-integer", description = "The [positive-integer](https://framework.metaschema.dev/specification/datatypes/#positive-integer) data type."), @AllowedValue(value = "string", description = "The [string](https://framework.metaschema.dev/specification/datatypes/#string) data type."), @AllowedValue(value = "token", description = "The [token](https://framework.metaschema.dev/specification/datatypes/#token) data type."), @AllowedValue(value = "uri", description = "The [uri](https://framework.metaschema.dev/specification/datatypes/#uri) data type."), @AllowedValue(value = "uri-reference", description = "The [uri-reference](https://framework.metaschema.dev/specification/datatypes/#uri-reference) data type."), @AllowedValue(value = "uuid", description = "The [uuid](https://framework.metaschema.dev/specification/datatypes/#uuid) data type."), @AllowedValue(value = "base64Binary", description = "An old name which is deprecated for use in favor of the 'base64' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "dateTime", description = "An old name which is deprecated for use in favor of the 'date-time' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "dateTime-with-timezone", description = "An old name which is deprecated for use in favor of the 'date-time-with-timezone' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "email", description = "An old name which is deprecated for use in favor of the 'email-address' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "nonNegativeInteger", description = "An old name which is deprecated for use in favor of the 'non-negative-integer' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "positiveInteger", description = "An old name which is deprecated for use in favor of the 'positive-integer' data type.", deprecatedVersion = "1.0.0")}))
-    )
+        valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR,
+            allowOthers = true,
+            values = { @AllowedValue(value = "base64",
+                description = "The [base64](https://framework.metaschema.dev/specification/datatypes/#base64) data type."),
+                @AllowedValue(value = "boolean",
+                    description = "The [boolean](https://framework.metaschema.dev/specification/datatypes/#boolean) data type."),
+                @AllowedValue(value = "date",
+                    description = "The [date](https://framework.metaschema.dev/specification/datatypes/#date) data type."),
+                @AllowedValue(value = "date-time",
+                    description = "The [date-time](https://framework.metaschema.dev/specification/datatypes/#date-time) data type."),
+                @AllowedValue(value = "date-time-with-timezone",
+                    description = "The [date-time-with-timezone](https://framework.metaschema.dev/specification/datatypes/#date-time-with-timezone) data type."),
+                @AllowedValue(value = "date-with-timezone",
+                    description = "The [date-with-timezone](https://framework.metaschema.dev/specification/datatypes/#date-with-timezone) data type."),
+                @AllowedValue(value = "day-time-duration",
+                    description = "The [day-time-duration](https://framework.metaschema.dev/specification/datatypes/#day-time-duration) data type."),
+                @AllowedValue(value = "decimal",
+                    description = "The [decimal](https://framework.metaschema.dev/specification/datatypes/#decimal) data type."),
+                @AllowedValue(value = "email-address",
+                    description = "The [email-address](https://framework.metaschema.dev/specification/datatypes/#email-address) data type."),
+                @AllowedValue(value = "hostname",
+                    description = "The [hostname](https://framework.metaschema.dev/specification/datatypes/#hostname) data type."),
+                @AllowedValue(value = "integer",
+                    description = "The [integer](https://framework.metaschema.dev/specification/datatypes/#integer) data type."),
+                @AllowedValue(value = "ip-v4-address",
+                    description = "The [ip-v4-address](https://framework.metaschema.dev/specification/datatypes/#ip-v4-address) data type."),
+                @AllowedValue(value = "ip-v6-address",
+                    description = "The [ip-v6-address](https://framework.metaschema.dev/specification/datatypes/#ip-v6-address) data type."),
+                @AllowedValue(value = "non-negative-integer",
+                    description = "The [non-negative-integer](https://framework.metaschema.dev/specification/datatypes/#non-negative-integer) data type."),
+                @AllowedValue(value = "positive-integer",
+                    description = "The [positive-integer](https://framework.metaschema.dev/specification/datatypes/#positive-integer) data type."),
+                @AllowedValue(value = "string",
+                    description = "The [string](https://framework.metaschema.dev/specification/datatypes/#string) data type."),
+                @AllowedValue(value = "token",
+                    description = "The [token](https://framework.metaschema.dev/specification/datatypes/#token) data type."),
+                @AllowedValue(value = "uri",
+                    description = "The [uri](https://framework.metaschema.dev/specification/datatypes/#uri) data type."),
+                @AllowedValue(value = "uri-reference",
+                    description = "The [uri-reference](https://framework.metaschema.dev/specification/datatypes/#uri-reference) data type."),
+                @AllowedValue(value = "uuid",
+                    description = "The [uuid](https://framework.metaschema.dev/specification/datatypes/#uuid) data type."),
+                @AllowedValue(value = "base64Binary",
+                    description = "An old name which is deprecated for use in favor of the 'base64' data type.",
+                    deprecatedVersion = "1.0.0"),
+                @AllowedValue(value = "dateTime",
+                    description = "An old name which is deprecated for use in favor of the 'date-time' data type.",
+                    deprecatedVersion = "1.0.0"),
+                @AllowedValue(value = "dateTime-with-timezone",
+                    description = "An old name which is deprecated for use in favor of the 'date-time-with-timezone' data type.",
+                    deprecatedVersion = "1.0.0"),
+                @AllowedValue(value = "email",
+                    description = "An old name which is deprecated for use in favor of the 'email-address' data type.",
+                    deprecatedVersion = "1.0.0"),
+                @AllowedValue(value = "nonNegativeInteger",
+                    description = "An old name which is deprecated for use in favor of the 'non-negative-integer' data type.",
+                    deprecatedVersion = "1.0.0"),
+                @AllowedValue(value = "positiveInteger",
+                    description = "An old name which is deprecated for use in favor of the 'positive-integer' data type.",
+                    deprecatedVersion = "1.0.0") })))
     private String _asType;
 
     @BoundFlag(
         formalName = "Default Flag Value",
         name = "default",
-        typeAdapter = StringAdapter.class
-    )
+        typeAdapter = StringAdapter.class)
     private String _default;
 
     /**
@@ -1923,27 +2174,25 @@ public class METASCHEMA implements IBoundObject {
         formalName = "Formal Name",
         description = "A formal name for the data construct, to be presented in documentation.",
         useName = "formal-name",
-        typeAdapter = StringAdapter.class
-    )
+        typeAdapter = StringAdapter.class)
     private String _formalName;
 
     /**
-     * A short description of the data construct's purpose, describing the constructs semantics.
+     * A short description of the data construct's purpose, describing the
+     * constructs semantics.
      */
     @BoundField(
         formalName = "Description",
         description = "A short description of the data construct's purpose, describing the constructs semantics.",
         useName = "description",
-        typeAdapter = MarkupLineAdapter.class
-    )
+        typeAdapter = MarkupLineAdapter.class)
     private MarkupLine _description;
 
     @BoundAssembly(
         formalName = "Property",
         useName = "prop",
         maxOccurs = -1,
-        groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST)
-    )
+        groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST))
     private List<Property> _props;
 
     /**
@@ -1952,45 +2201,46 @@ public class METASCHEMA implements IBoundObject {
     @BoundField(
         formalName = "Use Name",
         description = "Allows the name of the definition to be overridden.",
-        useName = "use-name"
-    )
+        useName = "use-name")
     private UseName _useName;
 
     @BoundAssembly(
-        useName = "constraint"
-    )
+        useName = "constraint")
     private FlagConstraints _constraint;
 
     /**
-     * Any explanatory or helpful information to be provided about the remarks parent.
+     * Any explanatory or helpful information to be provided about the remarks
+     * parent.
      */
     @BoundField(
         formalName = "Remarks",
         description = "Any explanatory or helpful information to be provided about the remarks parent.",
-        useName = "remarks"
-    )
+        useName = "remarks")
     private Remarks _remarks;
 
     @BoundAssembly(
         formalName = "Example",
         useName = "example",
         maxOccurs = -1,
-        groupAs = @GroupAs(name = "examples", inJson = JsonGroupAsBehavior.LIST)
-    )
+        groupAs = @GroupAs(name = "examples", inJson = JsonGroupAsBehavior.LIST))
     private List<Example> _examples;
 
     /**
-     * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.METASCHEMA.DefineFlag} instance with no metadata.
+     * Constructs a new
+     * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.METASCHEMA.DefineFlag}
+     * instance with no metadata.
      */
     public DefineFlag() {
       this(null);
     }
 
     /**
-     * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.METASCHEMA.DefineFlag} instance with the specified metadata.
+     * Constructs a new
+     * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.METASCHEMA.DefineFlag}
+     * instance with the specified metadata.
      *
      * @param data
-     *           the metaschema data, or {@code null} if none
+     *          the metaschema data, or {@code null} if none
      */
     public DefineFlag(IMetaschemaData data) {
       this.__metaschemaData = data;
@@ -2015,7 +2265,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the global Flag Name.
      *
      * @param value
-     *           the name value to set
+     *          the name value to set
      */
     public void setName(@NonNull String value) {
       _name = value;
@@ -2035,7 +2285,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the global Flag Binary Name.
      *
      * @param value
-     *           the index value to set
+     *          the index value to set, or {@code null} to clear
      */
     public void setIndex(@Nullable BigInteger value) {
       _index = value;
@@ -2055,7 +2305,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the definition Scope.
      *
      * @param value
-     *           the scope value to set
+     *          the scope value to set, or {@code null} to clear
      */
     public void setScope(@Nullable String value) {
       _scope = value;
@@ -2075,7 +2325,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the deprecated Version.
      *
      * @param value
-     *           the deprecated value to set
+     *          the deprecated value to set, or {@code null} to clear
      */
     public void setDeprecated(@Nullable String value) {
       _deprecated = value;
@@ -2095,7 +2345,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the flag Value Data Type.
      *
      * @param value
-     *           the as-type value to set
+     *          the as-type value to set, or {@code null} to clear
      */
     public void setAsType(@Nullable String value) {
       _asType = value;
@@ -2115,7 +2365,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the default Flag Value.
      *
      * @param value
-     *           the default value to set
+     *          the default value to set, or {@code null} to clear
      */
     public void setDefault(@Nullable String value) {
       _default = value;
@@ -2141,7 +2391,7 @@ public class METASCHEMA implements IBoundObject {
      * A formal name for the data construct, to be presented in documentation.
      *
      * @param value
-     *           the formal-name value to set
+     *          the formal-name value to set, or {@code null} to clear
      */
     public void setFormalName(@Nullable String value) {
       _formalName = value;
@@ -2151,7 +2401,8 @@ public class METASCHEMA implements IBoundObject {
      * Get the description.
      *
      * <p>
-     * A short description of the data construct's purpose, describing the constructs semantics.
+     * A short description of the data construct's purpose, describing the
+     * constructs semantics.
      *
      * @return the description value, or {@code null} if not set
      */
@@ -2164,10 +2415,11 @@ public class METASCHEMA implements IBoundObject {
      * Set the description.
      *
      * <p>
-     * A short description of the data construct's purpose, describing the constructs semantics.
+     * A short description of the data construct's purpose, describing the
+     * constructs semantics.
      *
      * @param value
-     *           the description value to set
+     *          the description value to set, or {@code null} to clear
      */
     public void setDescription(@Nullable MarkupLine value) {
       _description = value;
@@ -2190,7 +2442,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the property.
      *
      * @param value
-     *           the prop value to set
+     *          the prop value to set
      */
     public void setProps(@NonNull List<Property> value) {
       _props = value;
@@ -2198,11 +2450,13 @@ public class METASCHEMA implements IBoundObject {
 
     /**
      * Add a new {@link Property} item to the underlying collection.
-     * @param item the item to add
+     *
+     * @param item
+     *          the item to add
      * @return {@code true}
      */
     public boolean addProp(Property item) {
-      Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+      Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
       if (_props == null) {
         _props = new LinkedList<>();
       }
@@ -2210,12 +2464,15 @@ public class METASCHEMA implements IBoundObject {
     }
 
     /**
-     * Remove the first matching {@link Property} item from the underlying collection.
-     * @param item the item to remove
+     * Remove the first matching {@link Property} item from the underlying
+     * collection.
+     *
+     * @param item
+     *          the item to remove
      * @return {@code true} if the item was removed or {@code false} otherwise
      */
     public boolean removeProp(Property item) {
-      Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+      Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
       return _props != null && _props.remove(value);
     }
 
@@ -2239,7 +2496,7 @@ public class METASCHEMA implements IBoundObject {
      * Allows the name of the definition to be overridden.
      *
      * @param value
-     *           the use-name value to set
+     *          the use-name value to set, or {@code null} to clear
      */
     public void setUseName(@Nullable UseName value) {
       _useName = value;
@@ -2259,7 +2516,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the {@code constraint} property.
      *
      * @param value
-     *           the constraint value to set
+     *          the constraint value to set, or {@code null} to clear
      */
     public void setConstraint(@Nullable FlagConstraints value) {
       _constraint = value;
@@ -2269,7 +2526,8 @@ public class METASCHEMA implements IBoundObject {
      * Get the remarks.
      *
      * <p>
-     * Any explanatory or helpful information to be provided about the remarks parent.
+     * Any explanatory or helpful information to be provided about the remarks
+     * parent.
      *
      * @return the remarks value, or {@code null} if not set
      */
@@ -2282,10 +2540,11 @@ public class METASCHEMA implements IBoundObject {
      * Set the remarks.
      *
      * <p>
-     * Any explanatory or helpful information to be provided about the remarks parent.
+     * Any explanatory or helpful information to be provided about the remarks
+     * parent.
      *
      * @param value
-     *           the remarks value to set
+     *          the remarks value to set, or {@code null} to clear
      */
     public void setRemarks(@Nullable Remarks value) {
       _remarks = value;
@@ -2308,7 +2567,7 @@ public class METASCHEMA implements IBoundObject {
      * Set the example.
      *
      * @param value
-     *           the example value to set
+     *          the example value to set
      */
     public void setExamples(@NonNull List<Example> value) {
       _examples = value;
@@ -2316,11 +2575,13 @@ public class METASCHEMA implements IBoundObject {
 
     /**
      * Add a new {@link Example} item to the underlying collection.
-     * @param item the item to add
+     *
+     * @param item
+     *          the item to add
      * @return {@code true}
      */
     public boolean addExample(Example item) {
-      Example value = ObjectUtils.requireNonNull(item,"item cannot be null");
+      Example value = ObjectUtils.requireNonNull(item, "item cannot be null");
       if (_examples == null) {
         _examples = new LinkedList<>();
       }
@@ -2328,12 +2589,15 @@ public class METASCHEMA implements IBoundObject {
     }
 
     /**
-     * Remove the first matching {@link Example} item from the underlying collection.
-     * @param item the item to remove
+     * Remove the first matching {@link Example} item from the underlying
+     * collection.
+     *
+     * @param item
+     *          the item to remove
      * @return {@code true} if the item was removed or {@code false} otherwise
      */
     public boolean removeExample(Example item) {
-      Example value = ObjectUtils.requireNonNull(item,"item cannot be null");
+      Example value = ObjectUtils.requireNonNull(item, "item cannot be null");
       return _examples != null && _examples.remove(value);
     }
 

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/MetapathContext.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/MetapathContext.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -23,57 +24,58 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 
 @MetaschemaAssembly(
     name = "metapath-context",
-    moduleClass = MetaschemaModelModule.class
-)
+    moduleClass = MetaschemaModelModule.class)
 public class MetapathContext implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
   /**
-   * A Metapath expression identifying the model node that the constraints will be applied to.
+   * A Metapath expression identifying the model node that the constraints will be
+   * applied to.
    */
   @BoundAssembly(
       description = "A Metapath expression identifying the model node that the constraints will be applied to.",
       useName = "metapath",
       minOccurs = 1,
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "metapaths", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "metapaths", inJson = JsonGroupAsBehavior.LIST))
   private List<MetaschemaMetapath> _metapaths;
 
   @BoundAssembly(
-      useName = "constraints"
-  )
+      useName = "constraints")
   private AssemblyConstraints _constraints;
 
   @BoundAssembly(
       useName = "context",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "contexts", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "contexts", inJson = JsonGroupAsBehavior.LIST))
   private List<MetapathContext> _contexts;
 
   /**
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    */
   @BoundField(
       formalName = "Remarks",
       description = "Any explanatory or helpful information to be provided about the remarks parent.",
-      useName = "remarks"
-  )
+      useName = "remarks")
   private Remarks _remarks;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetapathContext} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetapathContext}
+   * instance with no metadata.
    */
   public MetapathContext() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetapathContext} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetapathContext}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public MetapathContext(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -88,7 +90,8 @@ public class MetapathContext implements IBoundObject {
    * Get the {@code metapath} property.
    *
    * <p>
-   * A Metapath expression identifying the model node that the constraints will be applied to.
+   * A Metapath expression identifying the model node that the constraints will be
+   * applied to.
    *
    * @return the metapath value
    */
@@ -104,10 +107,11 @@ public class MetapathContext implements IBoundObject {
    * Set the {@code metapath} property.
    *
    * <p>
-   * A Metapath expression identifying the model node that the constraints will be applied to.
+   * A Metapath expression identifying the model node that the constraints will be
+   * applied to.
    *
    * @param value
-   *           the metapath value to set
+   *          the metapath value to set
    */
   public void setMetapaths(@NonNull List<MetaschemaMetapath> value) {
     _metapaths = value;
@@ -115,11 +119,13 @@ public class MetapathContext implements IBoundObject {
 
   /**
    * Add a new {@link MetaschemaMetapath} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addMetapath(MetaschemaMetapath item) {
-    MetaschemaMetapath value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    MetaschemaMetapath value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_metapaths == null) {
       _metapaths = new LinkedList<>();
     }
@@ -127,12 +133,15 @@ public class MetapathContext implements IBoundObject {
   }
 
   /**
-   * Remove the first matching {@link MetaschemaMetapath} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link MetaschemaMetapath} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeMetapath(MetaschemaMetapath item) {
-    MetaschemaMetapath value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    MetaschemaMetapath value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _metapaths != null && _metapaths.remove(value);
   }
 
@@ -150,7 +159,7 @@ public class MetapathContext implements IBoundObject {
    * Set the {@code constraints} property.
    *
    * @param value
-   *           the constraints value to set
+   *          the constraints value to set, or {@code null} to clear
    */
   public void setConstraints(@Nullable AssemblyConstraints value) {
     _constraints = value;
@@ -173,7 +182,7 @@ public class MetapathContext implements IBoundObject {
    * Set the {@code context} property.
    *
    * @param value
-   *           the context value to set
+   *          the context value to set
    */
   public void setContexts(@NonNull List<MetapathContext> value) {
     _contexts = value;
@@ -181,11 +190,13 @@ public class MetapathContext implements IBoundObject {
 
   /**
    * Add a new {@link MetapathContext} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addContext(MetapathContext item) {
-    MetapathContext value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    MetapathContext value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_contexts == null) {
       _contexts = new LinkedList<>();
     }
@@ -193,12 +204,15 @@ public class MetapathContext implements IBoundObject {
   }
 
   /**
-   * Remove the first matching {@link MetapathContext} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link MetapathContext} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeContext(MetapathContext item) {
-    MetapathContext value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    MetapathContext value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _contexts != null && _contexts.remove(value);
   }
 
@@ -206,7 +220,8 @@ public class MetapathContext implements IBoundObject {
    * Get the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @return the remarks value, or {@code null} if not set
    */
@@ -219,10 +234,11 @@ public class MetapathContext implements IBoundObject {
    * Set the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @param value
-   *           the remarks value to set
+   *          the remarks value to set, or {@code null} to clear
    */
   public void setRemarks(@Nullable Remarks value) {
     _remarks = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/MetapathNamespace.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/MetapathNamespace.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -19,14 +20,14 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 /**
- * Assigns a Metapath namespace to a prefix for use in a Metapath expression in a lexical qualified name.
+ * Assigns a Metapath namespace to a prefix for use in a Metapath expression in
+ * a lexical qualified name.
  */
 @MetaschemaAssembly(
     formalName = "Metapath Namespace Declaration",
     description = "Assigns a Metapath namespace to a prefix for use in a Metapath expression in a lexical qualified name.",
     name = "metapath-namespace",
-    moduleClass = MetaschemaModelModule.class
-)
+    moduleClass = MetaschemaModelModule.class)
 public class MetapathNamespace implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
@@ -38,8 +39,7 @@ public class MetapathNamespace implements IBoundObject {
       description = "The namespace URI to bind to the prefix.",
       name = "uri",
       required = true,
-      typeAdapter = UriAdapter.class
-  )
+      typeAdapter = UriAdapter.class)
   private URI _uri;
 
   /**
@@ -50,22 +50,25 @@ public class MetapathNamespace implements IBoundObject {
       description = "The prefix that is bound to the namespace.",
       name = "prefix",
       required = true,
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _prefix;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetapathNamespace} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetapathNamespace}
+   * instance with no metadata.
    */
   public MetapathNamespace() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetapathNamespace} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetapathNamespace}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public MetapathNamespace(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -96,7 +99,7 @@ public class MetapathNamespace implements IBoundObject {
    * The namespace URI to bind to the prefix.
    *
    * @param value
-   *           the uri value to set
+   *          the uri value to set
    */
   public void setUri(@NonNull URI value) {
     _uri = value;
@@ -122,7 +125,7 @@ public class MetapathNamespace implements IBoundObject {
    * The prefix that is bound to the namespace.
    *
    * @param value
-   *           the prefix value to set
+   *          the prefix value to set
    */
   public void setPrefix(@NonNull String value) {
     _prefix = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/MetaschemaMetaConstraints.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/MetaschemaMetaConstraints.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -33,7 +34,8 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 /**
- * Defines constraint rules to be applied to an existing set of Metaschema module-based models.
+ * Defines constraint rules to be applied to an existing set of Metaschema
+ * module-based models.
  */
 @MetaschemaAssembly(
     formalName = "External Module Constraints",
@@ -41,60 +43,75 @@ import org.apache.commons.lang3.builder.ToStringStyle;
     name = "metaschema-meta-constraints",
     moduleClass = MetaschemaModelModule.class,
     rootName = "metaschema-meta-constraints",
-    valueConstraints = @ValueConstraints(lets = @Let(name = "deprecated-type-map", target = "map { 'base64Binary':'base64','dateTime':'date-time','dateTime-with-timezone':'date-time-with-timezone','email':'email-address','nonNegativeInteger':'non-negative-integer','positiveInteger':'positive-integer' }"), expect = @Expect(id = "metaschema-deprecated-types", formalName = "Avoid Deprecated Data Type Use", description = "Ensure that the data type specified is not one of the legacy Metaschema data types which have been deprecated (i.e. base64Binary, dateTime, dateTime-with-timezone, email, nonNegativeInteger, positiveInteger).", level = IConstraint.Level.WARNING, target = ".//matches/@datatype|.//(define-field|define-flag)/@as-type", test = "not(data(.)=('base64Binary','dateTime','dateTime-with-timezone','email','nonNegativeInteger','positiveInteger'))", message = "Use of the type '{ data(.) }' is deprecated. Use '{ $deprecated-type-map(data(.))}' instead.")),
-    modelConstraints = @gov.nist.secauto.metaschema.databind.model.annotations.AssemblyConstraints(unique = {@IsUnique(id = "meta-constraints-namespace-unique-entry", formalName = "Require Unique Namespace Entries", description = "Ensures that all declared namespace entries are unique.", level = IConstraint.Level.ERROR, target = "namespace-binding", keyFields = {@KeyField(target = "@prefix"), @KeyField(target = "@uri")}), @IsUnique(id = "meta-constraints-namespace-unique-prefix", formalName = "Require Unique Namespace Entry Prefixes", description = "Ensures that all declared namespace entries have a unique prefix.", level = IConstraint.Level.ERROR, target = "namespace-binding", keyFields = @KeyField(target = "@prefix"))})
-)
+    valueConstraints = @ValueConstraints(lets = @Let(name = "deprecated-type-map",
+        target = "map { 'base64Binary':'base64','dateTime':'date-time','dateTime-with-timezone':'date-time-with-timezone','email':'email-address','nonNegativeInteger':'non-negative-integer','positiveInteger':'positive-integer' }"),
+        expect = @Expect(id = "metaschema-deprecated-types", formalName = "Avoid Deprecated Data Type Use",
+            description = "Ensure that the data type specified is not one of the legacy Metaschema data types which have been deprecated (i.e. base64Binary, dateTime, dateTime-with-timezone, email, nonNegativeInteger, positiveInteger).",
+            level = IConstraint.Level.WARNING, target = ".//matches/@datatype|.//(define-field|define-flag)/@as-type",
+            test = "not(data(.)=('base64Binary','dateTime','dateTime-with-timezone','email','nonNegativeInteger','positiveInteger'))",
+            message = "Use of the type '{ data(.) }' is deprecated. Use '{ $deprecated-type-map(data(.))}' instead.")),
+    modelConstraints = @gov.nist.secauto.metaschema.databind.model.annotations.AssemblyConstraints(unique = {
+        @IsUnique(id = "meta-constraints-namespace-unique-entry", formalName = "Require Unique Namespace Entries",
+            description = "Ensures that all declared namespace entries are unique.", level = IConstraint.Level.ERROR,
+            target = "namespace-binding", keyFields = { @KeyField(target = "@prefix"), @KeyField(target = "@uri") }),
+        @IsUnique(id = "meta-constraints-namespace-unique-prefix",
+            formalName = "Require Unique Namespace Entry Prefixes",
+            description = "Ensures that all declared namespace entries have a unique prefix.",
+            level = IConstraint.Level.ERROR, target = "namespace-binding",
+            keyFields = @KeyField(target = "@prefix")) }))
 public class MetaschemaMetaConstraints implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
   /**
-   * Declares a set of Metaschema constraints from an out-of-line resource to import, supporting composition of constraint sets.
+   * Declares a set of Metaschema constraints from an out-of-line resource to
+   * import, supporting composition of constraint sets.
    */
   @BoundAssembly(
       description = "Declares a set of Metaschema constraints from an out-of-line resource to import, supporting composition of constraint sets.",
       useName = "import",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "imports", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "imports", inJson = JsonGroupAsBehavior.LIST))
   private List<Import> _imports;
 
   /**
-   * Assigns a Metapath namespace to a prefix for use in a Metapath expression in a lexical qualified name.
+   * Assigns a Metapath namespace to a prefix for use in a Metapath expression in
+   * a lexical qualified name.
    */
   @BoundAssembly(
       formalName = "Metapath Namespace Declaration",
       description = "Assigns a Metapath namespace to a prefix for use in a Metapath expression in a lexical qualified name.",
       useName = "namespace-binding",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "namespace-bindings", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "namespace-bindings", inJson = JsonGroupAsBehavior.LIST))
   private List<MetapathNamespace> _namespaceBindings;
 
   @BoundAssembly(
-      useName = "definition-context"
-  )
+      useName = "definition-context")
   private DefinitionContext _definitionContext;
 
   @BoundAssembly(
       useName = "context",
       minOccurs = 1,
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "contexts", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "contexts", inJson = JsonGroupAsBehavior.LIST))
   private List<MetapathContext> _contexts;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaMetaConstraints} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaMetaConstraints}
+   * instance with no metadata.
    */
   public MetaschemaMetaConstraints() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaMetaConstraints} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaMetaConstraints}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public MetaschemaMetaConstraints(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -109,7 +126,8 @@ public class MetaschemaMetaConstraints implements IBoundObject {
    * Get the {@code import} property.
    *
    * <p>
-   * Declares a set of Metaschema constraints from an out-of-line resource to import, supporting composition of constraint sets.
+   * Declares a set of Metaschema constraints from an out-of-line resource to
+   * import, supporting composition of constraint sets.
    *
    * @return the import value
    */
@@ -125,10 +143,11 @@ public class MetaschemaMetaConstraints implements IBoundObject {
    * Set the {@code import} property.
    *
    * <p>
-   * Declares a set of Metaschema constraints from an out-of-line resource to import, supporting composition of constraint sets.
+   * Declares a set of Metaschema constraints from an out-of-line resource to
+   * import, supporting composition of constraint sets.
    *
    * @param value
-   *           the import value to set
+   *          the import value to set
    */
   public void setImports(@NonNull List<Import> value) {
     _imports = value;
@@ -136,11 +155,13 @@ public class MetaschemaMetaConstraints implements IBoundObject {
 
   /**
    * Add a new {@link Import} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addImport(Import item) {
-    Import value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Import value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_imports == null) {
       _imports = new LinkedList<>();
     }
@@ -149,11 +170,13 @@ public class MetaschemaMetaConstraints implements IBoundObject {
 
   /**
    * Remove the first matching {@link Import} item from the underlying collection.
-   * @param item the item to remove
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeImport(Import item) {
-    Import value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Import value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _imports != null && _imports.remove(value);
   }
 
@@ -161,7 +184,8 @@ public class MetaschemaMetaConstraints implements IBoundObject {
    * Get the metapath Namespace Declaration.
    *
    * <p>
-   * Assigns a Metapath namespace to a prefix for use in a Metapath expression in a lexical qualified name.
+   * Assigns a Metapath namespace to a prefix for use in a Metapath expression in
+   * a lexical qualified name.
    *
    * @return the namespace-binding value
    */
@@ -177,10 +201,11 @@ public class MetaschemaMetaConstraints implements IBoundObject {
    * Set the metapath Namespace Declaration.
    *
    * <p>
-   * Assigns a Metapath namespace to a prefix for use in a Metapath expression in a lexical qualified name.
+   * Assigns a Metapath namespace to a prefix for use in a Metapath expression in
+   * a lexical qualified name.
    *
    * @param value
-   *           the namespace-binding value to set
+   *          the namespace-binding value to set
    */
   public void setNamespaceBindings(@NonNull List<MetapathNamespace> value) {
     _namespaceBindings = value;
@@ -188,11 +213,13 @@ public class MetaschemaMetaConstraints implements IBoundObject {
 
   /**
    * Add a new {@link MetapathNamespace} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addNamespaceBinding(MetapathNamespace item) {
-    MetapathNamespace value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    MetapathNamespace value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_namespaceBindings == null) {
       _namespaceBindings = new LinkedList<>();
     }
@@ -200,12 +227,15 @@ public class MetaschemaMetaConstraints implements IBoundObject {
   }
 
   /**
-   * Remove the first matching {@link MetapathNamespace} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link MetapathNamespace} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeNamespaceBinding(MetapathNamespace item) {
-    MetapathNamespace value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    MetapathNamespace value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _namespaceBindings != null && _namespaceBindings.remove(value);
   }
 
@@ -223,7 +253,7 @@ public class MetaschemaMetaConstraints implements IBoundObject {
    * Set the {@code definition-context} property.
    *
    * @param value
-   *           the definition-context value to set
+   *          the definition-context value to set, or {@code null} to clear
    */
   public void setDefinitionContext(@Nullable DefinitionContext value) {
     _definitionContext = value;
@@ -246,7 +276,7 @@ public class MetaschemaMetaConstraints implements IBoundObject {
    * Set the {@code context} property.
    *
    * @param value
-   *           the context value to set
+   *          the context value to set
    */
   public void setContexts(@NonNull List<MetapathContext> value) {
     _contexts = value;
@@ -254,11 +284,13 @@ public class MetaschemaMetaConstraints implements IBoundObject {
 
   /**
    * Add a new {@link MetapathContext} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addContext(MetapathContext item) {
-    MetapathContext value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    MetapathContext value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_contexts == null) {
       _contexts = new LinkedList<>();
     }
@@ -266,12 +298,15 @@ public class MetaschemaMetaConstraints implements IBoundObject {
   }
 
   /**
-   * Remove the first matching {@link MetapathContext} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link MetapathContext} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeContext(MetapathContext item) {
-    MetapathContext value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    MetapathContext value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _contexts != null && _contexts.remove(value);
   }
 
@@ -281,39 +316,43 @@ public class MetaschemaMetaConstraints implements IBoundObject {
   }
 
   /**
-   * Declares a set of Metaschema constraints from an out-of-line resource to import, supporting composition of constraint sets.
+   * Declares a set of Metaschema constraints from an out-of-line resource to
+   * import, supporting composition of constraint sets.
    */
   @MetaschemaAssembly(
       description = "Declares a set of Metaschema constraints from an out-of-line resource to import, supporting composition of constraint sets.",
       name = "import",
-      moduleClass = MetaschemaModelModule.class
-  )
+      moduleClass = MetaschemaModelModule.class)
   public static class Import implements IBoundObject {
     private final IMetaschemaData __metaschemaData;
 
     /**
-     * A relative or absolute URI for retrieving an out-of-line Metaschema constraint definition.
+     * A relative or absolute URI for retrieving an out-of-line Metaschema
+     * constraint definition.
      */
     @BoundFlag(
         description = "A relative or absolute URI for retrieving an out-of-line Metaschema constraint definition.",
         name = "href",
         required = true,
-        typeAdapter = UriReferenceAdapter.class
-    )
+        typeAdapter = UriReferenceAdapter.class)
     private URI _href;
 
     /**
-     * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaMetaConstraints.Import} instance with no metadata.
+     * Constructs a new
+     * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaMetaConstraints.Import}
+     * instance with no metadata.
      */
     public Import() {
       this(null);
     }
 
     /**
-     * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaMetaConstraints.Import} instance with the specified metadata.
+     * Constructs a new
+     * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaMetaConstraints.Import}
+     * instance with the specified metadata.
      *
      * @param data
-     *           the metaschema data, or {@code null} if none
+     *          the metaschema data, or {@code null} if none
      */
     public Import(IMetaschemaData data) {
       this.__metaschemaData = data;
@@ -328,7 +367,8 @@ public class MetaschemaMetaConstraints implements IBoundObject {
      * Get the {@code href} property.
      *
      * <p>
-     * A relative or absolute URI for retrieving an out-of-line Metaschema constraint definition.
+     * A relative or absolute URI for retrieving an out-of-line Metaschema
+     * constraint definition.
      *
      * @return the href value
      */
@@ -341,10 +381,11 @@ public class MetaschemaMetaConstraints implements IBoundObject {
      * Set the {@code href} property.
      *
      * <p>
-     * A relative or absolute URI for retrieving an out-of-line Metaschema constraint definition.
+     * A relative or absolute URI for retrieving an out-of-line Metaschema
+     * constraint definition.
      *
      * @param value
-     *           the href value to set
+     *          the href value to set
      */
     public void setHref(@NonNull URI value) {
       _href = value;
@@ -358,53 +399,53 @@ public class MetaschemaMetaConstraints implements IBoundObject {
 
   @MetaschemaAssembly(
       name = "definition-context",
-      moduleClass = MetaschemaModelModule.class
-  )
+      moduleClass = MetaschemaModelModule.class)
   public static class DefinitionContext implements IBoundObject {
     private final IMetaschemaData __metaschemaData;
 
     @BoundFlag(
         name = "name",
         required = true,
-        typeAdapter = TokenAdapter.class
-    )
+        typeAdapter = TokenAdapter.class)
     private String _name;
 
     @BoundFlag(
         name = "namespace",
         required = true,
-        typeAdapter = UriAdapter.class
-    )
+        typeAdapter = UriAdapter.class)
     private URI _namespace;
 
     @BoundAssembly(
         useName = "constraints",
-        minOccurs = 1
-    )
+        minOccurs = 1)
     private AssemblyConstraints _constraints;
 
     /**
-     * Any explanatory or helpful information to be provided about the remarks parent.
+     * Any explanatory or helpful information to be provided about the remarks
+     * parent.
      */
     @BoundField(
         formalName = "Remarks",
         description = "Any explanatory or helpful information to be provided about the remarks parent.",
-        useName = "remarks"
-    )
+        useName = "remarks")
     private Remarks _remarks;
 
     /**
-     * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaMetaConstraints.DefinitionContext} instance with no metadata.
+     * Constructs a new
+     * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaMetaConstraints.DefinitionContext}
+     * instance with no metadata.
      */
     public DefinitionContext() {
       this(null);
     }
 
     /**
-     * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaMetaConstraints.DefinitionContext} instance with the specified metadata.
+     * Constructs a new
+     * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaMetaConstraints.DefinitionContext}
+     * instance with the specified metadata.
      *
      * @param data
-     *           the metaschema data, or {@code null} if none
+     *          the metaschema data, or {@code null} if none
      */
     public DefinitionContext(IMetaschemaData data) {
       this.__metaschemaData = data;
@@ -429,7 +470,7 @@ public class MetaschemaMetaConstraints implements IBoundObject {
      * Set the {@code name} property.
      *
      * @param value
-     *           the name value to set
+     *          the name value to set
      */
     public void setName(@NonNull String value) {
       _name = value;
@@ -449,7 +490,7 @@ public class MetaschemaMetaConstraints implements IBoundObject {
      * Set the {@code namespace} property.
      *
      * @param value
-     *           the namespace value to set
+     *          the namespace value to set
      */
     public void setNamespace(@NonNull URI value) {
       _namespace = value;
@@ -469,7 +510,7 @@ public class MetaschemaMetaConstraints implements IBoundObject {
      * Set the {@code constraints} property.
      *
      * @param value
-     *           the constraints value to set
+     *          the constraints value to set
      */
     public void setConstraints(@NonNull AssemblyConstraints value) {
       _constraints = value;
@@ -479,7 +520,8 @@ public class MetaschemaMetaConstraints implements IBoundObject {
      * Get the remarks.
      *
      * <p>
-     * Any explanatory or helpful information to be provided about the remarks parent.
+     * Any explanatory or helpful information to be provided about the remarks
+     * parent.
      *
      * @return the remarks value, or {@code null} if not set
      */
@@ -492,10 +534,11 @@ public class MetaschemaMetaConstraints implements IBoundObject {
      * Set the remarks.
      *
      * <p>
-     * Any explanatory or helpful information to be provided about the remarks parent.
+     * Any explanatory or helpful information to be provided about the remarks
+     * parent.
      *
      * @param value
-     *           the remarks value to set
+     *          the remarks value to set, or {@code null} to clear
      */
     public void setRemarks(@Nullable Remarks value) {
       _remarks = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/MetaschemaMetapath.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/MetaschemaMetapath.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -17,35 +18,38 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 /**
- * A Metapath expression identifying the model node that the constraints will be applied to.
+ * A Metapath expression identifying the model node that the constraints will be
+ * applied to.
  */
 @MetaschemaAssembly(
     description = "A Metapath expression identifying the model node that the constraints will be applied to.",
     name = "metaschema-metapath",
-    moduleClass = MetaschemaModelModule.class
-)
+    moduleClass = MetaschemaModelModule.class)
 public class MetaschemaMetapath implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
   @BoundFlag(
       name = "target",
       required = true,
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _target;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaMetapath} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaMetapath}
+   * instance with no metadata.
    */
   public MetaschemaMetapath() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaMetapath} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaMetapath}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public MetaschemaMetapath(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -70,7 +74,7 @@ public class MetaschemaMetapath implements IBoundObject {
    * Set the {@code target} property.
    *
    * @param value
-   *           the target value to set
+   *          the target value to set
    */
   public void setTarget(@NonNull String value) {
     _target = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/MetaschemaModelModule.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/MetaschemaModelModule.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import gov.nist.secauto.metaschema.core.datatype.markup.MarkupLine;
@@ -62,9 +63,9 @@ import java.util.List;
         MetaschemaMetaConstraints.class,
         MetaschemaMetapath.class,
         MetapathContext.class
-    }
-)
-public final class MetaschemaModelModule extends AbstractBoundModule {
+    })
+public final class MetaschemaModelModule
+    extends AbstractBoundModule {
   private static final MarkupLine NAME = MarkupLine.fromMarkdown("Metaschema Model");
 
   private static final String SHORT_NAME = "metaschema-model";
@@ -79,9 +80,9 @@ public final class MetaschemaModelModule extends AbstractBoundModule {
    * Construct a new module instance.
    *
    * @param importedModules
-   *           modules imported by this module
+   *          modules imported by this module
    * @param bindingContext
-   *           the binding context to associate with this module
+   *          the binding context to associate with this module
    */
   public MetaschemaModelModule(List<? extends IBoundModule> importedModules,
       IBindingContext bindingContext) {

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/MetaschemaModuleConstraints.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/MetaschemaModuleConstraints.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -38,7 +39,8 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 /**
- * Defines constraint rules to be applied to an existing set of Metaschema module-based models.
+ * Defines constraint rules to be applied to an existing set of Metaschema
+ * module-based models.
  */
 @MetaschemaAssembly(
     formalName = "External Module Constraints",
@@ -46,8 +48,13 @@ import org.apache.commons.lang3.builder.ToStringStyle;
     name = "metaschema-module-constraints",
     moduleClass = MetaschemaModelModule.class,
     rootName = "METASCHEMA-CONSTRAINTS",
-    valueConstraints = @ValueConstraints(lets = @Let(name = "deprecated-type-map", target = "map { 'base64Binary':'base64','dateTime':'date-time','dateTime-with-timezone':'date-time-with-timezone','email':'email-address','nonNegativeInteger':'non-negative-integer','positiveInteger':'positive-integer' }"), expect = @Expect(id = "metaschema-deprecated-types", formalName = "Avoid Deprecated Data Type Use", description = "Ensure that the data type specified is not one of the legacy Metaschema data types which have been deprecated (i.e. base64Binary, dateTime, dateTime-with-timezone, email, nonNegativeInteger, positiveInteger).", level = IConstraint.Level.WARNING, target = ".//matches/@datatype|.//(define-field|define-flag)/@as-type", test = "not(data(.)=('base64Binary','dateTime','dateTime-with-timezone','email','nonNegativeInteger','positiveInteger'))", message = "Use of the type '{ data(.) }' is deprecated. Use '{ $deprecated-type-map(data(.))}' instead."))
-)
+    valueConstraints = @ValueConstraints(lets = @Let(name = "deprecated-type-map",
+        target = "map { 'base64Binary':'base64','dateTime':'date-time','dateTime-with-timezone':'date-time-with-timezone','email':'email-address','nonNegativeInteger':'non-negative-integer','positiveInteger':'positive-integer' }"),
+        expect = @Expect(id = "metaschema-deprecated-types", formalName = "Avoid Deprecated Data Type Use",
+            description = "Ensure that the data type specified is not one of the legacy Metaschema data types which have been deprecated (i.e. base64Binary, dateTime, dateTime-with-timezone, email, nonNegativeInteger, positiveInteger).",
+            level = IConstraint.Level.WARNING, target = ".//matches/@datatype|.//(define-field|define-flag)/@as-type",
+            test = "not(data(.)=('base64Binary','dateTime','dateTime-with-timezone','email','nonNegativeInteger','positiveInteger'))",
+            message = "Use of the type '{ data(.) }' is deprecated. Use '{ $deprecated-type-map(data(.))}' instead.")))
 public class MetaschemaModuleConstraints implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
@@ -58,64 +65,66 @@ public class MetaschemaModuleConstraints implements IBoundObject {
       description = "The name of this constraint set.",
       useName = "name",
       minOccurs = 1,
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _name;
 
   /**
-   * The version of this constraint set. A version string used to distinguish between multiple revisions of the same resource.
+   * The version of this constraint set. A version string used to distinguish
+   * between multiple revisions of the same resource.
    */
   @BoundField(
       description = "The version of this constraint set. A version string used to distinguish between multiple revisions of the same resource.",
       useName = "version",
       minOccurs = 1,
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _version;
 
   /**
-   * Declares a set of Metaschema constraints from an out-of-line resource to import, supporting composition of constraint sets.
+   * Declares a set of Metaschema constraints from an out-of-line resource to
+   * import, supporting composition of constraint sets.
    */
   @BoundAssembly(
       description = "Declares a set of Metaschema constraints from an out-of-line resource to import, supporting composition of constraint sets.",
       useName = "import",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "imports", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "imports", inJson = JsonGroupAsBehavior.LIST))
   private List<Import> _imports;
 
   /**
-   * Assigns a Metapath namespace to a prefix for use in a Metapath expression in a lexical qualified name.
+   * Assigns a Metapath namespace to a prefix for use in a Metapath expression in
+   * a lexical qualified name.
    */
   @BoundAssembly(
       formalName = "Metapath Namespace Declaration",
       description = "Assigns a Metapath namespace to a prefix for use in a Metapath expression in a lexical qualified name.",
       useName = "namespace-binding",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "namespace-bindings", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "namespace-bindings", inJson = JsonGroupAsBehavior.LIST))
   private List<MetapathNamespace> _namespaceBindings;
 
   @BoundAssembly(
       useName = "scope",
       minOccurs = 1,
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "scopes", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "scopes", inJson = JsonGroupAsBehavior.LIST))
   private List<Scope> _scopes;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModuleConstraints} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModuleConstraints}
+   * instance with no metadata.
    */
   public MetaschemaModuleConstraints() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModuleConstraints} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModuleConstraints}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public MetaschemaModuleConstraints(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -146,7 +155,7 @@ public class MetaschemaModuleConstraints implements IBoundObject {
    * The name of this constraint set.
    *
    * @param value
-   *           the name value to set
+   *          the name value to set
    */
   public void setName(@NonNull String value) {
     _name = value;
@@ -156,7 +165,8 @@ public class MetaschemaModuleConstraints implements IBoundObject {
    * Get the {@code version} property.
    *
    * <p>
-   * The version of this constraint set. A version string used to distinguish between multiple revisions of the same resource.
+   * The version of this constraint set. A version string used to distinguish
+   * between multiple revisions of the same resource.
    *
    * @return the version value
    */
@@ -169,10 +179,11 @@ public class MetaschemaModuleConstraints implements IBoundObject {
    * Set the {@code version} property.
    *
    * <p>
-   * The version of this constraint set. A version string used to distinguish between multiple revisions of the same resource.
+   * The version of this constraint set. A version string used to distinguish
+   * between multiple revisions of the same resource.
    *
    * @param value
-   *           the version value to set
+   *          the version value to set
    */
   public void setVersion(@NonNull String value) {
     _version = value;
@@ -182,7 +193,8 @@ public class MetaschemaModuleConstraints implements IBoundObject {
    * Get the {@code import} property.
    *
    * <p>
-   * Declares a set of Metaschema constraints from an out-of-line resource to import, supporting composition of constraint sets.
+   * Declares a set of Metaschema constraints from an out-of-line resource to
+   * import, supporting composition of constraint sets.
    *
    * @return the import value
    */
@@ -198,10 +210,11 @@ public class MetaschemaModuleConstraints implements IBoundObject {
    * Set the {@code import} property.
    *
    * <p>
-   * Declares a set of Metaschema constraints from an out-of-line resource to import, supporting composition of constraint sets.
+   * Declares a set of Metaschema constraints from an out-of-line resource to
+   * import, supporting composition of constraint sets.
    *
    * @param value
-   *           the import value to set
+   *          the import value to set
    */
   public void setImports(@NonNull List<Import> value) {
     _imports = value;
@@ -209,11 +222,13 @@ public class MetaschemaModuleConstraints implements IBoundObject {
 
   /**
    * Add a new {@link Import} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addImport(Import item) {
-    Import value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Import value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_imports == null) {
       _imports = new LinkedList<>();
     }
@@ -222,11 +237,13 @@ public class MetaschemaModuleConstraints implements IBoundObject {
 
   /**
    * Remove the first matching {@link Import} item from the underlying collection.
-   * @param item the item to remove
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeImport(Import item) {
-    Import value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Import value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _imports != null && _imports.remove(value);
   }
 
@@ -234,7 +251,8 @@ public class MetaschemaModuleConstraints implements IBoundObject {
    * Get the metapath Namespace Declaration.
    *
    * <p>
-   * Assigns a Metapath namespace to a prefix for use in a Metapath expression in a lexical qualified name.
+   * Assigns a Metapath namespace to a prefix for use in a Metapath expression in
+   * a lexical qualified name.
    *
    * @return the namespace-binding value
    */
@@ -250,10 +268,11 @@ public class MetaschemaModuleConstraints implements IBoundObject {
    * Set the metapath Namespace Declaration.
    *
    * <p>
-   * Assigns a Metapath namespace to a prefix for use in a Metapath expression in a lexical qualified name.
+   * Assigns a Metapath namespace to a prefix for use in a Metapath expression in
+   * a lexical qualified name.
    *
    * @param value
-   *           the namespace-binding value to set
+   *          the namespace-binding value to set
    */
   public void setNamespaceBindings(@NonNull List<MetapathNamespace> value) {
     _namespaceBindings = value;
@@ -261,11 +280,13 @@ public class MetaschemaModuleConstraints implements IBoundObject {
 
   /**
    * Add a new {@link MetapathNamespace} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addNamespaceBinding(MetapathNamespace item) {
-    MetapathNamespace value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    MetapathNamespace value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_namespaceBindings == null) {
       _namespaceBindings = new LinkedList<>();
     }
@@ -273,12 +294,15 @@ public class MetaschemaModuleConstraints implements IBoundObject {
   }
 
   /**
-   * Remove the first matching {@link MetapathNamespace} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link MetapathNamespace} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeNamespaceBinding(MetapathNamespace item) {
-    MetapathNamespace value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    MetapathNamespace value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _namespaceBindings != null && _namespaceBindings.remove(value);
   }
 
@@ -299,7 +323,7 @@ public class MetaschemaModuleConstraints implements IBoundObject {
    * Set the {@code scope} property.
    *
    * @param value
-   *           the scope value to set
+   *          the scope value to set
    */
   public void setScopes(@NonNull List<Scope> value) {
     _scopes = value;
@@ -307,11 +331,13 @@ public class MetaschemaModuleConstraints implements IBoundObject {
 
   /**
    * Add a new {@link Scope} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addScope(Scope item) {
-    Scope value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Scope value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_scopes == null) {
       _scopes = new LinkedList<>();
     }
@@ -320,11 +346,13 @@ public class MetaschemaModuleConstraints implements IBoundObject {
 
   /**
    * Remove the first matching {@link Scope} item from the underlying collection.
-   * @param item the item to remove
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeScope(Scope item) {
-    Scope value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Scope value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _scopes != null && _scopes.remove(value);
   }
 
@@ -334,39 +362,43 @@ public class MetaschemaModuleConstraints implements IBoundObject {
   }
 
   /**
-   * Declares a set of Metaschema constraints from an out-of-line resource to import, supporting composition of constraint sets.
+   * Declares a set of Metaschema constraints from an out-of-line resource to
+   * import, supporting composition of constraint sets.
    */
   @MetaschemaAssembly(
       description = "Declares a set of Metaschema constraints from an out-of-line resource to import, supporting composition of constraint sets.",
       name = "import",
-      moduleClass = MetaschemaModelModule.class
-  )
+      moduleClass = MetaschemaModelModule.class)
   public static class Import implements IBoundObject {
     private final IMetaschemaData __metaschemaData;
 
     /**
-     * A relative or absolute URI for retrieving an out-of-line Metaschema constraint definition.
+     * A relative or absolute URI for retrieving an out-of-line Metaschema
+     * constraint definition.
      */
     @BoundFlag(
         description = "A relative or absolute URI for retrieving an out-of-line Metaschema constraint definition.",
         name = "href",
         required = true,
-        typeAdapter = UriReferenceAdapter.class
-    )
+        typeAdapter = UriReferenceAdapter.class)
     private URI _href;
 
     /**
-     * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModuleConstraints.Import} instance with no metadata.
+     * Constructs a new
+     * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModuleConstraints.Import}
+     * instance with no metadata.
      */
     public Import() {
       this(null);
     }
 
     /**
-     * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModuleConstraints.Import} instance with the specified metadata.
+     * Constructs a new
+     * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModuleConstraints.Import}
+     * instance with the specified metadata.
      *
      * @param data
-     *           the metaschema data, or {@code null} if none
+     *          the metaschema data, or {@code null} if none
      */
     public Import(IMetaschemaData data) {
       this.__metaschemaData = data;
@@ -381,7 +413,8 @@ public class MetaschemaModuleConstraints implements IBoundObject {
      * Get the {@code href} property.
      *
      * <p>
-     * A relative or absolute URI for retrieving an out-of-line Metaschema constraint definition.
+     * A relative or absolute URI for retrieving an out-of-line Metaschema
+     * constraint definition.
      *
      * @return the href value
      */
@@ -394,10 +427,11 @@ public class MetaschemaModuleConstraints implements IBoundObject {
      * Set the {@code href} property.
      *
      * <p>
-     * A relative or absolute URI for retrieving an out-of-line Metaschema constraint definition.
+     * A relative or absolute URI for retrieving an out-of-line Metaschema
+     * constraint definition.
      *
      * @param value
-     *           the href value to set
+     *          the href value to set
      */
     public void setHref(@NonNull URI value) {
       _href = value;
@@ -411,23 +445,20 @@ public class MetaschemaModuleConstraints implements IBoundObject {
 
   @MetaschemaAssembly(
       name = "scope",
-      moduleClass = MetaschemaModelModule.class
-  )
+      moduleClass = MetaschemaModelModule.class)
   public static class Scope implements IBoundObject {
     private final IMetaschemaData __metaschemaData;
 
     @BoundFlag(
         name = "metaschema-namespace",
         required = true,
-        typeAdapter = UriAdapter.class
-    )
+        typeAdapter = UriAdapter.class)
     private URI _metaschemaNamespace;
 
     @BoundFlag(
         name = "metaschema-short-name",
         required = true,
-        typeAdapter = TokenAdapter.class
-    )
+        typeAdapter = TokenAdapter.class)
     private String _metaschemaShortName;
 
     @BoundChoiceGroup(
@@ -438,39 +469,41 @@ public class MetaschemaModuleConstraints implements IBoundObject {
             @BoundGroupedAssembly(useName = "assembly", binding = Assembly.class),
             @BoundGroupedAssembly(useName = "field", binding = Field.class),
             @BoundGroupedAssembly(useName = "flag", binding = Flag.class)
-        }
-    )
+        })
     private List<? extends IValueConstraintsBase> _constraints;
 
     @BoundField(
         formalName = "Constraint Condition Violation Message",
         useName = "message",
-        typeAdapter = StringAdapter.class
-    )
+        typeAdapter = StringAdapter.class)
     private String _message;
 
     /**
-     * Any explanatory or helpful information to be provided about the remarks parent.
+     * Any explanatory or helpful information to be provided about the remarks
+     * parent.
      */
     @BoundField(
         formalName = "Remarks",
         description = "Any explanatory or helpful information to be provided about the remarks parent.",
-        useName = "remarks"
-    )
+        useName = "remarks")
     private Remarks _remarks;
 
     /**
-     * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModuleConstraints.Scope} instance with no metadata.
+     * Constructs a new
+     * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModuleConstraints.Scope}
+     * instance with no metadata.
      */
     public Scope() {
       this(null);
     }
 
     /**
-     * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModuleConstraints.Scope} instance with the specified metadata.
+     * Constructs a new
+     * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModuleConstraints.Scope}
+     * instance with the specified metadata.
      *
      * @param data
-     *           the metaschema data, or {@code null} if none
+     *          the metaschema data, or {@code null} if none
      */
     public Scope(IMetaschemaData data) {
       this.__metaschemaData = data;
@@ -495,7 +528,7 @@ public class MetaschemaModuleConstraints implements IBoundObject {
      * Set the {@code metaschema-namespace} property.
      *
      * @param value
-     *           the metaschema-namespace value to set
+     *          the metaschema-namespace value to set
      */
     public void setMetaschemaNamespace(@NonNull URI value) {
       _metaschemaNamespace = value;
@@ -515,7 +548,7 @@ public class MetaschemaModuleConstraints implements IBoundObject {
      * Set the {@code metaschema-short-name} property.
      *
      * @param value
-     *           the metaschema-short-name value to set
+     *          the metaschema-short-name value to set
      */
     public void setMetaschemaShortName(@NonNull String value) {
       _metaschemaShortName = value;
@@ -544,7 +577,7 @@ public class MetaschemaModuleConstraints implements IBoundObject {
      * Items in this collection must implement {@link IValueConstraintsBase}.
      *
      * @param value
-     *           the constraints items to set
+     *          the constraints items to set
      */
     public void setConstraints(@NonNull List<? extends IValueConstraintsBase> value) {
       _constraints = value;
@@ -564,7 +597,7 @@ public class MetaschemaModuleConstraints implements IBoundObject {
      * Set the constraint Condition Violation Message.
      *
      * @param value
-     *           the message value to set
+     *          the message value to set, or {@code null} to clear
      */
     public void setMessage(@Nullable String value) {
       _message = value;
@@ -574,7 +607,8 @@ public class MetaschemaModuleConstraints implements IBoundObject {
      * Get the remarks.
      *
      * <p>
-     * Any explanatory or helpful information to be provided about the remarks parent.
+     * Any explanatory or helpful information to be provided about the remarks
+     * parent.
      *
      * @return the remarks value, or {@code null} if not set
      */
@@ -587,10 +621,11 @@ public class MetaschemaModuleConstraints implements IBoundObject {
      * Set the remarks.
      *
      * <p>
-     * Any explanatory or helpful information to be provided about the remarks parent.
+     * Any explanatory or helpful information to be provided about the remarks
+     * parent.
      *
      * @param value
-     *           the remarks value to set
+     *          the remarks value to set, or {@code null} to clear
      */
     public void setRemarks(@Nullable Remarks value) {
       _remarks = value;
@@ -603,8 +638,7 @@ public class MetaschemaModuleConstraints implements IBoundObject {
 
     @MetaschemaAssembly(
         name = "assembly",
-        moduleClass = MetaschemaModelModule.class
-    )
+        moduleClass = MetaschemaModelModule.class)
     public static class Assembly implements IValueTargetedConstraintsBase {
       private final IMetaschemaData __metaschemaData;
 
@@ -612,8 +646,7 @@ public class MetaschemaModuleConstraints implements IBoundObject {
           formalName = "Constraint Target Metapath Expression",
           name = "target",
           required = true,
-          typeAdapter = StringAdapter.class
-      )
+          typeAdapter = StringAdapter.class)
       private String _target;
 
       @BoundChoiceGroup(
@@ -621,30 +654,41 @@ public class MetaschemaModuleConstraints implements IBoundObject {
           maxOccurs = -1,
           groupAs = @GroupAs(name = "rules", inJson = JsonGroupAsBehavior.LIST),
           assemblies = {
-              @BoundGroupedAssembly(formalName = "Allowed Values Constraint", useName = "allowed-values", binding = TargetedAllowedValuesConstraint.class),
-              @BoundGroupedAssembly(formalName = "Expect Condition Constraint", useName = "expect", binding = TargetedExpectConstraint.class),
-              @BoundGroupedAssembly(formalName = "Targeted Index Has Key Constraint", useName = "index-has-key", binding = TargetedIndexHasKeyConstraint.class),
-              @BoundGroupedAssembly(formalName = "Value Matches Constraint", useName = "matches", binding = TargetedMatchesConstraint.class),
-              @BoundGroupedAssembly(formalName = "Targeted Unique Constraint", useName = "is-unique", binding = TargetedIsUniqueConstraint.class),
-              @BoundGroupedAssembly(formalName = "Targeted Index Constraint", useName = "index", binding = TargetedIndexConstraint.class),
-              @BoundGroupedAssembly(formalName = "Targeted Cardinality Constraint", useName = "has-cardinality", binding = TargetedHasCardinalityConstraint.class),
-              @BoundGroupedAssembly(formalName = "Report Condition Constraint", useName = "report", binding = TargetedReportConstraint.class)
-          }
-      )
+              @BoundGroupedAssembly(formalName = "Allowed Values Constraint", useName = "allowed-values",
+                  binding = TargetedAllowedValuesConstraint.class),
+              @BoundGroupedAssembly(formalName = "Expect Condition Constraint", useName = "expect",
+                  binding = TargetedExpectConstraint.class),
+              @BoundGroupedAssembly(formalName = "Targeted Index Has Key Constraint", useName = "index-has-key",
+                  binding = TargetedIndexHasKeyConstraint.class),
+              @BoundGroupedAssembly(formalName = "Value Matches Constraint", useName = "matches",
+                  binding = TargetedMatchesConstraint.class),
+              @BoundGroupedAssembly(formalName = "Targeted Unique Constraint", useName = "is-unique",
+                  binding = TargetedIsUniqueConstraint.class),
+              @BoundGroupedAssembly(formalName = "Targeted Index Constraint", useName = "index",
+                  binding = TargetedIndexConstraint.class),
+              @BoundGroupedAssembly(formalName = "Targeted Cardinality Constraint", useName = "has-cardinality",
+                  binding = TargetedHasCardinalityConstraint.class),
+              @BoundGroupedAssembly(formalName = "Report Condition Constraint", useName = "report",
+                  binding = TargetedReportConstraint.class)
+          })
       private List<? extends ITargetedConstraintBase> _rules;
 
       /**
-       * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModuleConstraints.Scope.Assembly} instance with no metadata.
+       * Constructs a new
+       * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModuleConstraints.Scope.Assembly}
+       * instance with no metadata.
        */
       public Assembly() {
         this(null);
       }
 
       /**
-       * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModuleConstraints.Scope.Assembly} instance with the specified metadata.
+       * Constructs a new
+       * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModuleConstraints.Scope.Assembly}
+       * instance with the specified metadata.
        *
        * @param data
-       *           the metaschema data, or {@code null} if none
+       *          the metaschema data, or {@code null} if none
        */
       public Assembly(IMetaschemaData data) {
         this.__metaschemaData = data;
@@ -669,7 +713,7 @@ public class MetaschemaModuleConstraints implements IBoundObject {
        * Set the constraint Target Metapath Expression.
        *
        * @param value
-       *           the target value to set
+       *          the target value to set
        */
       public void setTarget(@NonNull String value) {
         _target = value;
@@ -699,7 +743,7 @@ public class MetaschemaModuleConstraints implements IBoundObject {
        * Items in this collection must implement {@link ITargetedConstraintBase}.
        *
        * @param value
-       *           the rules items to set
+       *          the rules items to set
        */
       public void setRules(@NonNull List<? extends ITargetedConstraintBase> value) {
         _rules = value;
@@ -713,8 +757,7 @@ public class MetaschemaModuleConstraints implements IBoundObject {
 
     @MetaschemaAssembly(
         name = "field",
-        moduleClass = MetaschemaModelModule.class
-    )
+        moduleClass = MetaschemaModelModule.class)
     public static class Field implements IValueTargetedConstraintsBase {
       private final IMetaschemaData __metaschemaData;
 
@@ -722,8 +765,7 @@ public class MetaschemaModuleConstraints implements IBoundObject {
           formalName = "Constraint Target Metapath Expression",
           name = "target",
           required = true,
-          typeAdapter = StringAdapter.class
-      )
+          typeAdapter = StringAdapter.class)
       private String _target;
 
       @BoundChoiceGroup(
@@ -731,27 +773,35 @@ public class MetaschemaModuleConstraints implements IBoundObject {
           maxOccurs = -1,
           groupAs = @GroupAs(name = "rules", inJson = JsonGroupAsBehavior.LIST),
           assemblies = {
-              @BoundGroupedAssembly(formalName = "Allowed Values Constraint", useName = "allowed-values", binding = TargetedAllowedValuesConstraint.class),
-              @BoundGroupedAssembly(formalName = "Expect Condition Constraint", useName = "expect", binding = TargetedExpectConstraint.class),
-              @BoundGroupedAssembly(formalName = "Targeted Index Has Key Constraint", useName = "index-has-key", binding = TargetedIndexHasKeyConstraint.class),
-              @BoundGroupedAssembly(formalName = "Value Matches Constraint", useName = "matches", binding = TargetedMatchesConstraint.class),
-              @BoundGroupedAssembly(formalName = "Report Condition Constraint", useName = "report", binding = TargetedReportConstraint.class)
-          }
-      )
+              @BoundGroupedAssembly(formalName = "Allowed Values Constraint", useName = "allowed-values",
+                  binding = TargetedAllowedValuesConstraint.class),
+              @BoundGroupedAssembly(formalName = "Expect Condition Constraint", useName = "expect",
+                  binding = TargetedExpectConstraint.class),
+              @BoundGroupedAssembly(formalName = "Targeted Index Has Key Constraint", useName = "index-has-key",
+                  binding = TargetedIndexHasKeyConstraint.class),
+              @BoundGroupedAssembly(formalName = "Value Matches Constraint", useName = "matches",
+                  binding = TargetedMatchesConstraint.class),
+              @BoundGroupedAssembly(formalName = "Report Condition Constraint", useName = "report",
+                  binding = TargetedReportConstraint.class)
+          })
       private List<? extends ITargetedConstraintBase> _rules;
 
       /**
-       * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModuleConstraints.Scope.Field} instance with no metadata.
+       * Constructs a new
+       * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModuleConstraints.Scope.Field}
+       * instance with no metadata.
        */
       public Field() {
         this(null);
       }
 
       /**
-       * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModuleConstraints.Scope.Field} instance with the specified metadata.
+       * Constructs a new
+       * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModuleConstraints.Scope.Field}
+       * instance with the specified metadata.
        *
        * @param data
-       *           the metaschema data, or {@code null} if none
+       *          the metaschema data, or {@code null} if none
        */
       public Field(IMetaschemaData data) {
         this.__metaschemaData = data;
@@ -776,7 +826,7 @@ public class MetaschemaModuleConstraints implements IBoundObject {
        * Set the constraint Target Metapath Expression.
        *
        * @param value
-       *           the target value to set
+       *          the target value to set
        */
       public void setTarget(@NonNull String value) {
         _target = value;
@@ -806,7 +856,7 @@ public class MetaschemaModuleConstraints implements IBoundObject {
        * Items in this collection must implement {@link ITargetedConstraintBase}.
        *
        * @param value
-       *           the rules items to set
+       *          the rules items to set
        */
       public void setRules(@NonNull List<? extends ITargetedConstraintBase> value) {
         _rules = value;
@@ -820,8 +870,7 @@ public class MetaschemaModuleConstraints implements IBoundObject {
 
     @MetaschemaAssembly(
         name = "flag",
-        moduleClass = MetaschemaModelModule.class
-    )
+        moduleClass = MetaschemaModelModule.class)
     public static class Flag implements IValueConstraintsBase {
       private final IMetaschemaData __metaschemaData;
 
@@ -829,8 +878,7 @@ public class MetaschemaModuleConstraints implements IBoundObject {
           formalName = "Constraint Target Metapath Expression",
           name = "target",
           required = true,
-          typeAdapter = StringAdapter.class
-      )
+          typeAdapter = StringAdapter.class)
       private String _target;
 
       @BoundChoiceGroup(
@@ -838,27 +886,35 @@ public class MetaschemaModuleConstraints implements IBoundObject {
           maxOccurs = -1,
           groupAs = @GroupAs(name = "rules", inJson = JsonGroupAsBehavior.LIST),
           assemblies = {
-              @BoundGroupedAssembly(formalName = "Allowed Values Constraint", useName = "allowed-values", binding = FlagAllowedValues.class),
-              @BoundGroupedAssembly(formalName = "Expect Condition Constraint", useName = "expect", binding = FlagExpect.class),
-              @BoundGroupedAssembly(formalName = "Index Has Key Constraint", useName = "index-has-key", binding = FlagIndexHasKey.class),
-              @BoundGroupedAssembly(formalName = "Value Matches Constraint", useName = "matches", binding = FlagMatches.class),
-              @BoundGroupedAssembly(formalName = "Report Condition Constraint", useName = "report", binding = FlagReport.class)
-          }
-      )
+              @BoundGroupedAssembly(formalName = "Allowed Values Constraint", useName = "allowed-values",
+                  binding = FlagAllowedValues.class),
+              @BoundGroupedAssembly(formalName = "Expect Condition Constraint", useName = "expect",
+                  binding = FlagExpect.class),
+              @BoundGroupedAssembly(formalName = "Index Has Key Constraint", useName = "index-has-key",
+                  binding = FlagIndexHasKey.class),
+              @BoundGroupedAssembly(formalName = "Value Matches Constraint", useName = "matches",
+                  binding = FlagMatches.class),
+              @BoundGroupedAssembly(formalName = "Report Condition Constraint", useName = "report",
+                  binding = FlagReport.class)
+          })
       private List<? extends IConstraintBase> _rules;
 
       /**
-       * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModuleConstraints.Scope.Flag} instance with no metadata.
+       * Constructs a new
+       * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModuleConstraints.Scope.Flag}
+       * instance with no metadata.
        */
       public Flag() {
         this(null);
       }
 
       /**
-       * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModuleConstraints.Scope.Flag} instance with the specified metadata.
+       * Constructs a new
+       * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModuleConstraints.Scope.Flag}
+       * instance with the specified metadata.
        *
        * @param data
-       *           the metaschema data, or {@code null} if none
+       *          the metaschema data, or {@code null} if none
        */
       public Flag(IMetaschemaData data) {
         this.__metaschemaData = data;
@@ -883,7 +939,7 @@ public class MetaschemaModuleConstraints implements IBoundObject {
        * Set the constraint Target Metapath Expression.
        *
        * @param value
-       *           the target value to set
+       *          the target value to set
        */
       public void setTarget(@NonNull String value) {
         _target = value;
@@ -913,7 +969,7 @@ public class MetaschemaModuleConstraints implements IBoundObject {
        * Items in this collection must implement {@link IConstraintBase}.
        *
        * @param value
-       *           the rules items to set
+       *          the rules items to set
        */
       public void setRules(@NonNull List<? extends IConstraintBase> value) {
         _rules = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/Property.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/Property.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -23,8 +24,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @MetaschemaAssembly(
     formalName = "Property",
     name = "property",
-    moduleClass = MetaschemaModelModule.class
-)
+    moduleClass = MetaschemaModelModule.class)
 public class Property implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
@@ -32,38 +32,39 @@ public class Property implements IBoundObject {
       formalName = "Property Name",
       name = "name",
       required = true,
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _name;
 
   @BoundFlag(
       formalName = "Property Namespace",
       name = "namespace",
       defaultValue = "http://csrc.nist.gov/ns/oscal/metaschema/1.0",
-      typeAdapter = UriAdapter.class
-  )
+      typeAdapter = UriAdapter.class)
   private URI _namespace;
 
   @BoundFlag(
       formalName = "Property Value",
       name = "value",
       required = true,
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _value;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.Property} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.Property}
+   * instance with no metadata.
    */
   public Property() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.Property} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.Property}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public Property(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -88,7 +89,7 @@ public class Property implements IBoundObject {
    * Set the property Name.
    *
    * @param value
-   *           the name value to set
+   *          the name value to set
    */
   public void setName(@NonNull String value) {
     _name = value;
@@ -108,7 +109,7 @@ public class Property implements IBoundObject {
    * Set the property Namespace.
    *
    * @param value
-   *           the namespace value to set
+   *          the namespace value to set, or {@code null} to clear
    */
   public void setNamespace(@Nullable URI value) {
     _namespace = value;
@@ -128,7 +129,7 @@ public class Property implements IBoundObject {
    * Set the property Value.
    *
    * @param value
-   *           the value value to set
+   *          the value value to set
    */
   public void setValue(@NonNull String value) {
     _value = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/Remarks.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/Remarks.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -24,19 +25,20 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 /**
- * Any explanatory or helpful information to be provided about the remarks parent.
+ * Any explanatory or helpful information to be provided about the remarks
+ * parent.
  */
 @MetaschemaField(
     formalName = "Remarks",
     description = "Any explanatory or helpful information to be provided about the remarks parent.",
     name = "remarks",
-    moduleClass = MetaschemaModelModule.class
-)
+    moduleClass = MetaschemaModelModule.class)
 public class Remarks implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
   /**
-   * Mark as &lsquo;XML&rsquo; for XML-only or &lsquo;JSON&rsquo; for JSON-only remarks.
+   * Mark as &lsquo;XML&rsquo; for XML-only or &lsquo;JSON&rsquo; for JSON-only
+   * remarks.
    */
   @BoundFlag(
       formalName = "Remark Class",
@@ -44,28 +46,33 @@ public class Remarks implements IBoundObject {
       name = "class",
       defaultValue = "ALL",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "XML", description = "The remark applies to only XML representations."), @AllowedValue(value = "JSON", description = "The remark applies to only JSON and YAML representations."), @AllowedValue(value = "ALL", description = "The remark applies to all representations.")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR,
+          values = { @AllowedValue(value = "XML", description = "The remark applies to only XML representations."),
+              @AllowedValue(value = "JSON", description = "The remark applies to only JSON and YAML representations."),
+              @AllowedValue(value = "ALL", description = "The remark applies to all representations.") })))
   private String _clazz;
 
   @BoundFieldValue(
       valueKeyName = "remark",
-      typeAdapter = MarkupMultilineAdapter.class
-  )
+      typeAdapter = MarkupMultilineAdapter.class)
   private MarkupMultiline _remark;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.Remarks} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.Remarks}
+   * instance with no metadata.
    */
   public Remarks() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.Remarks} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.Remarks}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public Remarks(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -80,7 +87,8 @@ public class Remarks implements IBoundObject {
    * Get the remark Class.
    *
    * <p>
-   * Mark as &lsquo;XML&rsquo; for XML-only or &lsquo;JSON&rsquo; for JSON-only remarks.
+   * Mark as &lsquo;XML&rsquo; for XML-only or &lsquo;JSON&rsquo; for JSON-only
+   * remarks.
    *
    * @return the class value, or {@code null} if not set
    */
@@ -93,10 +101,11 @@ public class Remarks implements IBoundObject {
    * Set the remark Class.
    *
    * <p>
-   * Mark as &lsquo;XML&rsquo; for XML-only or &lsquo;JSON&rsquo; for JSON-only remarks.
+   * Mark as &lsquo;XML&rsquo; for XML-only or &lsquo;JSON&rsquo; for JSON-only
+   * remarks.
    *
    * @param value
-   *           the class value to set
+   *          the class value to set, or {@code null} to clear
    */
   public void setClazz(@Nullable String value) {
     _clazz = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedAllowedValuesConstraint.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedAllowedValuesConstraint.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -34,16 +35,14 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @MetaschemaAssembly(
     formalName = "Allowed Values Constraint",
     name = "targeted-allowed-values-constraint",
-    moduleClass = MetaschemaModelModule.class
-)
+    moduleClass = MetaschemaModelModule.class)
 public class TargetedAllowedValuesConstraint implements IBoundObject, ITargetedConstraintBase {
   private final IMetaschemaData __metaschemaData;
 
   @BoundFlag(
       formalName = "Constraint Identifier",
       name = "id",
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _id;
 
   @BoundFlag(
@@ -51,8 +50,17 @@ public class TargetedAllowedValuesConstraint implements IBoundObject, ITargetedC
       name = "level",
       defaultValue = "ERROR",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "CRITICAL", description = "A violation of the constraint represents a serious fault in the content that will prevent typical use of the content."), @AllowedValue(value = "ERROR", description = "A violation of the constraint represents a fault in the content. This may include issues around compatibility, integrity, consistency, etc."), @AllowedValue(value = "WARNING", description = "A violation of the constraint represents a potential issue with the content."), @AllowedValue(value = "INFORMATIONAL", description = "A violation of the constraint represents a point of interest."), @AllowedValue(value = "DEBUG", description = "A violation of the constraint represents a fault in the content that may warrant review by a developer when performing model or tool development.")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {
+          @AllowedValue(value = "CRITICAL",
+              description = "A violation of the constraint represents a serious fault in the content that will prevent typical use of the content."),
+          @AllowedValue(value = "ERROR",
+              description = "A violation of the constraint represents a fault in the content. This may include issues around compatibility, integrity, consistency, etc."),
+          @AllowedValue(value = "WARNING",
+              description = "A violation of the constraint represents a potential issue with the content."),
+          @AllowedValue(value = "INFORMATIONAL",
+              description = "A violation of the constraint represents a point of interest."),
+          @AllowedValue(value = "DEBUG",
+              description = "A violation of the constraint represents a fault in the content that may warrant review by a developer when performing model or tool development.") })))
   private String _level;
 
   @BoundFlag(
@@ -60,12 +68,14 @@ public class TargetedAllowedValuesConstraint implements IBoundObject, ITargetedC
       name = "allow-other",
       defaultValue = "no",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "no", description = "Other value are not allowed."), @AllowedValue(value = "yes", description = "Other values are allowed.")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR,
+          values = { @AllowedValue(value = "no", description = "Other value are not allowed."),
+              @AllowedValue(value = "yes", description = "Other values are allowed.") })))
   private String _allowOther;
 
   /**
-   * Determines if the given enumerated values may be extended by other allowed value constraints.
+   * Determines if the given enumerated values may be extended by other allowed
+   * value constraints.
    */
   @BoundFlag(
       formalName = "Allow Extension?",
@@ -73,16 +83,18 @@ public class TargetedAllowedValuesConstraint implements IBoundObject, ITargetedC
       name = "extensible",
       defaultValue = "external",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "model", description = "Can be extended by constraints within the same module."), @AllowedValue(value = "external", description = "Can be extended by external constraints."), @AllowedValue(value = "none", description = "Cannot be extended.")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR,
+          values = {
+              @AllowedValue(value = "model", description = "Can be extended by constraints within the same module."),
+              @AllowedValue(value = "external", description = "Can be extended by external constraints."),
+              @AllowedValue(value = "none", description = "Cannot be extended.") })))
   private String _extensible;
 
   @BoundFlag(
       formalName = "Constraint Target Metapath Expression",
       name = "target",
       required = true,
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _target;
 
   /**
@@ -92,27 +104,25 @@ public class TargetedAllowedValuesConstraint implements IBoundObject, ITargetedC
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
       useName = "formal-name",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   /**
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    */
   @BoundField(
       formalName = "Description",
       description = "A short description of the data construct's purpose, describing the constructs semantics.",
       useName = "description",
-      typeAdapter = MarkupLineAdapter.class
-  )
+      typeAdapter = MarkupLineAdapter.class)
   private MarkupLine _description;
 
   @BoundAssembly(
       formalName = "Property",
       useName = "prop",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST))
   private List<Property> _props;
 
   @BoundField(
@@ -120,32 +130,35 @@ public class TargetedAllowedValuesConstraint implements IBoundObject, ITargetedC
       useName = "enum",
       minOccurs = 1,
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "enums", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "enums", inJson = JsonGroupAsBehavior.LIST))
   private List<ConstraintValueEnum> _enums;
 
   /**
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    */
   @BoundField(
       formalName = "Remarks",
       description = "Any explanatory or helpful information to be provided about the remarks parent.",
-      useName = "remarks"
-  )
+      useName = "remarks")
   private Remarks _remarks;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedAllowedValuesConstraint} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedAllowedValuesConstraint}
+   * instance with no metadata.
    */
   public TargetedAllowedValuesConstraint() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedAllowedValuesConstraint} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedAllowedValuesConstraint}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public TargetedAllowedValuesConstraint(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -171,7 +184,7 @@ public class TargetedAllowedValuesConstraint implements IBoundObject, ITargetedC
    * Set the constraint Identifier.
    *
    * @param value
-   *           the id value to set
+   *          the id value to set, or {@code null} to clear
    */
   public void setId(@Nullable String value) {
     _id = value;
@@ -192,7 +205,7 @@ public class TargetedAllowedValuesConstraint implements IBoundObject, ITargetedC
    * Set the constraint Severity Level.
    *
    * @param value
-   *           the level value to set
+   *          the level value to set, or {@code null} to clear
    */
   public void setLevel(@Nullable String value) {
     _level = value;
@@ -212,7 +225,7 @@ public class TargetedAllowedValuesConstraint implements IBoundObject, ITargetedC
    * Set the allow Non-Enumerated Values?.
    *
    * @param value
-   *           the allow-other value to set
+   *          the allow-other value to set, or {@code null} to clear
    */
   public void setAllowOther(@Nullable String value) {
     _allowOther = value;
@@ -222,7 +235,8 @@ public class TargetedAllowedValuesConstraint implements IBoundObject, ITargetedC
    * Get the allow Extension?.
    *
    * <p>
-   * Determines if the given enumerated values may be extended by other allowed value constraints.
+   * Determines if the given enumerated values may be extended by other allowed
+   * value constraints.
    *
    * @return the extensible value, or {@code null} if not set
    */
@@ -235,10 +249,11 @@ public class TargetedAllowedValuesConstraint implements IBoundObject, ITargetedC
    * Set the allow Extension?.
    *
    * <p>
-   * Determines if the given enumerated values may be extended by other allowed value constraints.
+   * Determines if the given enumerated values may be extended by other allowed
+   * value constraints.
    *
    * @param value
-   *           the extensible value to set
+   *          the extensible value to set, or {@code null} to clear
    */
   public void setExtensible(@Nullable String value) {
     _extensible = value;
@@ -259,7 +274,7 @@ public class TargetedAllowedValuesConstraint implements IBoundObject, ITargetedC
    * Set the constraint Target Metapath Expression.
    *
    * @param value
-   *           the target value to set
+   *          the target value to set
    */
   public void setTarget(@NonNull String value) {
     _target = value;
@@ -286,7 +301,7 @@ public class TargetedAllowedValuesConstraint implements IBoundObject, ITargetedC
    * A formal name for the data construct, to be presented in documentation.
    *
    * @param value
-   *           the formal-name value to set
+   *          the formal-name value to set, or {@code null} to clear
    */
   public void setFormalName(@Nullable String value) {
     _formalName = value;
@@ -296,7 +311,8 @@ public class TargetedAllowedValuesConstraint implements IBoundObject, ITargetedC
    * Get the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @return the description value, or {@code null} if not set
    */
@@ -310,10 +326,11 @@ public class TargetedAllowedValuesConstraint implements IBoundObject, ITargetedC
    * Set the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @param value
-   *           the description value to set
+   *          the description value to set, or {@code null} to clear
    */
   public void setDescription(@Nullable MarkupLine value) {
     _description = value;
@@ -337,7 +354,7 @@ public class TargetedAllowedValuesConstraint implements IBoundObject, ITargetedC
    * Set the property.
    *
    * @param value
-   *           the prop value to set
+   *          the prop value to set
    */
   public void setProps(@NonNull List<Property> value) {
     _props = value;
@@ -345,11 +362,13 @@ public class TargetedAllowedValuesConstraint implements IBoundObject, ITargetedC
 
   /**
    * Add a new {@link Property} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_props == null) {
       _props = new LinkedList<>();
     }
@@ -357,12 +376,15 @@ public class TargetedAllowedValuesConstraint implements IBoundObject, ITargetedC
   }
 
   /**
-   * Remove the first matching {@link Property} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link Property} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _props != null && _props.remove(value);
   }
 
@@ -383,7 +405,7 @@ public class TargetedAllowedValuesConstraint implements IBoundObject, ITargetedC
    * Set the allowed Value Enumeration.
    *
    * @param value
-   *           the enum value to set
+   *          the enum value to set
    */
   public void setEnums(@NonNull List<ConstraintValueEnum> value) {
     _enums = value;
@@ -391,11 +413,13 @@ public class TargetedAllowedValuesConstraint implements IBoundObject, ITargetedC
 
   /**
    * Add a new {@link ConstraintValueEnum} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addEnum(ConstraintValueEnum item) {
-    ConstraintValueEnum value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    ConstraintValueEnum value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_enums == null) {
       _enums = new LinkedList<>();
     }
@@ -403,12 +427,15 @@ public class TargetedAllowedValuesConstraint implements IBoundObject, ITargetedC
   }
 
   /**
-   * Remove the first matching {@link ConstraintValueEnum} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link ConstraintValueEnum} item from the
+   * underlying collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeEnum(ConstraintValueEnum item) {
-    ConstraintValueEnum value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    ConstraintValueEnum value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _enums != null && _enums.remove(value);
   }
 
@@ -416,7 +443,8 @@ public class TargetedAllowedValuesConstraint implements IBoundObject, ITargetedC
    * Get the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @return the remarks value, or {@code null} if not set
    */
@@ -430,10 +458,11 @@ public class TargetedAllowedValuesConstraint implements IBoundObject, ITargetedC
    * Set the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @param value
-   *           the remarks value to set
+   *          the remarks value to set, or {@code null} to clear
    */
   public void setRemarks(@Nullable Remarks value) {
     _remarks = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedExpectConstraint.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedExpectConstraint.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -35,16 +36,15 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @MetaschemaAssembly(
     formalName = "Expect Condition Constraint",
     name = "targeted-expect-constraint",
-    moduleClass = MetaschemaModelModule.class
-)
-public class TargetedExpectConstraint implements IBoundObject, ITargetedConstraintBase, IConfigurableMessageConstraintBase {
+    moduleClass = MetaschemaModelModule.class)
+public class TargetedExpectConstraint
+    implements IBoundObject, ITargetedConstraintBase, IConfigurableMessageConstraintBase {
   private final IMetaschemaData __metaschemaData;
 
   @BoundFlag(
       formalName = "Constraint Identifier",
       name = "id",
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _id;
 
   @BoundFlag(
@@ -52,24 +52,31 @@ public class TargetedExpectConstraint implements IBoundObject, ITargetedConstrai
       name = "level",
       defaultValue = "ERROR",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "CRITICAL", description = "A violation of the constraint represents a serious fault in the content that will prevent typical use of the content."), @AllowedValue(value = "ERROR", description = "A violation of the constraint represents a fault in the content. This may include issues around compatibility, integrity, consistency, etc."), @AllowedValue(value = "WARNING", description = "A violation of the constraint represents a potential issue with the content."), @AllowedValue(value = "INFORMATIONAL", description = "A violation of the constraint represents a point of interest."), @AllowedValue(value = "DEBUG", description = "A violation of the constraint represents a fault in the content that may warrant review by a developer when performing model or tool development.")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {
+          @AllowedValue(value = "CRITICAL",
+              description = "A violation of the constraint represents a serious fault in the content that will prevent typical use of the content."),
+          @AllowedValue(value = "ERROR",
+              description = "A violation of the constraint represents a fault in the content. This may include issues around compatibility, integrity, consistency, etc."),
+          @AllowedValue(value = "WARNING",
+              description = "A violation of the constraint represents a potential issue with the content."),
+          @AllowedValue(value = "INFORMATIONAL",
+              description = "A violation of the constraint represents a point of interest."),
+          @AllowedValue(value = "DEBUG",
+              description = "A violation of the constraint represents a fault in the content that may warrant review by a developer when performing model or tool development.") })))
   private String _level;
 
   @BoundFlag(
       formalName = "Expect Test Condition",
       name = "test",
       required = true,
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _test;
 
   @BoundFlag(
       formalName = "Constraint Target Metapath Expression",
       name = "target",
       required = true,
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _target;
 
   /**
@@ -79,58 +86,59 @@ public class TargetedExpectConstraint implements IBoundObject, ITargetedConstrai
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
       useName = "formal-name",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   /**
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    */
   @BoundField(
       formalName = "Description",
       description = "A short description of the data construct's purpose, describing the constructs semantics.",
       useName = "description",
-      typeAdapter = MarkupLineAdapter.class
-  )
+      typeAdapter = MarkupLineAdapter.class)
   private MarkupLine _description;
 
   @BoundAssembly(
       formalName = "Property",
       useName = "prop",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST))
   private List<Property> _props;
 
   @BoundField(
       formalName = "Constraint Condition Violation Message",
       useName = "message",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _message;
 
   /**
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    */
   @BoundField(
       formalName = "Remarks",
       description = "Any explanatory or helpful information to be provided about the remarks parent.",
-      useName = "remarks"
-  )
+      useName = "remarks")
   private Remarks _remarks;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedExpectConstraint} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedExpectConstraint}
+   * instance with no metadata.
    */
   public TargetedExpectConstraint() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedExpectConstraint} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedExpectConstraint}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public TargetedExpectConstraint(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -156,7 +164,7 @@ public class TargetedExpectConstraint implements IBoundObject, ITargetedConstrai
    * Set the constraint Identifier.
    *
    * @param value
-   *           the id value to set
+   *          the id value to set, or {@code null} to clear
    */
   public void setId(@Nullable String value) {
     _id = value;
@@ -177,7 +185,7 @@ public class TargetedExpectConstraint implements IBoundObject, ITargetedConstrai
    * Set the constraint Severity Level.
    *
    * @param value
-   *           the level value to set
+   *          the level value to set, or {@code null} to clear
    */
   public void setLevel(@Nullable String value) {
     _level = value;
@@ -197,7 +205,7 @@ public class TargetedExpectConstraint implements IBoundObject, ITargetedConstrai
    * Set the expect Test Condition.
    *
    * @param value
-   *           the test value to set
+   *          the test value to set
    */
   public void setTest(@NonNull String value) {
     _test = value;
@@ -218,7 +226,7 @@ public class TargetedExpectConstraint implements IBoundObject, ITargetedConstrai
    * Set the constraint Target Metapath Expression.
    *
    * @param value
-   *           the target value to set
+   *          the target value to set
    */
   public void setTarget(@NonNull String value) {
     _target = value;
@@ -245,7 +253,7 @@ public class TargetedExpectConstraint implements IBoundObject, ITargetedConstrai
    * A formal name for the data construct, to be presented in documentation.
    *
    * @param value
-   *           the formal-name value to set
+   *          the formal-name value to set, or {@code null} to clear
    */
   public void setFormalName(@Nullable String value) {
     _formalName = value;
@@ -255,7 +263,8 @@ public class TargetedExpectConstraint implements IBoundObject, ITargetedConstrai
    * Get the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @return the description value, or {@code null} if not set
    */
@@ -269,10 +278,11 @@ public class TargetedExpectConstraint implements IBoundObject, ITargetedConstrai
    * Set the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @param value
-   *           the description value to set
+   *          the description value to set, or {@code null} to clear
    */
   public void setDescription(@Nullable MarkupLine value) {
     _description = value;
@@ -296,7 +306,7 @@ public class TargetedExpectConstraint implements IBoundObject, ITargetedConstrai
    * Set the property.
    *
    * @param value
-   *           the prop value to set
+   *          the prop value to set
    */
   public void setProps(@NonNull List<Property> value) {
     _props = value;
@@ -304,11 +314,13 @@ public class TargetedExpectConstraint implements IBoundObject, ITargetedConstrai
 
   /**
    * Add a new {@link Property} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_props == null) {
       _props = new LinkedList<>();
     }
@@ -316,12 +328,15 @@ public class TargetedExpectConstraint implements IBoundObject, ITargetedConstrai
   }
 
   /**
-   * Remove the first matching {@link Property} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link Property} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _props != null && _props.remove(value);
   }
 
@@ -340,7 +355,7 @@ public class TargetedExpectConstraint implements IBoundObject, ITargetedConstrai
    * Set the constraint Condition Violation Message.
    *
    * @param value
-   *           the message value to set
+   *          the message value to set, or {@code null} to clear
    */
   public void setMessage(@Nullable String value) {
     _message = value;
@@ -350,7 +365,8 @@ public class TargetedExpectConstraint implements IBoundObject, ITargetedConstrai
    * Get the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @return the remarks value, or {@code null} if not set
    */
@@ -364,10 +380,11 @@ public class TargetedExpectConstraint implements IBoundObject, ITargetedConstrai
    * Set the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @param value
-   *           the remarks value to set
+   *          the remarks value to set, or {@code null} to clear
    */
   public void setRemarks(@Nullable Remarks value) {
     _remarks = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedHasCardinalityConstraint.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedHasCardinalityConstraint.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -38,16 +39,15 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @MetaschemaAssembly(
     formalName = "Targeted Cardinality Constraint",
     name = "targeted-has-cardinality-constraint",
-    moduleClass = MetaschemaModelModule.class
-)
-public class TargetedHasCardinalityConstraint implements IBoundObject, ITargetedConstraintBase, IConfigurableMessageConstraintBase {
+    moduleClass = MetaschemaModelModule.class)
+public class TargetedHasCardinalityConstraint
+    implements IBoundObject, ITargetedConstraintBase, IConfigurableMessageConstraintBase {
   private final IMetaschemaData __metaschemaData;
 
   @BoundFlag(
       formalName = "Constraint Identifier",
       name = "id",
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _id;
 
   @BoundFlag(
@@ -55,31 +55,38 @@ public class TargetedHasCardinalityConstraint implements IBoundObject, ITargeted
       name = "level",
       defaultValue = "ERROR",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "CRITICAL", description = "A violation of the constraint represents a serious fault in the content that will prevent typical use of the content."), @AllowedValue(value = "ERROR", description = "A violation of the constraint represents a fault in the content. This may include issues around compatibility, integrity, consistency, etc."), @AllowedValue(value = "WARNING", description = "A violation of the constraint represents a potential issue with the content."), @AllowedValue(value = "INFORMATIONAL", description = "A violation of the constraint represents a point of interest."), @AllowedValue(value = "DEBUG", description = "A violation of the constraint represents a fault in the content that may warrant review by a developer when performing model or tool development.")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {
+          @AllowedValue(value = "CRITICAL",
+              description = "A violation of the constraint represents a serious fault in the content that will prevent typical use of the content."),
+          @AllowedValue(value = "ERROR",
+              description = "A violation of the constraint represents a fault in the content. This may include issues around compatibility, integrity, consistency, etc."),
+          @AllowedValue(value = "WARNING",
+              description = "A violation of the constraint represents a potential issue with the content."),
+          @AllowedValue(value = "INFORMATIONAL",
+              description = "A violation of the constraint represents a point of interest."),
+          @AllowedValue(value = "DEBUG",
+              description = "A violation of the constraint represents a fault in the content that may warrant review by a developer when performing model or tool development.") })))
   private String _level;
 
   @BoundFlag(
       formalName = "Minimum Occurrence",
       name = "min-occurs",
-      typeAdapter = NonNegativeIntegerAdapter.class
-  )
+      typeAdapter = NonNegativeIntegerAdapter.class)
   private BigInteger _minOccurs;
 
   @BoundFlag(
       formalName = "Maximum Occurrence",
       name = "max-occurs",
       typeAdapter = StringAdapter.class,
-      valueConstraints = @ValueConstraints(matches = @Matches(level = IConstraint.Level.ERROR, pattern = "^[1-9][0-9]*|unbounded$"))
-  )
+      valueConstraints = @ValueConstraints(
+          matches = @Matches(level = IConstraint.Level.ERROR, pattern = "^[1-9][0-9]*|unbounded$")))
   private String _maxOccurs;
 
   @BoundFlag(
       formalName = "Constraint Target Metapath Expression",
       name = "target",
       required = true,
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _target;
 
   /**
@@ -89,58 +96,59 @@ public class TargetedHasCardinalityConstraint implements IBoundObject, ITargeted
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
       useName = "formal-name",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   /**
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    */
   @BoundField(
       formalName = "Description",
       description = "A short description of the data construct's purpose, describing the constructs semantics.",
       useName = "description",
-      typeAdapter = MarkupLineAdapter.class
-  )
+      typeAdapter = MarkupLineAdapter.class)
   private MarkupLine _description;
 
   @BoundAssembly(
       formalName = "Property",
       useName = "prop",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST))
   private List<Property> _props;
 
   @BoundField(
       formalName = "Constraint Condition Violation Message",
       useName = "message",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _message;
 
   /**
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    */
   @BoundField(
       formalName = "Remarks",
       description = "Any explanatory or helpful information to be provided about the remarks parent.",
-      useName = "remarks"
-  )
+      useName = "remarks")
   private Remarks _remarks;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedHasCardinalityConstraint} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedHasCardinalityConstraint}
+   * instance with no metadata.
    */
   public TargetedHasCardinalityConstraint() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedHasCardinalityConstraint} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedHasCardinalityConstraint}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public TargetedHasCardinalityConstraint(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -166,7 +174,7 @@ public class TargetedHasCardinalityConstraint implements IBoundObject, ITargeted
    * Set the constraint Identifier.
    *
    * @param value
-   *           the id value to set
+   *          the id value to set, or {@code null} to clear
    */
   public void setId(@Nullable String value) {
     _id = value;
@@ -187,7 +195,7 @@ public class TargetedHasCardinalityConstraint implements IBoundObject, ITargeted
    * Set the constraint Severity Level.
    *
    * @param value
-   *           the level value to set
+   *          the level value to set, or {@code null} to clear
    */
   public void setLevel(@Nullable String value) {
     _level = value;
@@ -207,7 +215,7 @@ public class TargetedHasCardinalityConstraint implements IBoundObject, ITargeted
    * Set the minimum Occurrence.
    *
    * @param value
-   *           the min-occurs value to set
+   *          the min-occurs value to set, or {@code null} to clear
    */
   public void setMinOccurs(@Nullable BigInteger value) {
     _minOccurs = value;
@@ -227,7 +235,7 @@ public class TargetedHasCardinalityConstraint implements IBoundObject, ITargeted
    * Set the maximum Occurrence.
    *
    * @param value
-   *           the max-occurs value to set
+   *          the max-occurs value to set, or {@code null} to clear
    */
   public void setMaxOccurs(@Nullable String value) {
     _maxOccurs = value;
@@ -248,7 +256,7 @@ public class TargetedHasCardinalityConstraint implements IBoundObject, ITargeted
    * Set the constraint Target Metapath Expression.
    *
    * @param value
-   *           the target value to set
+   *          the target value to set
    */
   public void setTarget(@NonNull String value) {
     _target = value;
@@ -275,7 +283,7 @@ public class TargetedHasCardinalityConstraint implements IBoundObject, ITargeted
    * A formal name for the data construct, to be presented in documentation.
    *
    * @param value
-   *           the formal-name value to set
+   *          the formal-name value to set, or {@code null} to clear
    */
   public void setFormalName(@Nullable String value) {
     _formalName = value;
@@ -285,7 +293,8 @@ public class TargetedHasCardinalityConstraint implements IBoundObject, ITargeted
    * Get the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @return the description value, or {@code null} if not set
    */
@@ -299,10 +308,11 @@ public class TargetedHasCardinalityConstraint implements IBoundObject, ITargeted
    * Set the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @param value
-   *           the description value to set
+   *          the description value to set, or {@code null} to clear
    */
   public void setDescription(@Nullable MarkupLine value) {
     _description = value;
@@ -326,7 +336,7 @@ public class TargetedHasCardinalityConstraint implements IBoundObject, ITargeted
    * Set the property.
    *
    * @param value
-   *           the prop value to set
+   *          the prop value to set
    */
   public void setProps(@NonNull List<Property> value) {
     _props = value;
@@ -334,11 +344,13 @@ public class TargetedHasCardinalityConstraint implements IBoundObject, ITargeted
 
   /**
    * Add a new {@link Property} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_props == null) {
       _props = new LinkedList<>();
     }
@@ -346,12 +358,15 @@ public class TargetedHasCardinalityConstraint implements IBoundObject, ITargeted
   }
 
   /**
-   * Remove the first matching {@link Property} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link Property} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _props != null && _props.remove(value);
   }
 
@@ -370,7 +385,7 @@ public class TargetedHasCardinalityConstraint implements IBoundObject, ITargeted
    * Set the constraint Condition Violation Message.
    *
    * @param value
-   *           the message value to set
+   *          the message value to set, or {@code null} to clear
    */
   public void setMessage(@Nullable String value) {
     _message = value;
@@ -380,7 +395,8 @@ public class TargetedHasCardinalityConstraint implements IBoundObject, ITargeted
    * Get the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @return the remarks value, or {@code null} if not set
    */
@@ -394,10 +410,11 @@ public class TargetedHasCardinalityConstraint implements IBoundObject, ITargeted
    * Set the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @param value
-   *           the remarks value to set
+   *          the remarks value to set, or {@code null} to clear
    */
   public void setRemarks(@Nullable Remarks value) {
     _remarks = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedIndexConstraint.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedIndexConstraint.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -35,16 +36,15 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @MetaschemaAssembly(
     formalName = "Targeted Index Constraint",
     name = "targeted-index-constraint",
-    moduleClass = MetaschemaModelModule.class
-)
-public class TargetedIndexConstraint implements IBoundObject, ITargetedConstraintBase, IConfigurableMessageConstraintBase {
+    moduleClass = MetaschemaModelModule.class)
+public class TargetedIndexConstraint
+    implements IBoundObject, ITargetedConstraintBase, IConfigurableMessageConstraintBase {
   private final IMetaschemaData __metaschemaData;
 
   @BoundFlag(
       formalName = "Constraint Identifier",
       name = "id",
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _id;
 
   @BoundFlag(
@@ -52,24 +52,31 @@ public class TargetedIndexConstraint implements IBoundObject, ITargetedConstrain
       name = "level",
       defaultValue = "ERROR",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "CRITICAL", description = "A violation of the constraint represents a serious fault in the content that will prevent typical use of the content."), @AllowedValue(value = "ERROR", description = "A violation of the constraint represents a fault in the content. This may include issues around compatibility, integrity, consistency, etc."), @AllowedValue(value = "WARNING", description = "A violation of the constraint represents a potential issue with the content."), @AllowedValue(value = "INFORMATIONAL", description = "A violation of the constraint represents a point of interest."), @AllowedValue(value = "DEBUG", description = "A violation of the constraint represents a fault in the content that may warrant review by a developer when performing model or tool development.")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {
+          @AllowedValue(value = "CRITICAL",
+              description = "A violation of the constraint represents a serious fault in the content that will prevent typical use of the content."),
+          @AllowedValue(value = "ERROR",
+              description = "A violation of the constraint represents a fault in the content. This may include issues around compatibility, integrity, consistency, etc."),
+          @AllowedValue(value = "WARNING",
+              description = "A violation of the constraint represents a potential issue with the content."),
+          @AllowedValue(value = "INFORMATIONAL",
+              description = "A violation of the constraint represents a point of interest."),
+          @AllowedValue(value = "DEBUG",
+              description = "A violation of the constraint represents a fault in the content that may warrant review by a developer when performing model or tool development.") })))
   private String _level;
 
   @BoundFlag(
       formalName = "Index Name",
       name = "name",
       required = true,
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _name;
 
   @BoundFlag(
       formalName = "Constraint Target Metapath Expression",
       name = "target",
       required = true,
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _target;
 
   /**
@@ -79,27 +86,25 @@ public class TargetedIndexConstraint implements IBoundObject, ITargetedConstrain
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
       useName = "formal-name",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   /**
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    */
   @BoundField(
       formalName = "Description",
       description = "A short description of the data construct's purpose, describing the constructs semantics.",
       useName = "description",
-      typeAdapter = MarkupLineAdapter.class
-  )
+      typeAdapter = MarkupLineAdapter.class)
   private MarkupLine _description;
 
   @BoundAssembly(
       formalName = "Property",
       useName = "prop",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST))
   private List<Property> _props;
 
   @BoundAssembly(
@@ -107,39 +112,41 @@ public class TargetedIndexConstraint implements IBoundObject, ITargetedConstrain
       useName = "key-field",
       minOccurs = 1,
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "key-fields", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "key-fields", inJson = JsonGroupAsBehavior.LIST))
   private List<KeyConstraintField> _keyFields;
 
   @BoundField(
       formalName = "Constraint Condition Violation Message",
       useName = "message",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _message;
 
   /**
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    */
   @BoundField(
       formalName = "Remarks",
       description = "Any explanatory or helpful information to be provided about the remarks parent.",
-      useName = "remarks"
-  )
+      useName = "remarks")
   private Remarks _remarks;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedIndexConstraint} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedIndexConstraint}
+   * instance with no metadata.
    */
   public TargetedIndexConstraint() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedIndexConstraint} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedIndexConstraint}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public TargetedIndexConstraint(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -165,7 +172,7 @@ public class TargetedIndexConstraint implements IBoundObject, ITargetedConstrain
    * Set the constraint Identifier.
    *
    * @param value
-   *           the id value to set
+   *          the id value to set, or {@code null} to clear
    */
   public void setId(@Nullable String value) {
     _id = value;
@@ -186,7 +193,7 @@ public class TargetedIndexConstraint implements IBoundObject, ITargetedConstrain
    * Set the constraint Severity Level.
    *
    * @param value
-   *           the level value to set
+   *          the level value to set, or {@code null} to clear
    */
   public void setLevel(@Nullable String value) {
     _level = value;
@@ -206,7 +213,7 @@ public class TargetedIndexConstraint implements IBoundObject, ITargetedConstrain
    * Set the index Name.
    *
    * @param value
-   *           the name value to set
+   *          the name value to set
    */
   public void setName(@NonNull String value) {
     _name = value;
@@ -227,7 +234,7 @@ public class TargetedIndexConstraint implements IBoundObject, ITargetedConstrain
    * Set the constraint Target Metapath Expression.
    *
    * @param value
-   *           the target value to set
+   *          the target value to set
    */
   public void setTarget(@NonNull String value) {
     _target = value;
@@ -254,7 +261,7 @@ public class TargetedIndexConstraint implements IBoundObject, ITargetedConstrain
    * A formal name for the data construct, to be presented in documentation.
    *
    * @param value
-   *           the formal-name value to set
+   *          the formal-name value to set, or {@code null} to clear
    */
   public void setFormalName(@Nullable String value) {
     _formalName = value;
@@ -264,7 +271,8 @@ public class TargetedIndexConstraint implements IBoundObject, ITargetedConstrain
    * Get the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @return the description value, or {@code null} if not set
    */
@@ -278,10 +286,11 @@ public class TargetedIndexConstraint implements IBoundObject, ITargetedConstrain
    * Set the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @param value
-   *           the description value to set
+   *          the description value to set, or {@code null} to clear
    */
   public void setDescription(@Nullable MarkupLine value) {
     _description = value;
@@ -305,7 +314,7 @@ public class TargetedIndexConstraint implements IBoundObject, ITargetedConstrain
    * Set the property.
    *
    * @param value
-   *           the prop value to set
+   *          the prop value to set
    */
   public void setProps(@NonNull List<Property> value) {
     _props = value;
@@ -313,11 +322,13 @@ public class TargetedIndexConstraint implements IBoundObject, ITargetedConstrain
 
   /**
    * Add a new {@link Property} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_props == null) {
       _props = new LinkedList<>();
     }
@@ -325,12 +336,15 @@ public class TargetedIndexConstraint implements IBoundObject, ITargetedConstrain
   }
 
   /**
-   * Remove the first matching {@link Property} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link Property} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _props != null && _props.remove(value);
   }
 
@@ -351,7 +365,7 @@ public class TargetedIndexConstraint implements IBoundObject, ITargetedConstrain
    * Set the key Constraint Field.
    *
    * @param value
-   *           the key-field value to set
+   *          the key-field value to set
    */
   public void setKeyFields(@NonNull List<KeyConstraintField> value) {
     _keyFields = value;
@@ -359,11 +373,13 @@ public class TargetedIndexConstraint implements IBoundObject, ITargetedConstrain
 
   /**
    * Add a new {@link KeyConstraintField} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addKeyField(KeyConstraintField item) {
-    KeyConstraintField value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    KeyConstraintField value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_keyFields == null) {
       _keyFields = new LinkedList<>();
     }
@@ -371,12 +387,15 @@ public class TargetedIndexConstraint implements IBoundObject, ITargetedConstrain
   }
 
   /**
-   * Remove the first matching {@link KeyConstraintField} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link KeyConstraintField} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeKeyField(KeyConstraintField item) {
-    KeyConstraintField value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    KeyConstraintField value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _keyFields != null && _keyFields.remove(value);
   }
 
@@ -395,7 +414,7 @@ public class TargetedIndexConstraint implements IBoundObject, ITargetedConstrain
    * Set the constraint Condition Violation Message.
    *
    * @param value
-   *           the message value to set
+   *          the message value to set, or {@code null} to clear
    */
   public void setMessage(@Nullable String value) {
     _message = value;
@@ -405,7 +424,8 @@ public class TargetedIndexConstraint implements IBoundObject, ITargetedConstrain
    * Get the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @return the remarks value, or {@code null} if not set
    */
@@ -419,10 +439,11 @@ public class TargetedIndexConstraint implements IBoundObject, ITargetedConstrain
    * Set the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @param value
-   *           the remarks value to set
+   *          the remarks value to set, or {@code null} to clear
    */
   public void setRemarks(@Nullable Remarks value) {
     _remarks = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedIndexHasKeyConstraint.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedIndexHasKeyConstraint.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -35,16 +36,15 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @MetaschemaAssembly(
     formalName = "Targeted Index Has Key Constraint",
     name = "targeted-index-has-key-constraint",
-    moduleClass = MetaschemaModelModule.class
-)
-public class TargetedIndexHasKeyConstraint implements IBoundObject, ITargetedConstraintBase, IConfigurableMessageConstraintBase {
+    moduleClass = MetaschemaModelModule.class)
+public class TargetedIndexHasKeyConstraint
+    implements IBoundObject, ITargetedConstraintBase, IConfigurableMessageConstraintBase {
   private final IMetaschemaData __metaschemaData;
 
   @BoundFlag(
       formalName = "Constraint Identifier",
       name = "id",
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _id;
 
   @BoundFlag(
@@ -52,24 +52,31 @@ public class TargetedIndexHasKeyConstraint implements IBoundObject, ITargetedCon
       name = "level",
       defaultValue = "ERROR",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "CRITICAL", description = "A violation of the constraint represents a serious fault in the content that will prevent typical use of the content."), @AllowedValue(value = "ERROR", description = "A violation of the constraint represents a fault in the content. This may include issues around compatibility, integrity, consistency, etc."), @AllowedValue(value = "WARNING", description = "A violation of the constraint represents a potential issue with the content."), @AllowedValue(value = "INFORMATIONAL", description = "A violation of the constraint represents a point of interest."), @AllowedValue(value = "DEBUG", description = "A violation of the constraint represents a fault in the content that may warrant review by a developer when performing model or tool development.")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {
+          @AllowedValue(value = "CRITICAL",
+              description = "A violation of the constraint represents a serious fault in the content that will prevent typical use of the content."),
+          @AllowedValue(value = "ERROR",
+              description = "A violation of the constraint represents a fault in the content. This may include issues around compatibility, integrity, consistency, etc."),
+          @AllowedValue(value = "WARNING",
+              description = "A violation of the constraint represents a potential issue with the content."),
+          @AllowedValue(value = "INFORMATIONAL",
+              description = "A violation of the constraint represents a point of interest."),
+          @AllowedValue(value = "DEBUG",
+              description = "A violation of the constraint represents a fault in the content that may warrant review by a developer when performing model or tool development.") })))
   private String _level;
 
   @BoundFlag(
       formalName = "Index Name",
       name = "name",
       required = true,
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _name;
 
   @BoundFlag(
       formalName = "Constraint Target Metapath Expression",
       name = "target",
       required = true,
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _target;
 
   /**
@@ -79,27 +86,25 @@ public class TargetedIndexHasKeyConstraint implements IBoundObject, ITargetedCon
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
       useName = "formal-name",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   /**
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    */
   @BoundField(
       formalName = "Description",
       description = "A short description of the data construct's purpose, describing the constructs semantics.",
       useName = "description",
-      typeAdapter = MarkupLineAdapter.class
-  )
+      typeAdapter = MarkupLineAdapter.class)
   private MarkupLine _description;
 
   @BoundAssembly(
       formalName = "Property",
       useName = "prop",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST))
   private List<Property> _props;
 
   @BoundAssembly(
@@ -107,39 +112,41 @@ public class TargetedIndexHasKeyConstraint implements IBoundObject, ITargetedCon
       useName = "key-field",
       minOccurs = 1,
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "key-fields", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "key-fields", inJson = JsonGroupAsBehavior.LIST))
   private List<KeyConstraintField> _keyFields;
 
   @BoundField(
       formalName = "Constraint Condition Violation Message",
       useName = "message",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _message;
 
   /**
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    */
   @BoundField(
       formalName = "Remarks",
       description = "Any explanatory or helpful information to be provided about the remarks parent.",
-      useName = "remarks"
-  )
+      useName = "remarks")
   private Remarks _remarks;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedIndexHasKeyConstraint} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedIndexHasKeyConstraint}
+   * instance with no metadata.
    */
   public TargetedIndexHasKeyConstraint() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedIndexHasKeyConstraint} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedIndexHasKeyConstraint}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public TargetedIndexHasKeyConstraint(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -165,7 +172,7 @@ public class TargetedIndexHasKeyConstraint implements IBoundObject, ITargetedCon
    * Set the constraint Identifier.
    *
    * @param value
-   *           the id value to set
+   *          the id value to set, or {@code null} to clear
    */
   public void setId(@Nullable String value) {
     _id = value;
@@ -186,7 +193,7 @@ public class TargetedIndexHasKeyConstraint implements IBoundObject, ITargetedCon
    * Set the constraint Severity Level.
    *
    * @param value
-   *           the level value to set
+   *          the level value to set, or {@code null} to clear
    */
   public void setLevel(@Nullable String value) {
     _level = value;
@@ -206,7 +213,7 @@ public class TargetedIndexHasKeyConstraint implements IBoundObject, ITargetedCon
    * Set the index Name.
    *
    * @param value
-   *           the name value to set
+   *          the name value to set
    */
   public void setName(@NonNull String value) {
     _name = value;
@@ -227,7 +234,7 @@ public class TargetedIndexHasKeyConstraint implements IBoundObject, ITargetedCon
    * Set the constraint Target Metapath Expression.
    *
    * @param value
-   *           the target value to set
+   *          the target value to set
    */
   public void setTarget(@NonNull String value) {
     _target = value;
@@ -254,7 +261,7 @@ public class TargetedIndexHasKeyConstraint implements IBoundObject, ITargetedCon
    * A formal name for the data construct, to be presented in documentation.
    *
    * @param value
-   *           the formal-name value to set
+   *          the formal-name value to set, or {@code null} to clear
    */
   public void setFormalName(@Nullable String value) {
     _formalName = value;
@@ -264,7 +271,8 @@ public class TargetedIndexHasKeyConstraint implements IBoundObject, ITargetedCon
    * Get the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @return the description value, or {@code null} if not set
    */
@@ -278,10 +286,11 @@ public class TargetedIndexHasKeyConstraint implements IBoundObject, ITargetedCon
    * Set the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @param value
-   *           the description value to set
+   *          the description value to set, or {@code null} to clear
    */
   public void setDescription(@Nullable MarkupLine value) {
     _description = value;
@@ -305,7 +314,7 @@ public class TargetedIndexHasKeyConstraint implements IBoundObject, ITargetedCon
    * Set the property.
    *
    * @param value
-   *           the prop value to set
+   *          the prop value to set
    */
   public void setProps(@NonNull List<Property> value) {
     _props = value;
@@ -313,11 +322,13 @@ public class TargetedIndexHasKeyConstraint implements IBoundObject, ITargetedCon
 
   /**
    * Add a new {@link Property} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_props == null) {
       _props = new LinkedList<>();
     }
@@ -325,12 +336,15 @@ public class TargetedIndexHasKeyConstraint implements IBoundObject, ITargetedCon
   }
 
   /**
-   * Remove the first matching {@link Property} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link Property} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _props != null && _props.remove(value);
   }
 
@@ -351,7 +365,7 @@ public class TargetedIndexHasKeyConstraint implements IBoundObject, ITargetedCon
    * Set the key Constraint Field.
    *
    * @param value
-   *           the key-field value to set
+   *          the key-field value to set
    */
   public void setKeyFields(@NonNull List<KeyConstraintField> value) {
     _keyFields = value;
@@ -359,11 +373,13 @@ public class TargetedIndexHasKeyConstraint implements IBoundObject, ITargetedCon
 
   /**
    * Add a new {@link KeyConstraintField} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addKeyField(KeyConstraintField item) {
-    KeyConstraintField value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    KeyConstraintField value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_keyFields == null) {
       _keyFields = new LinkedList<>();
     }
@@ -371,12 +387,15 @@ public class TargetedIndexHasKeyConstraint implements IBoundObject, ITargetedCon
   }
 
   /**
-   * Remove the first matching {@link KeyConstraintField} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link KeyConstraintField} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeKeyField(KeyConstraintField item) {
-    KeyConstraintField value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    KeyConstraintField value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _keyFields != null && _keyFields.remove(value);
   }
 
@@ -395,7 +414,7 @@ public class TargetedIndexHasKeyConstraint implements IBoundObject, ITargetedCon
    * Set the constraint Condition Violation Message.
    *
    * @param value
-   *           the message value to set
+   *          the message value to set, or {@code null} to clear
    */
   public void setMessage(@Nullable String value) {
     _message = value;
@@ -405,7 +424,8 @@ public class TargetedIndexHasKeyConstraint implements IBoundObject, ITargetedCon
    * Get the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @return the remarks value, or {@code null} if not set
    */
@@ -419,10 +439,11 @@ public class TargetedIndexHasKeyConstraint implements IBoundObject, ITargetedCon
    * Set the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @param value
-   *           the remarks value to set
+   *          the remarks value to set, or {@code null} to clear
    */
   public void setRemarks(@Nullable Remarks value) {
     _remarks = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedIsUniqueConstraint.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedIsUniqueConstraint.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -35,16 +36,15 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @MetaschemaAssembly(
     formalName = "Targeted Unique Constraint",
     name = "targeted-is-unique-constraint",
-    moduleClass = MetaschemaModelModule.class
-)
-public class TargetedIsUniqueConstraint implements IBoundObject, ITargetedConstraintBase, IConfigurableMessageConstraintBase {
+    moduleClass = MetaschemaModelModule.class)
+public class TargetedIsUniqueConstraint
+    implements IBoundObject, ITargetedConstraintBase, IConfigurableMessageConstraintBase {
   private final IMetaschemaData __metaschemaData;
 
   @BoundFlag(
       formalName = "Constraint Identifier",
       name = "id",
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _id;
 
   @BoundFlag(
@@ -52,16 +52,24 @@ public class TargetedIsUniqueConstraint implements IBoundObject, ITargetedConstr
       name = "level",
       defaultValue = "ERROR",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "CRITICAL", description = "A violation of the constraint represents a serious fault in the content that will prevent typical use of the content."), @AllowedValue(value = "ERROR", description = "A violation of the constraint represents a fault in the content. This may include issues around compatibility, integrity, consistency, etc."), @AllowedValue(value = "WARNING", description = "A violation of the constraint represents a potential issue with the content."), @AllowedValue(value = "INFORMATIONAL", description = "A violation of the constraint represents a point of interest."), @AllowedValue(value = "DEBUG", description = "A violation of the constraint represents a fault in the content that may warrant review by a developer when performing model or tool development.")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {
+          @AllowedValue(value = "CRITICAL",
+              description = "A violation of the constraint represents a serious fault in the content that will prevent typical use of the content."),
+          @AllowedValue(value = "ERROR",
+              description = "A violation of the constraint represents a fault in the content. This may include issues around compatibility, integrity, consistency, etc."),
+          @AllowedValue(value = "WARNING",
+              description = "A violation of the constraint represents a potential issue with the content."),
+          @AllowedValue(value = "INFORMATIONAL",
+              description = "A violation of the constraint represents a point of interest."),
+          @AllowedValue(value = "DEBUG",
+              description = "A violation of the constraint represents a fault in the content that may warrant review by a developer when performing model or tool development.") })))
   private String _level;
 
   @BoundFlag(
       formalName = "Constraint Target Metapath Expression",
       name = "target",
       required = true,
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _target;
 
   /**
@@ -71,27 +79,25 @@ public class TargetedIsUniqueConstraint implements IBoundObject, ITargetedConstr
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
       useName = "formal-name",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   /**
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    */
   @BoundField(
       formalName = "Description",
       description = "A short description of the data construct's purpose, describing the constructs semantics.",
       useName = "description",
-      typeAdapter = MarkupLineAdapter.class
-  )
+      typeAdapter = MarkupLineAdapter.class)
   private MarkupLine _description;
 
   @BoundAssembly(
       formalName = "Property",
       useName = "prop",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST))
   private List<Property> _props;
 
   @BoundAssembly(
@@ -99,39 +105,41 @@ public class TargetedIsUniqueConstraint implements IBoundObject, ITargetedConstr
       useName = "key-field",
       minOccurs = 1,
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "key-fields", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "key-fields", inJson = JsonGroupAsBehavior.LIST))
   private List<KeyConstraintField> _keyFields;
 
   @BoundField(
       formalName = "Constraint Condition Violation Message",
       useName = "message",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _message;
 
   /**
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    */
   @BoundField(
       formalName = "Remarks",
       description = "Any explanatory or helpful information to be provided about the remarks parent.",
-      useName = "remarks"
-  )
+      useName = "remarks")
   private Remarks _remarks;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedIsUniqueConstraint} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedIsUniqueConstraint}
+   * instance with no metadata.
    */
   public TargetedIsUniqueConstraint() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedIsUniqueConstraint} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedIsUniqueConstraint}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public TargetedIsUniqueConstraint(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -157,7 +165,7 @@ public class TargetedIsUniqueConstraint implements IBoundObject, ITargetedConstr
    * Set the constraint Identifier.
    *
    * @param value
-   *           the id value to set
+   *          the id value to set, or {@code null} to clear
    */
   public void setId(@Nullable String value) {
     _id = value;
@@ -178,7 +186,7 @@ public class TargetedIsUniqueConstraint implements IBoundObject, ITargetedConstr
    * Set the constraint Severity Level.
    *
    * @param value
-   *           the level value to set
+   *          the level value to set, or {@code null} to clear
    */
   public void setLevel(@Nullable String value) {
     _level = value;
@@ -199,7 +207,7 @@ public class TargetedIsUniqueConstraint implements IBoundObject, ITargetedConstr
    * Set the constraint Target Metapath Expression.
    *
    * @param value
-   *           the target value to set
+   *          the target value to set
    */
   public void setTarget(@NonNull String value) {
     _target = value;
@@ -226,7 +234,7 @@ public class TargetedIsUniqueConstraint implements IBoundObject, ITargetedConstr
    * A formal name for the data construct, to be presented in documentation.
    *
    * @param value
-   *           the formal-name value to set
+   *          the formal-name value to set, or {@code null} to clear
    */
   public void setFormalName(@Nullable String value) {
     _formalName = value;
@@ -236,7 +244,8 @@ public class TargetedIsUniqueConstraint implements IBoundObject, ITargetedConstr
    * Get the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @return the description value, or {@code null} if not set
    */
@@ -250,10 +259,11 @@ public class TargetedIsUniqueConstraint implements IBoundObject, ITargetedConstr
    * Set the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @param value
-   *           the description value to set
+   *          the description value to set, or {@code null} to clear
    */
   public void setDescription(@Nullable MarkupLine value) {
     _description = value;
@@ -277,7 +287,7 @@ public class TargetedIsUniqueConstraint implements IBoundObject, ITargetedConstr
    * Set the property.
    *
    * @param value
-   *           the prop value to set
+   *          the prop value to set
    */
   public void setProps(@NonNull List<Property> value) {
     _props = value;
@@ -285,11 +295,13 @@ public class TargetedIsUniqueConstraint implements IBoundObject, ITargetedConstr
 
   /**
    * Add a new {@link Property} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_props == null) {
       _props = new LinkedList<>();
     }
@@ -297,12 +309,15 @@ public class TargetedIsUniqueConstraint implements IBoundObject, ITargetedConstr
   }
 
   /**
-   * Remove the first matching {@link Property} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link Property} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _props != null && _props.remove(value);
   }
 
@@ -323,7 +338,7 @@ public class TargetedIsUniqueConstraint implements IBoundObject, ITargetedConstr
    * Set the key Constraint Field.
    *
    * @param value
-   *           the key-field value to set
+   *          the key-field value to set
    */
   public void setKeyFields(@NonNull List<KeyConstraintField> value) {
     _keyFields = value;
@@ -331,11 +346,13 @@ public class TargetedIsUniqueConstraint implements IBoundObject, ITargetedConstr
 
   /**
    * Add a new {@link KeyConstraintField} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addKeyField(KeyConstraintField item) {
-    KeyConstraintField value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    KeyConstraintField value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_keyFields == null) {
       _keyFields = new LinkedList<>();
     }
@@ -343,12 +360,15 @@ public class TargetedIsUniqueConstraint implements IBoundObject, ITargetedConstr
   }
 
   /**
-   * Remove the first matching {@link KeyConstraintField} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link KeyConstraintField} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeKeyField(KeyConstraintField item) {
-    KeyConstraintField value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    KeyConstraintField value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _keyFields != null && _keyFields.remove(value);
   }
 
@@ -367,7 +387,7 @@ public class TargetedIsUniqueConstraint implements IBoundObject, ITargetedConstr
    * Set the constraint Condition Violation Message.
    *
    * @param value
-   *           the message value to set
+   *          the message value to set, or {@code null} to clear
    */
   public void setMessage(@Nullable String value) {
     _message = value;
@@ -377,7 +397,8 @@ public class TargetedIsUniqueConstraint implements IBoundObject, ITargetedConstr
    * Get the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @return the remarks value, or {@code null} if not set
    */
@@ -391,10 +412,11 @@ public class TargetedIsUniqueConstraint implements IBoundObject, ITargetedConstr
    * Set the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @param value
-   *           the remarks value to set
+   *          the remarks value to set, or {@code null} to clear
    */
   public void setRemarks(@Nullable Remarks value) {
     _remarks = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedMatchesConstraint.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedMatchesConstraint.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -35,16 +36,15 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @MetaschemaAssembly(
     formalName = "Value Matches Constraint",
     name = "targeted-matches-constraint",
-    moduleClass = MetaschemaModelModule.class
-)
-public class TargetedMatchesConstraint implements IBoundObject, ITargetedConstraintBase, IConfigurableMessageConstraintBase {
+    moduleClass = MetaschemaModelModule.class)
+public class TargetedMatchesConstraint
+    implements IBoundObject, ITargetedConstraintBase, IConfigurableMessageConstraintBase {
   private final IMetaschemaData __metaschemaData;
 
   @BoundFlag(
       formalName = "Constraint Identifier",
       name = "id",
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _id;
 
   @BoundFlag(
@@ -52,31 +52,96 @@ public class TargetedMatchesConstraint implements IBoundObject, ITargetedConstra
       name = "level",
       defaultValue = "ERROR",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "CRITICAL", description = "A violation of the constraint represents a serious fault in the content that will prevent typical use of the content."), @AllowedValue(value = "ERROR", description = "A violation of the constraint represents a fault in the content. This may include issues around compatibility, integrity, consistency, etc."), @AllowedValue(value = "WARNING", description = "A violation of the constraint represents a potential issue with the content."), @AllowedValue(value = "INFORMATIONAL", description = "A violation of the constraint represents a point of interest."), @AllowedValue(value = "DEBUG", description = "A violation of the constraint represents a fault in the content that may warrant review by a developer when performing model or tool development.")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {
+          @AllowedValue(value = "CRITICAL",
+              description = "A violation of the constraint represents a serious fault in the content that will prevent typical use of the content."),
+          @AllowedValue(value = "ERROR",
+              description = "A violation of the constraint represents a fault in the content. This may include issues around compatibility, integrity, consistency, etc."),
+          @AllowedValue(value = "WARNING",
+              description = "A violation of the constraint represents a potential issue with the content."),
+          @AllowedValue(value = "INFORMATIONAL",
+              description = "A violation of the constraint represents a point of interest."),
+          @AllowedValue(value = "DEBUG",
+              description = "A violation of the constraint represents a fault in the content that may warrant review by a developer when performing model or tool development.") })))
   private String _level;
 
   @BoundFlag(
       formalName = "Matches Regular Expression",
       name = "regex",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _regex;
 
   @BoundFlag(
       formalName = "Matches Data Type",
       name = "datatype",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, allowOthers = true, values = {@AllowedValue(value = "base64", description = "The [base64](https://framework.metaschema.dev/specification/datatypes/#base64) data type."), @AllowedValue(value = "boolean", description = "The [boolean](https://framework.metaschema.dev/specification/datatypes/#boolean) data type."), @AllowedValue(value = "date", description = "The [date](https://framework.metaschema.dev/specification/datatypes/#date) data type."), @AllowedValue(value = "date-time", description = "The [date-time](https://framework.metaschema.dev/specification/datatypes/#date-time) data type."), @AllowedValue(value = "date-time-with-timezone", description = "The [date-time-with-timezone](https://framework.metaschema.dev/specification/datatypes/#date-time-with-timezone) data type."), @AllowedValue(value = "date-with-timezone", description = "The [date-with-timezone](https://framework.metaschema.dev/specification/datatypes/#date-with-timezone) data type."), @AllowedValue(value = "day-time-duration", description = "The [day-time-duration](https://framework.metaschema.dev/specification/datatypes/#day-time-duration) data type."), @AllowedValue(value = "decimal", description = "The [decimal](https://framework.metaschema.dev/specification/datatypes/#decimal) data type."), @AllowedValue(value = "email-address", description = "The [email-address](https://framework.metaschema.dev/specification/datatypes/#email-address) data type."), @AllowedValue(value = "hostname", description = "The [hostname](https://framework.metaschema.dev/specification/datatypes/#hostname) data type."), @AllowedValue(value = "integer", description = "The [integer](https://framework.metaschema.dev/specification/datatypes/#integer) data type."), @AllowedValue(value = "ip-v4-address", description = "The [ip-v4-address](https://framework.metaschema.dev/specification/datatypes/#ip-v4-address) data type."), @AllowedValue(value = "ip-v6-address", description = "The [ip-v6-address](https://framework.metaschema.dev/specification/datatypes/#ip-v6-address) data type."), @AllowedValue(value = "non-negative-integer", description = "The [non-negative-integer](https://framework.metaschema.dev/specification/datatypes/#non-negative-integer) data type."), @AllowedValue(value = "positive-integer", description = "The [positive-integer](https://framework.metaschema.dev/specification/datatypes/#positive-integer) data type."), @AllowedValue(value = "string", description = "The [string](https://framework.metaschema.dev/specification/datatypes/#string) data type."), @AllowedValue(value = "token", description = "The [token](https://framework.metaschema.dev/specification/datatypes/#token) data type."), @AllowedValue(value = "uri", description = "The [uri](https://framework.metaschema.dev/specification/datatypes/#uri) data type."), @AllowedValue(value = "uri-reference", description = "The [uri-reference](https://framework.metaschema.dev/specification/datatypes/#uri-reference) data type."), @AllowedValue(value = "uuid", description = "The [uuid](https://framework.metaschema.dev/specification/datatypes/#uuid) data type."), @AllowedValue(value = "base64Binary", description = "An old name which is deprecated for use in favor of the 'base64' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "dateTime", description = "An old name which is deprecated for use in favor of the 'date-time' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "dateTime-with-timezone", description = "An old name which is deprecated for use in favor of the 'date-time-with-timezone' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "email", description = "An old name which is deprecated for use in favor of the 'email-address' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "nonNegativeInteger", description = "An old name which is deprecated for use in favor of the 'non-negative-integer' data type.", deprecatedVersion = "1.0.0"), @AllowedValue(value = "positiveInteger", description = "An old name which is deprecated for use in favor of the 'positive-integer' data type.", deprecatedVersion = "1.0.0")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR,
+          allowOthers = true,
+          values = { @AllowedValue(value = "base64",
+              description = "The [base64](https://framework.metaschema.dev/specification/datatypes/#base64) data type."),
+              @AllowedValue(value = "boolean",
+                  description = "The [boolean](https://framework.metaschema.dev/specification/datatypes/#boolean) data type."),
+              @AllowedValue(value = "date",
+                  description = "The [date](https://framework.metaschema.dev/specification/datatypes/#date) data type."),
+              @AllowedValue(value = "date-time",
+                  description = "The [date-time](https://framework.metaschema.dev/specification/datatypes/#date-time) data type."),
+              @AllowedValue(value = "date-time-with-timezone",
+                  description = "The [date-time-with-timezone](https://framework.metaschema.dev/specification/datatypes/#date-time-with-timezone) data type."),
+              @AllowedValue(value = "date-with-timezone",
+                  description = "The [date-with-timezone](https://framework.metaschema.dev/specification/datatypes/#date-with-timezone) data type."),
+              @AllowedValue(value = "day-time-duration",
+                  description = "The [day-time-duration](https://framework.metaschema.dev/specification/datatypes/#day-time-duration) data type."),
+              @AllowedValue(value = "decimal",
+                  description = "The [decimal](https://framework.metaschema.dev/specification/datatypes/#decimal) data type."),
+              @AllowedValue(value = "email-address",
+                  description = "The [email-address](https://framework.metaschema.dev/specification/datatypes/#email-address) data type."),
+              @AllowedValue(value = "hostname",
+                  description = "The [hostname](https://framework.metaschema.dev/specification/datatypes/#hostname) data type."),
+              @AllowedValue(value = "integer",
+                  description = "The [integer](https://framework.metaschema.dev/specification/datatypes/#integer) data type."),
+              @AllowedValue(value = "ip-v4-address",
+                  description = "The [ip-v4-address](https://framework.metaschema.dev/specification/datatypes/#ip-v4-address) data type."),
+              @AllowedValue(value = "ip-v6-address",
+                  description = "The [ip-v6-address](https://framework.metaschema.dev/specification/datatypes/#ip-v6-address) data type."),
+              @AllowedValue(value = "non-negative-integer",
+                  description = "The [non-negative-integer](https://framework.metaschema.dev/specification/datatypes/#non-negative-integer) data type."),
+              @AllowedValue(value = "positive-integer",
+                  description = "The [positive-integer](https://framework.metaschema.dev/specification/datatypes/#positive-integer) data type."),
+              @AllowedValue(value = "string",
+                  description = "The [string](https://framework.metaschema.dev/specification/datatypes/#string) data type."),
+              @AllowedValue(value = "token",
+                  description = "The [token](https://framework.metaschema.dev/specification/datatypes/#token) data type."),
+              @AllowedValue(value = "uri",
+                  description = "The [uri](https://framework.metaschema.dev/specification/datatypes/#uri) data type."),
+              @AllowedValue(value = "uri-reference",
+                  description = "The [uri-reference](https://framework.metaschema.dev/specification/datatypes/#uri-reference) data type."),
+              @AllowedValue(value = "uuid",
+                  description = "The [uuid](https://framework.metaschema.dev/specification/datatypes/#uuid) data type."),
+              @AllowedValue(value = "base64Binary",
+                  description = "An old name which is deprecated for use in favor of the 'base64' data type.",
+                  deprecatedVersion = "1.0.0"),
+              @AllowedValue(value = "dateTime",
+                  description = "An old name which is deprecated for use in favor of the 'date-time' data type.",
+                  deprecatedVersion = "1.0.0"),
+              @AllowedValue(value = "dateTime-with-timezone",
+                  description = "An old name which is deprecated for use in favor of the 'date-time-with-timezone' data type.",
+                  deprecatedVersion = "1.0.0"),
+              @AllowedValue(value = "email",
+                  description = "An old name which is deprecated for use in favor of the 'email-address' data type.",
+                  deprecatedVersion = "1.0.0"),
+              @AllowedValue(value = "nonNegativeInteger",
+                  description = "An old name which is deprecated for use in favor of the 'non-negative-integer' data type.",
+                  deprecatedVersion = "1.0.0"),
+              @AllowedValue(value = "positiveInteger",
+                  description = "An old name which is deprecated for use in favor of the 'positive-integer' data type.",
+                  deprecatedVersion = "1.0.0") })))
   private String _datatype;
 
   @BoundFlag(
       formalName = "Constraint Target Metapath Expression",
       name = "target",
       required = true,
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _target;
 
   /**
@@ -86,58 +151,59 @@ public class TargetedMatchesConstraint implements IBoundObject, ITargetedConstra
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
       useName = "formal-name",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   /**
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    */
   @BoundField(
       formalName = "Description",
       description = "A short description of the data construct's purpose, describing the constructs semantics.",
       useName = "description",
-      typeAdapter = MarkupLineAdapter.class
-  )
+      typeAdapter = MarkupLineAdapter.class)
   private MarkupLine _description;
 
   @BoundAssembly(
       formalName = "Property",
       useName = "prop",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST))
   private List<Property> _props;
 
   @BoundField(
       formalName = "Constraint Condition Violation Message",
       useName = "message",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _message;
 
   /**
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    */
   @BoundField(
       formalName = "Remarks",
       description = "Any explanatory or helpful information to be provided about the remarks parent.",
-      useName = "remarks"
-  )
+      useName = "remarks")
   private Remarks _remarks;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedMatchesConstraint} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedMatchesConstraint}
+   * instance with no metadata.
    */
   public TargetedMatchesConstraint() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedMatchesConstraint} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedMatchesConstraint}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public TargetedMatchesConstraint(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -163,7 +229,7 @@ public class TargetedMatchesConstraint implements IBoundObject, ITargetedConstra
    * Set the constraint Identifier.
    *
    * @param value
-   *           the id value to set
+   *          the id value to set, or {@code null} to clear
    */
   public void setId(@Nullable String value) {
     _id = value;
@@ -184,7 +250,7 @@ public class TargetedMatchesConstraint implements IBoundObject, ITargetedConstra
    * Set the constraint Severity Level.
    *
    * @param value
-   *           the level value to set
+   *          the level value to set, or {@code null} to clear
    */
   public void setLevel(@Nullable String value) {
     _level = value;
@@ -204,7 +270,7 @@ public class TargetedMatchesConstraint implements IBoundObject, ITargetedConstra
    * Set the matches Regular Expression.
    *
    * @param value
-   *           the regex value to set
+   *          the regex value to set, or {@code null} to clear
    */
   public void setRegex(@Nullable String value) {
     _regex = value;
@@ -224,7 +290,7 @@ public class TargetedMatchesConstraint implements IBoundObject, ITargetedConstra
    * Set the matches Data Type.
    *
    * @param value
-   *           the datatype value to set
+   *          the datatype value to set, or {@code null} to clear
    */
   public void setDatatype(@Nullable String value) {
     _datatype = value;
@@ -245,7 +311,7 @@ public class TargetedMatchesConstraint implements IBoundObject, ITargetedConstra
    * Set the constraint Target Metapath Expression.
    *
    * @param value
-   *           the target value to set
+   *          the target value to set
    */
   public void setTarget(@NonNull String value) {
     _target = value;
@@ -272,7 +338,7 @@ public class TargetedMatchesConstraint implements IBoundObject, ITargetedConstra
    * A formal name for the data construct, to be presented in documentation.
    *
    * @param value
-   *           the formal-name value to set
+   *          the formal-name value to set, or {@code null} to clear
    */
   public void setFormalName(@Nullable String value) {
     _formalName = value;
@@ -282,7 +348,8 @@ public class TargetedMatchesConstraint implements IBoundObject, ITargetedConstra
    * Get the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @return the description value, or {@code null} if not set
    */
@@ -296,10 +363,11 @@ public class TargetedMatchesConstraint implements IBoundObject, ITargetedConstra
    * Set the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @param value
-   *           the description value to set
+   *          the description value to set, or {@code null} to clear
    */
   public void setDescription(@Nullable MarkupLine value) {
     _description = value;
@@ -323,7 +391,7 @@ public class TargetedMatchesConstraint implements IBoundObject, ITargetedConstra
    * Set the property.
    *
    * @param value
-   *           the prop value to set
+   *          the prop value to set
    */
   public void setProps(@NonNull List<Property> value) {
     _props = value;
@@ -331,11 +399,13 @@ public class TargetedMatchesConstraint implements IBoundObject, ITargetedConstra
 
   /**
    * Add a new {@link Property} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_props == null) {
       _props = new LinkedList<>();
     }
@@ -343,12 +413,15 @@ public class TargetedMatchesConstraint implements IBoundObject, ITargetedConstra
   }
 
   /**
-   * Remove the first matching {@link Property} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link Property} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _props != null && _props.remove(value);
   }
 
@@ -367,7 +440,7 @@ public class TargetedMatchesConstraint implements IBoundObject, ITargetedConstra
    * Set the constraint Condition Violation Message.
    *
    * @param value
-   *           the message value to set
+   *          the message value to set, or {@code null} to clear
    */
   public void setMessage(@Nullable String value) {
     _message = value;
@@ -377,7 +450,8 @@ public class TargetedMatchesConstraint implements IBoundObject, ITargetedConstra
    * Get the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @return the remarks value, or {@code null} if not set
    */
@@ -391,10 +465,11 @@ public class TargetedMatchesConstraint implements IBoundObject, ITargetedConstra
    * Set the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @param value
-   *           the remarks value to set
+   *          the remarks value to set, or {@code null} to clear
    */
   public void setRemarks(@Nullable Remarks value) {
     _remarks = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedReportConstraint.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/TargetedReportConstraint.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -35,16 +36,15 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @MetaschemaAssembly(
     formalName = "Report Condition Constraint",
     name = "targeted-report-constraint",
-    moduleClass = MetaschemaModelModule.class
-)
-public class TargetedReportConstraint implements IBoundObject, ITargetedConstraintBase, IConfigurableMessageConstraintBase {
+    moduleClass = MetaschemaModelModule.class)
+public class TargetedReportConstraint
+    implements IBoundObject, ITargetedConstraintBase, IConfigurableMessageConstraintBase {
   private final IMetaschemaData __metaschemaData;
 
   @BoundFlag(
       formalName = "Constraint Identifier",
       name = "id",
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _id;
 
   @BoundFlag(
@@ -52,24 +52,31 @@ public class TargetedReportConstraint implements IBoundObject, ITargetedConstrai
       name = "level",
       defaultValue = "ERROR",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "CRITICAL", description = "A violation of the constraint represents a serious fault in the content that will prevent typical use of the content."), @AllowedValue(value = "ERROR", description = "A violation of the constraint represents a fault in the content. This may include issues around compatibility, integrity, consistency, etc."), @AllowedValue(value = "WARNING", description = "A violation of the constraint represents a potential issue with the content."), @AllowedValue(value = "INFORMATIONAL", description = "A violation of the constraint represents a point of interest."), @AllowedValue(value = "DEBUG", description = "A violation of the constraint represents a fault in the content that may warrant review by a developer when performing model or tool development.")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {
+          @AllowedValue(value = "CRITICAL",
+              description = "A violation of the constraint represents a serious fault in the content that will prevent typical use of the content."),
+          @AllowedValue(value = "ERROR",
+              description = "A violation of the constraint represents a fault in the content. This may include issues around compatibility, integrity, consistency, etc."),
+          @AllowedValue(value = "WARNING",
+              description = "A violation of the constraint represents a potential issue with the content."),
+          @AllowedValue(value = "INFORMATIONAL",
+              description = "A violation of the constraint represents a point of interest."),
+          @AllowedValue(value = "DEBUG",
+              description = "A violation of the constraint represents a fault in the content that may warrant review by a developer when performing model or tool development.") })))
   private String _level;
 
   @BoundFlag(
       formalName = "Report Test Condition",
       name = "test",
       required = true,
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _test;
 
   @BoundFlag(
       formalName = "Constraint Target Metapath Expression",
       name = "target",
       required = true,
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _target;
 
   /**
@@ -79,58 +86,59 @@ public class TargetedReportConstraint implements IBoundObject, ITargetedConstrai
       formalName = "Formal Name",
       description = "A formal name for the data construct, to be presented in documentation.",
       useName = "formal-name",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _formalName;
 
   /**
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    */
   @BoundField(
       formalName = "Description",
       description = "A short description of the data construct's purpose, describing the constructs semantics.",
       useName = "description",
-      typeAdapter = MarkupLineAdapter.class
-  )
+      typeAdapter = MarkupLineAdapter.class)
   private MarkupLine _description;
 
   @BoundAssembly(
       formalName = "Property",
       useName = "prop",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "props", inJson = JsonGroupAsBehavior.LIST))
   private List<Property> _props;
 
   @BoundField(
       formalName = "Constraint Condition Violation Message",
       useName = "message",
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _message;
 
   /**
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    */
   @BoundField(
       formalName = "Remarks",
       description = "Any explanatory or helpful information to be provided about the remarks parent.",
-      useName = "remarks"
-  )
+      useName = "remarks")
   private Remarks _remarks;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedReportConstraint} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedReportConstraint}
+   * instance with no metadata.
    */
   public TargetedReportConstraint() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedReportConstraint} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.TargetedReportConstraint}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public TargetedReportConstraint(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -156,7 +164,7 @@ public class TargetedReportConstraint implements IBoundObject, ITargetedConstrai
    * Set the constraint Identifier.
    *
    * @param value
-   *           the id value to set
+   *          the id value to set, or {@code null} to clear
    */
   public void setId(@Nullable String value) {
     _id = value;
@@ -177,7 +185,7 @@ public class TargetedReportConstraint implements IBoundObject, ITargetedConstrai
    * Set the constraint Severity Level.
    *
    * @param value
-   *           the level value to set
+   *          the level value to set, or {@code null} to clear
    */
   public void setLevel(@Nullable String value) {
     _level = value;
@@ -197,7 +205,7 @@ public class TargetedReportConstraint implements IBoundObject, ITargetedConstrai
    * Set the report Test Condition.
    *
    * @param value
-   *           the test value to set
+   *          the test value to set
    */
   public void setTest(@NonNull String value) {
     _test = value;
@@ -218,7 +226,7 @@ public class TargetedReportConstraint implements IBoundObject, ITargetedConstrai
    * Set the constraint Target Metapath Expression.
    *
    * @param value
-   *           the target value to set
+   *          the target value to set
    */
   public void setTarget(@NonNull String value) {
     _target = value;
@@ -245,7 +253,7 @@ public class TargetedReportConstraint implements IBoundObject, ITargetedConstrai
    * A formal name for the data construct, to be presented in documentation.
    *
    * @param value
-   *           the formal-name value to set
+   *          the formal-name value to set, or {@code null} to clear
    */
   public void setFormalName(@Nullable String value) {
     _formalName = value;
@@ -255,7 +263,8 @@ public class TargetedReportConstraint implements IBoundObject, ITargetedConstrai
    * Get the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @return the description value, or {@code null} if not set
    */
@@ -269,10 +278,11 @@ public class TargetedReportConstraint implements IBoundObject, ITargetedConstrai
    * Set the description.
    *
    * <p>
-   * A short description of the data construct's purpose, describing the constructs semantics.
+   * A short description of the data construct's purpose, describing the
+   * constructs semantics.
    *
    * @param value
-   *           the description value to set
+   *          the description value to set, or {@code null} to clear
    */
   public void setDescription(@Nullable MarkupLine value) {
     _description = value;
@@ -296,7 +306,7 @@ public class TargetedReportConstraint implements IBoundObject, ITargetedConstrai
    * Set the property.
    *
    * @param value
-   *           the prop value to set
+   *          the prop value to set
    */
   public void setProps(@NonNull List<Property> value) {
     _props = value;
@@ -304,11 +314,13 @@ public class TargetedReportConstraint implements IBoundObject, ITargetedConstrai
 
   /**
    * Add a new {@link Property} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_props == null) {
       _props = new LinkedList<>();
     }
@@ -316,12 +328,15 @@ public class TargetedReportConstraint implements IBoundObject, ITargetedConstrai
   }
 
   /**
-   * Remove the first matching {@link Property} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link Property} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeProp(Property item) {
-    Property value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    Property value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _props != null && _props.remove(value);
   }
 
@@ -340,7 +355,7 @@ public class TargetedReportConstraint implements IBoundObject, ITargetedConstrai
    * Set the constraint Condition Violation Message.
    *
    * @param value
-   *           the message value to set
+   *          the message value to set, or {@code null} to clear
    */
   public void setMessage(@Nullable String value) {
     _message = value;
@@ -350,7 +365,8 @@ public class TargetedReportConstraint implements IBoundObject, ITargetedConstrai
    * Get the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @return the remarks value, or {@code null} if not set
    */
@@ -364,10 +380,11 @@ public class TargetedReportConstraint implements IBoundObject, ITargetedConstrai
    * Set the remarks.
    *
    * <p>
-   * Any explanatory or helpful information to be provided about the remarks parent.
+   * Any explanatory or helpful information to be provided about the remarks
+   * parent.
    *
    * @param value
-   *           the remarks value to set
+   *          the remarks value to set, or {@code null} to clear
    */
   public void setRemarks(@Nullable Remarks value) {
     _remarks = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/UseName.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/UseName.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -26,8 +27,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
     formalName = "Use Name",
     description = "Allows the name of the definition to be overridden.",
     name = "use-name",
-    moduleClass = MetaschemaModelModule.class
-)
+    moduleClass = MetaschemaModelModule.class)
 public class UseName implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
@@ -38,28 +38,30 @@ public class UseName implements IBoundObject {
       formalName = "Numeric Index",
       description = "Used for binary formats instead of the textual name.",
       name = "index",
-      typeAdapter = NonNegativeIntegerAdapter.class
-  )
+      typeAdapter = NonNegativeIntegerAdapter.class)
   private BigInteger _index;
 
   @BoundFieldValue(
       valueKeyName = "name",
-      typeAdapter = TokenAdapter.class
-  )
+      typeAdapter = TokenAdapter.class)
   private String _name;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.UseName} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.UseName}
+   * instance with no metadata.
    */
   public UseName() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.UseName} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.databind.model.metaschema.binding.UseName}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public UseName(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -90,7 +92,7 @@ public class UseName implements IBoundObject {
    * Used for binary formats instead of the textual name.
    *
    * @param value
-   *           the index value to set
+   *          the index value to set, or {@code null} to clear
    */
   public void setIndex(@Nullable BigInteger value) {
     _index = value;

--- a/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/package-info.java
+++ b/databind/src/main/java/gov/nist/secauto/metaschema/databind/model/metaschema/binding/package-info.java
@@ -5,11 +5,17 @@
 // Generated from: ../../../../../../../../../../../../core/metaschema/schema/metaschema/metaschema-module-metaschema.xml
 // Do not edit - changes will be lost when regenerated.
 /**
- * Provides generated Metaschema binding classes for module(s): Metaschema Model.
+ * Provides generated Metaschema binding classes for module(s): Metaschema
+ * Model.
  * <p>
  * version 1.0.0-rc.1
  */
+
 @gov.nist.secauto.metaschema.databind.model.annotations.MetaschemaPackage(moduleClass = {
-  gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModelModule.class})
-@gov.nist.secauto.metaschema.databind.model.annotations.XmlSchema(namespace = "http://csrc.nist.gov/ns/oscal/metaschema/1.0", xmlns = {@gov.nist.secauto.metaschema.databind.model.annotations.XmlNs(prefix = "", namespace = "http://csrc.nist.gov/ns/oscal/metaschema/1.0")}, xmlElementFormDefault = gov.nist.secauto.metaschema.databind.model.annotations.XmlNsForm.QUALIFIED)
+    gov.nist.secauto.metaschema.databind.model.metaschema.binding.MetaschemaModelModule.class })
+@gov.nist.secauto.metaschema.databind.model.annotations.XmlSchema(
+    namespace = "http://csrc.nist.gov/ns/oscal/metaschema/1.0",
+    xmlns = { @gov.nist.secauto.metaschema.databind.model.annotations.XmlNs(prefix = "",
+        namespace = "http://csrc.nist.gov/ns/oscal/metaschema/1.0") },
+    xmlElementFormDefault = gov.nist.secauto.metaschema.databind.model.annotations.XmlNsForm.QUALIFIED)
 package gov.nist.secauto.metaschema.databind.model.metaschema.binding;

--- a/databind/src/test/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/AbstractNamedModelInstanceTypeInfoTest.java
+++ b/databind/src/test/java/gov/nist/secauto/metaschema/databind/codegen/typeinfo/AbstractNamedModelInstanceTypeInfoTest.java
@@ -1,0 +1,190 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.metaschema.databind.codegen.typeinfo;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import gov.nist.secauto.metaschema.core.model.IFieldDefinition;
+import gov.nist.secauto.metaschema.core.model.IFieldInstanceAbsolute;
+import gov.nist.secauto.metaschema.core.util.ObjectUtils;
+import gov.nist.secauto.metaschema.databind.codegen.config.IBindingConfiguration;
+import gov.nist.secauto.metaschema.databind.codegen.typeinfo.def.IAssemblyDefinitionTypeInfo;
+
+import org.jmock.Expectations;
+import org.jmock.junit5.JUnit5Mockery;
+import org.jmock.lib.concurrent.Synchroniser;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Unit tests for {@link AbstractNamedModelInstanceTypeInfo#isRequired()}.
+ *
+ * <p>
+ * Tests verify that the isRequired() method correctly accounts for:
+ * <ul>
+ * <li>minOccurs and maxOccurs values</li>
+ * <li>Choice block membership (choiceId)</li>
+ * </ul>
+ */
+class AbstractNamedModelInstanceTypeInfoTest {
+
+  @RegisterExtension
+  JUnit5Mockery context = new JUnit5Mockery() {
+    {
+      setThreadingPolicy(new Synchroniser());
+    }
+  };
+
+  @NonNull
+  private final IFieldInstanceAbsolute fieldInstance
+      = ObjectUtils.notNull(context.mock(IFieldInstanceAbsolute.class));
+  @NonNull
+  private final IFieldDefinition fieldDefinition
+      = ObjectUtils.notNull(context.mock(IFieldDefinition.class));
+  @NonNull
+  private final IAssemblyDefinitionTypeInfo parentTypeInfo
+      = ObjectUtils.notNull(context.mock(IAssemblyDefinitionTypeInfo.class));
+
+  /**
+   * Creates a FieldInstanceTypeInfoImpl for testing with common mock setup.
+   *
+   * @param minOccurs
+   *          the minimum occurrences
+   * @param maxOccurs
+   *          the maximum occurrences (-1 for unbounded)
+   * @return the type info instance
+   */
+  @NonNull
+  private FieldInstanceTypeInfoImpl createTypeInfo(int minOccurs, int maxOccurs) {
+    IBindingConfiguration bindingConfig = ObjectUtils.notNull(context.mock(IBindingConfiguration.class));
+    DefaultTypeResolver typeResolver = new DefaultTypeResolver(bindingConfig);
+
+    context.checking(new Expectations() {
+      {
+        allowing(parentTypeInfo).getTypeResolver();
+        will(returnValue(typeResolver));
+
+        allowing(fieldInstance).getMinOccurs();
+        will(returnValue(minOccurs));
+
+        allowing(fieldInstance).getMaxOccurs();
+        will(returnValue(maxOccurs));
+
+        allowing(fieldInstance).getDefinition();
+        will(returnValue(fieldDefinition));
+
+        allowing(fieldInstance).getEffectiveName();
+        will(returnValue("test-field"));
+      }
+    });
+
+    return new FieldInstanceTypeInfoImpl(fieldInstance, parentTypeInfo);
+  }
+
+  /**
+   * Test that a required single-valued property (minOccurs=1, maxOccurs=1)
+   * outside a choice block returns true for isRequired().
+   */
+  @Test
+  void testIsRequiredReturnsTrueForRequiredSingleProperty() {
+    FieldInstanceTypeInfoImpl typeInfo = createTypeInfo(1, 1);
+
+    assertTrue(typeInfo.isRequired(),
+        "Property with minOccurs=1 and maxOccurs=1 outside choice should be required");
+  }
+
+  /**
+   * Test that an optional property (minOccurs=0) returns false for isRequired().
+   */
+  @Test
+  void testIsRequiredReturnsFalseForOptionalProperty() {
+    FieldInstanceTypeInfoImpl typeInfo = createTypeInfo(0, 1);
+
+    assertFalse(typeInfo.isRequired(),
+        "Property with minOccurs=0 should not be required");
+  }
+
+  /**
+   * Test that a collection property (maxOccurs > 1) returns false for
+   * isRequired() even with minOccurs=1.
+   */
+  @Test
+  void testIsRequiredReturnsFalseForCollectionProperty() {
+    FieldInstanceTypeInfoImpl typeInfo = createTypeInfo(1, -1);
+
+    assertFalse(typeInfo.isRequired(),
+        "Collection property (maxOccurs=-1) should not be required");
+  }
+
+  /**
+   * Test that a collection property with fixed upper bound returns false for
+   * isRequired().
+   */
+  @Test
+  void testIsRequiredReturnsFalseForBoundedCollectionProperty() {
+    FieldInstanceTypeInfoImpl typeInfo = createTypeInfo(1, 5);
+
+    assertFalse(typeInfo.isRequired(),
+        "Collection property (maxOccurs=5) should not be required");
+  }
+
+  /**
+   * Test that a property inside a choice block returns false for isRequired()
+   * even when minOccurs=1 and maxOccurs=1.
+   *
+   * <p>
+   * This is the key fix for issue #604: properties inside choice blocks are only
+   * conditionally required (when that choice branch is taken), so for null-safety
+   * purposes they must be treated as optional.
+   */
+  @Test
+  void testIsRequiredReturnsFalseForPropertyInsideChoiceBlock() {
+    FieldInstanceTypeInfoImpl typeInfo = createTypeInfo(1, 1);
+
+    // Before setting choiceId, should be required
+    assertTrue(typeInfo.isRequired(),
+        "Property should be required before being placed in a choice");
+
+    // Set choiceId to simulate being inside a choice block
+    typeInfo.setChoiceId("choice-1");
+
+    // After setting choiceId, should NOT be required
+    assertFalse(typeInfo.isRequired(),
+        "Property inside choice block should not be required even with minOccurs=1");
+  }
+
+  /**
+   * Test that an optional property inside a choice block remains not required.
+   */
+  @Test
+  void testIsRequiredReturnsFalseForOptionalPropertyInsideChoiceBlock() {
+    FieldInstanceTypeInfoImpl typeInfo = createTypeInfo(0, 1);
+
+    // Set choiceId
+    typeInfo.setChoiceId("choice-1");
+
+    assertFalse(typeInfo.isRequired(),
+        "Optional property inside choice block should not be required");
+  }
+
+  /**
+   * Test that clearing the choiceId restores the original required behavior.
+   */
+  @Test
+  void testIsRequiredRestoredWhenChoiceIdCleared() {
+    FieldInstanceTypeInfoImpl typeInfo = createTypeInfo(1, 1);
+
+    // Set and then clear choiceId
+    typeInfo.setChoiceId("choice-1");
+    typeInfo.setChoiceId(null);
+
+    assertTrue(typeInfo.isRequired(),
+        "Property should be required again after choiceId is cleared");
+  }
+}

--- a/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/GenerateSchema.java
+++ b/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/GenerateSchema.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../metaschema/unit-tests.yaml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.model.testing.testsuite;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -33,8 +34,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
     formalName = "Generate Schema",
     description = "Defines schema generation parameters and expected results.",
     name = "generate-schema",
-    moduleClass = MetaschemaTestSuiteModule.class
-)
+    moduleClass = MetaschemaTestSuiteModule.class)
 public class GenerateSchema implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
@@ -47,8 +47,9 @@ public class GenerateSchema implements IBoundObject {
       name = "generation-result",
       defaultValue = "SUCCESS",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "SUCCESS", description = "Generation succeeded."), @AllowedValue(value = "FAILURE", description = "Generation resulted in failure caused by some error.")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {
+          @AllowedValue(value = "SUCCESS", description = "Generation succeeded."),
+          @AllowedValue(value = "FAILURE", description = "Generation resulted in failure caused by some error.") })))
   private String _generationResult;
 
   /**
@@ -60,8 +61,10 @@ public class GenerateSchema implements IBoundObject {
       name = "validation-result",
       defaultValue = "VALID",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "VALID", description = "Validation succeeded."), @AllowedValue(value = "INVALID", description = "Validation resulted in failure caused by some content defect or error.")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR,
+          values = { @AllowedValue(value = "VALID", description = "Validation succeeded."),
+              @AllowedValue(value = "INVALID",
+                  description = "Validation resulted in failure caused by some content defect or error.") })))
   private String _validationResult;
 
   /**
@@ -71,8 +74,7 @@ public class GenerateSchema implements IBoundObject {
       formalName = "Metaschema",
       description = "Reference to a metaschema module to load.",
       useName = "metaschema",
-      minOccurs = 1
-  )
+      minOccurs = 1)
   private Metaschema _metaschema;
 
   /**
@@ -83,22 +85,25 @@ public class GenerateSchema implements IBoundObject {
       description = "A schema generation comparison test case.",
       useName = "generation-case",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "generation-cases", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "generation-cases", inJson = JsonGroupAsBehavior.LIST))
   private List<GenerationCase> _generationCases;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.model.testing.testsuite.GenerateSchema} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.model.testing.testsuite.GenerateSchema}
+   * instance with no metadata.
    */
   public GenerateSchema() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.model.testing.testsuite.GenerateSchema} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.model.testing.testsuite.GenerateSchema}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public GenerateSchema(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -129,7 +134,7 @@ public class GenerateSchema implements IBoundObject {
    * The expected result of schema generation.
    *
    * @param value
-   *           the generation-result value to set
+   *          the generation-result value to set, or {@code null} to clear
    */
   public void setGenerationResult(@Nullable String value) {
     _generationResult = value;
@@ -155,7 +160,7 @@ public class GenerateSchema implements IBoundObject {
    * The expected result of content validation.
    *
    * @param value
-   *           the validation-result value to set
+   *          the validation-result value to set, or {@code null} to clear
    */
   public void setValidationResult(@Nullable String value) {
     _validationResult = value;
@@ -181,7 +186,7 @@ public class GenerateSchema implements IBoundObject {
    * Reference to a metaschema module to load.
    *
    * @param value
-   *           the metaschema value to set
+   *          the metaschema value to set
    */
   public void setMetaschema(@NonNull Metaschema value) {
     _metaschema = value;
@@ -210,7 +215,7 @@ public class GenerateSchema implements IBoundObject {
    * A schema generation comparison test case.
    *
    * @param value
-   *           the generation-case value to set
+   *          the generation-case value to set
    */
   public void setGenerationCases(@NonNull List<GenerationCase> value) {
     _generationCases = value;
@@ -218,11 +223,13 @@ public class GenerateSchema implements IBoundObject {
 
   /**
    * Add a new {@link GenerationCase} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addGenerationCase(GenerationCase item) {
-    GenerationCase value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    GenerationCase value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_generationCases == null) {
       _generationCases = new LinkedList<>();
     }
@@ -230,12 +237,15 @@ public class GenerateSchema implements IBoundObject {
   }
 
   /**
-   * Remove the first matching {@link GenerationCase} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link GenerationCase} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeGenerationCase(GenerationCase item) {
-    GenerationCase value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    GenerationCase value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _generationCases != null && _generationCases.remove(value);
   }
 

--- a/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/GenerationCase.java
+++ b/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/GenerationCase.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../metaschema/unit-tests.yaml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.model.testing.testsuite;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -30,8 +31,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
     formalName = "Generation Case",
     description = "A schema generation comparison test case.",
     name = "generation-case",
-    moduleClass = MetaschemaTestSuiteModule.class
-)
+    moduleClass = MetaschemaTestSuiteModule.class)
 public class GenerationCase implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
@@ -43,8 +43,10 @@ public class GenerationCase implements IBoundObject {
       description = "The format of the source content.",
       name = "source-format",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "XML", description = "Content is XML."), @AllowedValue(value = "JSON", description = "Content is JSON."), @AllowedValue(value = "YAML", description = "Content is YAML.")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR,
+          values = { @AllowedValue(value = "XML", description = "Content is XML."),
+              @AllowedValue(value = "JSON", description = "Content is JSON."),
+              @AllowedValue(value = "YAML", description = "Content is YAML.") })))
   private String _sourceFormat;
 
   /**
@@ -55,8 +57,7 @@ public class GenerationCase implements IBoundObject {
       description = "A URI reference to the expected schema file location.",
       name = "location",
       required = true,
-      typeAdapter = UriReferenceAdapter.class
-  )
+      typeAdapter = UriReferenceAdapter.class)
   private URI _location;
 
   /**
@@ -68,22 +69,27 @@ public class GenerationCase implements IBoundObject {
       name = "match-result",
       defaultValue = "MATCH",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "MATCH", description = "The actual content matched the expected content."), @AllowedValue(value = "MISMATCH", description = "The actual content did not match the expected content.")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {
+          @AllowedValue(value = "MATCH", description = "The actual content matched the expected content."),
+          @AllowedValue(value = "MISMATCH", description = "The actual content did not match the expected content.") })))
   private String _matchResult;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.model.testing.testsuite.GenerationCase} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.model.testing.testsuite.GenerationCase}
+   * instance with no metadata.
    */
   public GenerationCase() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.model.testing.testsuite.GenerationCase} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.model.testing.testsuite.GenerationCase}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public GenerationCase(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -114,7 +120,7 @@ public class GenerationCase implements IBoundObject {
    * The format of the source content.
    *
    * @param value
-   *           the source-format value to set
+   *          the source-format value to set, or {@code null} to clear
    */
   public void setSourceFormat(@Nullable String value) {
     _sourceFormat = value;
@@ -140,7 +146,7 @@ public class GenerationCase implements IBoundObject {
    * A URI reference to the expected schema file location.
    *
    * @param value
-   *           the location value to set
+   *          the location value to set
    */
   public void setLocation(@NonNull URI value) {
     _location = value;
@@ -166,7 +172,7 @@ public class GenerationCase implements IBoundObject {
    * The expected result of content comparison.
    *
    * @param value
-   *           the match-result value to set
+   *          the match-result value to set, or {@code null} to clear
    */
   public void setMatchResult(@Nullable String value) {
     _matchResult = value;

--- a/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/Metaschema.java
+++ b/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/Metaschema.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../metaschema/unit-tests.yaml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.model.testing.testsuite;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -24,8 +25,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
     formalName = "Metaschema",
     description = "Reference to a metaschema module to load.",
     name = "metaschema",
-    moduleClass = MetaschemaTestSuiteModule.class
-)
+    moduleClass = MetaschemaTestSuiteModule.class)
 public class Metaschema implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
@@ -37,22 +37,25 @@ public class Metaschema implements IBoundObject {
       description = "A URI reference to the metaschema module location.",
       name = "location",
       required = true,
-      typeAdapter = UriReferenceAdapter.class
-  )
+      typeAdapter = UriReferenceAdapter.class)
   private URI _location;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.model.testing.testsuite.Metaschema} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.model.testing.testsuite.Metaschema}
+   * instance with no metadata.
    */
   public Metaschema() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.model.testing.testsuite.Metaschema} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.model.testing.testsuite.Metaschema}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public Metaschema(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -83,7 +86,7 @@ public class Metaschema implements IBoundObject {
    * A URI reference to the metaschema module location.
    *
    * @param value
-   *           the location value to set
+   *          the location value to set
    */
   public void setLocation(@NonNull URI value) {
     _location = value;

--- a/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/MetaschemaTestSuiteModule.java
+++ b/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/MetaschemaTestSuiteModule.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../metaschema/unit-tests.yaml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.model.testing.testsuite;
 
 import gov.nist.secauto.metaschema.core.datatype.markup.MarkupLine;
@@ -27,9 +28,9 @@ import java.util.List;
         Metaschema.class,
         ValidationCase.class,
         GenerationCase.class
-    }
-)
-public final class MetaschemaTestSuiteModule extends AbstractBoundModule {
+    })
+public final class MetaschemaTestSuiteModule
+    extends AbstractBoundModule {
   private static final MarkupLine NAME = MarkupLine.fromMarkdown("Metaschema Test Suite");
 
   private static final String SHORT_NAME = "metaschema-test-suite";
@@ -44,9 +45,9 @@ public final class MetaschemaTestSuiteModule extends AbstractBoundModule {
    * Construct a new module instance.
    *
    * @param importedModules
-   *           modules imported by this module
+   *          modules imported by this module
    * @param bindingContext
-   *           the binding context to associate with this module
+   *          the binding context to associate with this module
    */
   public MetaschemaTestSuiteModule(List<? extends IBoundModule> importedModules,
       IBindingContext bindingContext) {

--- a/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/TestCollection.java
+++ b/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/TestCollection.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../metaschema/unit-tests.yaml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.model.testing.testsuite;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -30,8 +31,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
     formalName = "Test Collection",
     description = "A collection of test scenarios located at a specific path.",
     name = "test-collection",
-    moduleClass = MetaschemaTestSuiteModule.class
-)
+    moduleClass = MetaschemaTestSuiteModule.class)
 public class TestCollection implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
@@ -43,8 +43,7 @@ public class TestCollection implements IBoundObject {
       description = "A URI reference to the location of this test collection.",
       name = "location",
       required = true,
-      typeAdapter = UriReferenceAdapter.class
-  )
+      typeAdapter = UriReferenceAdapter.class)
   private URI _location;
 
   /**
@@ -55,8 +54,7 @@ public class TestCollection implements IBoundObject {
       description = "The name of this test collection.",
       name = "name",
       required = true,
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _name;
 
   /**
@@ -68,22 +66,25 @@ public class TestCollection implements IBoundObject {
       useName = "test-scenario",
       minOccurs = 1,
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "test-scenarios", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "test-scenarios", inJson = JsonGroupAsBehavior.LIST))
   private List<TestScenario> _testScenarios;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.model.testing.testsuite.TestCollection} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.model.testing.testsuite.TestCollection}
+   * instance with no metadata.
    */
   public TestCollection() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.model.testing.testsuite.TestCollection} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.model.testing.testsuite.TestCollection}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public TestCollection(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -114,7 +115,7 @@ public class TestCollection implements IBoundObject {
    * A URI reference to the location of this test collection.
    *
    * @param value
-   *           the location value to set
+   *          the location value to set
    */
   public void setLocation(@NonNull URI value) {
     _location = value;
@@ -140,7 +141,7 @@ public class TestCollection implements IBoundObject {
    * The name of this test collection.
    *
    * @param value
-   *           the name value to set
+   *          the name value to set
    */
   public void setName(@NonNull String value) {
     _name = value;
@@ -169,7 +170,7 @@ public class TestCollection implements IBoundObject {
    * A test scenario that validates a metaschema and its content.
    *
    * @param value
-   *           the test-scenario value to set
+   *          the test-scenario value to set
    */
   public void setTestScenarios(@NonNull List<TestScenario> value) {
     _testScenarios = value;
@@ -177,11 +178,13 @@ public class TestCollection implements IBoundObject {
 
   /**
    * Add a new {@link TestScenario} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addTestScenario(TestScenario item) {
-    TestScenario value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    TestScenario value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_testScenarios == null) {
       _testScenarios = new LinkedList<>();
     }
@@ -189,12 +192,15 @@ public class TestCollection implements IBoundObject {
   }
 
   /**
-   * Remove the first matching {@link TestScenario} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link TestScenario} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeTestScenario(TestScenario item) {
-    TestScenario value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    TestScenario value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _testScenarios != null && _testScenarios.remove(value);
   }
 

--- a/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/TestScenario.java
+++ b/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/TestScenario.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../metaschema/unit-tests.yaml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.model.testing.testsuite;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -29,8 +30,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
     formalName = "Test Scenario",
     description = "A test scenario that validates a metaschema and its content.",
     name = "test-scenario",
-    moduleClass = MetaschemaTestSuiteModule.class
-)
+    moduleClass = MetaschemaTestSuiteModule.class)
 public class TestScenario implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
@@ -42,8 +42,7 @@ public class TestScenario implements IBoundObject {
       description = "The name of this test scenario.",
       name = "name",
       required = true,
-      typeAdapter = StringAdapter.class
-  )
+      typeAdapter = StringAdapter.class)
   private String _name;
 
   /**
@@ -52,8 +51,7 @@ public class TestScenario implements IBoundObject {
   @BoundAssembly(
       formalName = "Generate Schema",
       description = "Defines schema generation parameters and expected results.",
-      useName = "generate-schema"
-  )
+      useName = "generate-schema")
   private GenerateSchema _generateSchema;
 
   /**
@@ -64,22 +62,25 @@ public class TestScenario implements IBoundObject {
       description = "A content validation test case.",
       useName = "validation-case",
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "validation-cases", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "validation-cases", inJson = JsonGroupAsBehavior.LIST))
   private List<ValidationCase> _validationCases;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.model.testing.testsuite.TestScenario} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.model.testing.testsuite.TestScenario}
+   * instance with no metadata.
    */
   public TestScenario() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.model.testing.testsuite.TestScenario} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.model.testing.testsuite.TestScenario}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public TestScenario(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -110,7 +111,7 @@ public class TestScenario implements IBoundObject {
    * The name of this test scenario.
    *
    * @param value
-   *           the name value to set
+   *          the name value to set
    */
   public void setName(@NonNull String value) {
     _name = value;
@@ -136,7 +137,7 @@ public class TestScenario implements IBoundObject {
    * Defines schema generation parameters and expected results.
    *
    * @param value
-   *           the generate-schema value to set
+   *          the generate-schema value to set, or {@code null} to clear
    */
   public void setGenerateSchema(@Nullable GenerateSchema value) {
     _generateSchema = value;
@@ -165,7 +166,7 @@ public class TestScenario implements IBoundObject {
    * A content validation test case.
    *
    * @param value
-   *           the validation-case value to set
+   *          the validation-case value to set
    */
   public void setValidationCases(@NonNull List<ValidationCase> value) {
     _validationCases = value;
@@ -173,11 +174,13 @@ public class TestScenario implements IBoundObject {
 
   /**
    * Add a new {@link ValidationCase} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addValidationCase(ValidationCase item) {
-    ValidationCase value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    ValidationCase value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_validationCases == null) {
       _validationCases = new LinkedList<>();
     }
@@ -185,12 +188,15 @@ public class TestScenario implements IBoundObject {
   }
 
   /**
-   * Remove the first matching {@link ValidationCase} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link ValidationCase} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeValidationCase(ValidationCase item) {
-    ValidationCase value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    ValidationCase value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _validationCases != null && _validationCases.remove(value);
   }
 

--- a/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/TestSuite.java
+++ b/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/TestSuite.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../metaschema/unit-tests.yaml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.model.testing.testsuite;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -27,8 +28,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
     description = "The root element containing a collection of test collections.",
     name = "test-suite",
     moduleClass = MetaschemaTestSuiteModule.class,
-    rootName = "test-suite"
-)
+    rootName = "test-suite")
 public class TestSuite implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
@@ -41,22 +41,25 @@ public class TestSuite implements IBoundObject {
       useName = "test-collection",
       minOccurs = 1,
       maxOccurs = -1,
-      groupAs = @GroupAs(name = "test-collections", inJson = JsonGroupAsBehavior.LIST)
-  )
+      groupAs = @GroupAs(name = "test-collections", inJson = JsonGroupAsBehavior.LIST))
   private List<TestCollection> _testCollections;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.model.testing.testsuite.TestSuite} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.model.testing.testsuite.TestSuite}
+   * instance with no metadata.
    */
   public TestSuite() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.model.testing.testsuite.TestSuite} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.model.testing.testsuite.TestSuite}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public TestSuite(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -90,7 +93,7 @@ public class TestSuite implements IBoundObject {
    * A collection of test scenarios located at a specific path.
    *
    * @param value
-   *           the test-collection value to set
+   *          the test-collection value to set
    */
   public void setTestCollections(@NonNull List<TestCollection> value) {
     _testCollections = value;
@@ -98,11 +101,13 @@ public class TestSuite implements IBoundObject {
 
   /**
    * Add a new {@link TestCollection} item to the underlying collection.
-   * @param item the item to add
+   *
+   * @param item
+   *          the item to add
    * @return {@code true}
    */
   public boolean addTestCollection(TestCollection item) {
-    TestCollection value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    TestCollection value = ObjectUtils.requireNonNull(item, "item cannot be null");
     if (_testCollections == null) {
       _testCollections = new LinkedList<>();
     }
@@ -110,12 +115,15 @@ public class TestSuite implements IBoundObject {
   }
 
   /**
-   * Remove the first matching {@link TestCollection} item from the underlying collection.
-   * @param item the item to remove
+   * Remove the first matching {@link TestCollection} item from the underlying
+   * collection.
+   *
+   * @param item
+   *          the item to remove
    * @return {@code true} if the item was removed or {@code false} otherwise
    */
   public boolean removeTestCollection(TestCollection item) {
-    TestCollection value = ObjectUtils.requireNonNull(item,"item cannot be null");
+    TestCollection value = ObjectUtils.requireNonNull(item, "item cannot be null");
     return _testCollections != null && _testCollections.remove(value);
   }
 

--- a/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/ValidationCase.java
+++ b/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/ValidationCase.java
@@ -4,6 +4,7 @@
  */
 // Generated from: ../../../../../../../../metaschema/unit-tests.yaml
 // Do not edit - changes will be lost when regenerated.
+
 package gov.nist.secauto.metaschema.model.testing.testsuite;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -30,8 +31,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
     formalName = "Validation Case",
     description = "A content validation test case.",
     name = "validation-case",
-    moduleClass = MetaschemaTestSuiteModule.class
-)
+    moduleClass = MetaschemaTestSuiteModule.class)
 public class ValidationCase implements IBoundObject {
   private final IMetaschemaData __metaschemaData;
 
@@ -43,8 +43,10 @@ public class ValidationCase implements IBoundObject {
       description = "The format of the source content.",
       name = "source-format",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "XML", description = "Content is XML."), @AllowedValue(value = "JSON", description = "Content is JSON."), @AllowedValue(value = "YAML", description = "Content is YAML.")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR,
+          values = { @AllowedValue(value = "XML", description = "Content is XML."),
+              @AllowedValue(value = "JSON", description = "Content is JSON."),
+              @AllowedValue(value = "YAML", description = "Content is YAML.") })))
   private String _sourceFormat;
 
   /**
@@ -55,8 +57,7 @@ public class ValidationCase implements IBoundObject {
       description = "A URI reference to the content file location.",
       name = "location",
       required = true,
-      typeAdapter = UriReferenceAdapter.class
-  )
+      typeAdapter = UriReferenceAdapter.class)
   private URI _location;
 
   /**
@@ -68,22 +69,28 @@ public class ValidationCase implements IBoundObject {
       name = "validation-result",
       defaultValue = "VALID",
       typeAdapter = TokenAdapter.class,
-      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR, values = {@AllowedValue(value = "VALID", description = "Validation succeeded."), @AllowedValue(value = "INVALID", description = "Validation resulted in failure caused by some content defect or error.")}))
-  )
+      valueConstraints = @ValueConstraints(allowedValues = @AllowedValues(level = IConstraint.Level.ERROR,
+          values = { @AllowedValue(value = "VALID", description = "Validation succeeded."),
+              @AllowedValue(value = "INVALID",
+                  description = "Validation resulted in failure caused by some content defect or error.") })))
   private String _validationResult;
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.model.testing.testsuite.ValidationCase} instance with no metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.model.testing.testsuite.ValidationCase}
+   * instance with no metadata.
    */
   public ValidationCase() {
     this(null);
   }
 
   /**
-   * Constructs a new {@code gov.nist.secauto.metaschema.model.testing.testsuite.ValidationCase} instance with the specified metadata.
+   * Constructs a new
+   * {@code gov.nist.secauto.metaschema.model.testing.testsuite.ValidationCase}
+   * instance with the specified metadata.
    *
    * @param data
-   *           the metaschema data, or {@code null} if none
+   *          the metaschema data, or {@code null} if none
    */
   public ValidationCase(IMetaschemaData data) {
     this.__metaschemaData = data;
@@ -114,7 +121,7 @@ public class ValidationCase implements IBoundObject {
    * The format of the source content.
    *
    * @param value
-   *           the source-format value to set
+   *          the source-format value to set, or {@code null} to clear
    */
   public void setSourceFormat(@Nullable String value) {
     _sourceFormat = value;
@@ -140,7 +147,7 @@ public class ValidationCase implements IBoundObject {
    * A URI reference to the content file location.
    *
    * @param value
-   *           the location value to set
+   *          the location value to set
    */
   public void setLocation(@NonNull URI value) {
     _location = value;
@@ -166,7 +173,7 @@ public class ValidationCase implements IBoundObject {
    * The expected result of content validation.
    *
    * @param value
-   *           the validation-result value to set
+   *          the validation-result value to set, or {@code null} to clear
    */
   public void setValidationResult(@Nullable String value) {
     _validationResult = value;

--- a/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/package-info.java
+++ b/metaschema-testing/src/main/java/gov/nist/secauto/metaschema/model/testing/testsuite/package-info.java
@@ -5,11 +5,17 @@
 // Generated from: ../../../../../../../../metaschema/unit-tests.yaml
 // Do not edit - changes will be lost when regenerated.
 /**
- * Provides generated Metaschema binding classes for module(s): Metaschema Test Suite.
+ * Provides generated Metaschema binding classes for module(s): Metaschema Test
+ * Suite.
  * <p>
  * version 1.0.0
  */
+
 @gov.nist.secauto.metaschema.databind.model.annotations.MetaschemaPackage(moduleClass = {
-  gov.nist.secauto.metaschema.model.testing.testsuite.MetaschemaTestSuiteModule.class})
-@gov.nist.secauto.metaschema.databind.model.annotations.XmlSchema(namespace = "http://csrc.nist.gov/ns/metaschema/test-suite/1.0", xmlns = {@gov.nist.secauto.metaschema.databind.model.annotations.XmlNs(prefix = "", namespace = "http://csrc.nist.gov/ns/metaschema/test-suite/1.0")}, xmlElementFormDefault = gov.nist.secauto.metaschema.databind.model.annotations.XmlNsForm.QUALIFIED)
+    gov.nist.secauto.metaschema.model.testing.testsuite.MetaschemaTestSuiteModule.class })
+@gov.nist.secauto.metaschema.databind.model.annotations.XmlSchema(
+    namespace = "http://csrc.nist.gov/ns/metaschema/test-suite/1.0",
+    xmlns = { @gov.nist.secauto.metaschema.databind.model.annotations.XmlNs(prefix = "",
+        namespace = "http://csrc.nist.gov/ns/metaschema/test-suite/1.0") },
+    xmlElementFormDefault = gov.nist.secauto.metaschema.databind.model.annotations.XmlNsForm.QUALIFIED)
 package gov.nist.secauto.metaschema.model.testing.testsuite;


### PR DESCRIPTION
## Summary

- Fixes `isRequired()` to return `false` for properties inside Metaschema choice blocks
- Properties in choice blocks are conditionally required (requirement depends on which branch is taken)
- Generated getters/setters now have correct `@Nullable`/`@NonNull` annotations
- Javadocs on generated setters now document nullability behavior

## Changes

- `AbstractNamedModelInstanceTypeInfo.isRequired()` now checks for `choiceId` before returning `true`
- Updated `IPropertyTypeInfo.isRequired()` Javadoc to document choice block behavior
- Enhanced setter Javadoc generation to indicate when null values are acceptable
- Regenerated all bootstrap binding classes with correct annotations

## Test plan

- [x] New unit tests verify `isRequired()` returns `false` for choice properties
- [x] Unit tests cover boundary conditions (minOccurs, maxOccurs, collections)
- [x] Full CI build passes: `mvn clean install -PCI -Prelease`
- [x] Regenerated bindings show correct annotation changes (e.g., `METASCHEMA.getRootName()` now returns `@Nullable`)

Resolves #604

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed handling of required/optional field status for properties inside Metaschema choice blocks. Fields within choice blocks are now correctly treated as optional for null-safety.

* **New Features**
  * Added public accessor methods to retrieve metaschema data from constraint classes.

* **Documentation**
  * Updated development workflow documentation to clarify precedence rules for project-specific conventions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->