### PR TITLE
fix(deps): add test scope to junit-jupiter dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -447,6 +447,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 	<build>


### PR DESCRIPTION
## Summary

Adds missing `<scope>test</scope>` to the `junit-jupiter` dependency in the parent pom's `<dependencies>` section.

## Problem

The `junit-jupiter` dependency was declared without a scope, defaulting to `compile`. This caused junit jars (~1.3MB, 6 jars) to be included in runtime distributions of downstream projects like oscal-cli.

## Solution

Added `<scope>test</scope>` to the junit-jupiter dependency declaration:

```xml
<dependency>
    <groupId>org.junit.jupiter</groupId>
    <artifactId>junit-jupiter</artifactId>
    <scope>test</scope>
</dependency>
```

## Verification

- [x] `mvn dependency:tree -Dincludes=org.junit.jupiter:junit-jupiter` now shows `test` scope
- [x] Full CI build passes: `mvn clean install -PCI -Prelease`

Resolves #609

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency configuration to properly scope test dependencies, ensuring they are isolated to the test phase and excluded from production artifacts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->