### PR TITLE
chore: exclude generated binding classes from PMD and CPD checks

### DIFF
--- a/databind/pom.xml
+++ b/databind/pom.xml
@@ -103,6 +103,11 @@
 							<ruleset>src/main/config/pmd/ruleset.xml</ruleset>
 							<ruleset>src/main/config/pmd/field-naming-ruleset.xml</ruleset>
 						</rulesets>
+						<!-- Exclude generated binding classes from PMD and CPD -->
+						<excludes>
+							<exclude>**/dev/metaschema/databind/model/metaschema/binding/*.java</exclude>
+							<exclude>**/dev/metaschema/databind/config/binding/*.java</exclude>
+						</excludes>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/metaschema-testing/pom.xml
+++ b/metaschema-testing/pom.xml
@@ -73,6 +73,10 @@
 							<ruleset>src/main/config/pmd/ruleset.xml</ruleset>
 							<ruleset>src/main/config/pmd/field-naming-ruleset.xml</ruleset>
 						</rulesets>
+						<!-- Exclude generated binding classes from PMD and CPD -->
+						<excludes>
+							<exclude>**/dev/metaschema/model/testing/testsuite/**/*.java</exclude>
+						</excludes>
 					</configuration>
 				</plugin>
 			</plugins>


### PR DESCRIPTION
## Summary

- Add PMD excludes for generated binding classes in databind and metaschema-testing modules
- These classes are auto-generated from Metaschema modules and should not be subject to static analysis

## Changes

**databind/pom.xml:**
- Exclude `**/dev/metaschema/databind/model/metaschema/binding/*.java`
- Exclude `**/dev/metaschema/databind/config/binding/*.java`

**metaschema-testing/pom.xml:**
- Exclude `**/dev/metaschema/model/testing/testsuite/**/*.java`

## Test plan

- [x] Verified generated binding classes no longer appear in PMD reports
- [x] Verified generated binding classes no longer appear in CPD reports
- [x] Exclusion patterns match existing Checkstyle excludes in the same modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tool configurations to exclude generated code from static analysis checks. This refines code quality processes to focus on manually written code, improving analysis accuracy and reducing noise in development workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->