### PR TITLE
fix: exclude submodules from Trivy and CodeQL security scans

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,0 +1,6 @@
+name: "CodeQL config"
+
+# Exclude submodules from analysis - they have their own security scanning in their upstream repos
+paths-ignore:
+  - core/metaschema
+  - databind-modules/modules

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,6 +121,7 @@ jobs:
       uses: github/codeql-action/init@5d4e8d1aca955e8d8589aabd499c5cae939e33c7
       with:
         languages: java
+        config-file: .github/codeql-config.yml
     # -------------------------
     # Maven Build
     # -------------------------
@@ -189,8 +190,8 @@ jobs:
         format: 'sarif'
         output: 'trivy-results.sarif'
         severity: 'CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN'
-        # Exclude submodule (has its own security scanning) and Maven plugin IT target dirs
-        skip-dirs: 'core/metaschema,metaschema-maven-plugin/target'
+        # Exclude submodules (have their own security scanning) and Maven plugin IT target dirs
+        skip-dirs: 'core/metaschema,databind-modules/modules,metaschema-maven-plugin/target'
     - name: Trivy Summary
       if: ${{ !inputs.skip_code_scans }}
       run: |


### PR DESCRIPTION
## Summary

- Exclude submodules from Trivy and CodeQL security scans
- Submodules are outside the administrative domain of this repository and have their own security scanning in their upstream repos
- Scanning them here creates noise and duplicates alerts that should be addressed upstream

## Changes

- Added `databind-modules/modules` to Trivy `skip-dirs` (joining existing `core/metaschema`)
- Created `.github/codeql-config.yml` with `paths-ignore` for both submodules
- Updated CodeQL init action to reference the config file

## Test plan

- [ ] Verify Trivy scan no longer reports vulnerabilities from submodule paths
- [ ] Verify CodeQL scan no longer analyzes code in submodule paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD configuration to optimize code analysis workflow and exclude non-essential directories from scanning processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->