### PR TITLE
fix: make CommandService.getCommands() thread-safe

### DIFF
--- a/cli-processor/src/main/java/dev/metaschema/cli/processor/command/CommandService.java
+++ b/cli-processor/src/main/java/dev/metaschema/cli/processor/command/CommandService.java
@@ -26,7 +26,7 @@ import nl.talsmasoftware.lazy4j.Lazy;
 public final class CommandService {
   private static final Lazy<CommandService> INSTANCE = Lazy.of(CommandService::new);
   @NonNull
-  private final ServiceLoader<ICommand> loader;
+  private final Lazy<List<ICommand>> cachedCommands;
 
   /**
    * Get the singleton instance of the function service.
@@ -40,35 +40,30 @@ public final class CommandService {
   /**
    * Construct a new service.
    * <p>
-   * Initializes the ServiceLoader for ICommand implementations.
+   * Initializes the ServiceLoader for ICommand implementations and caches the
+   * loaded commands for thread-safe access.
    * <p>
    * This constructor is private to enforce the singleton pattern.
    */
   private CommandService() {
-    ServiceLoader<ICommand> loader = ServiceLoader.load(ICommand.class);
-    assert loader != null;
-    this.loader = loader;
-  }
-
-  /**
-   * Get the function service loader instance.
-   *
-   * @return the service loader instance.
-   */
-  @NonNull
-  private ServiceLoader<ICommand> getLoader() {
-    return loader;
+    this.cachedCommands = Lazy.of(() -> {
+      ServiceLoader<ICommand> loader = ServiceLoader.load(ICommand.class);
+      return ObjectUtils.notNull(loader.stream()
+          .map(Provider<ICommand>::get)
+          .collect(Collectors.toUnmodifiableList()));
+    });
   }
 
   /**
    * Get the loaded commands.
+   * <p>
+   * Commands are loaded once on first access and cached for subsequent calls.
+   * This ensures thread-safe access and consistent results across calls.
    *
    * @return the list of loaded commands
    */
   @NonNull
   public List<ICommand> getCommands() {
-    return ObjectUtils.notNull(getLoader().stream()
-        .map(Provider<ICommand>::get)
-        .collect(Collectors.toUnmodifiableList()));
+    return cachedCommands.get();
   }
 }

--- a/cli-processor/src/test/java/dev/metaschema/cli/processor/command/CommandServiceTest.java
+++ b/cli-processor/src/test/java/dev/metaschema/cli/processor/command/CommandServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -21,7 +22,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 /**
@@ -45,9 +45,9 @@ class CommandServiceTest {
     ExecutorService executor = Executors.newFixedThreadPool(threadCount);
     CountDownLatch startLatch = new CountDownLatch(1);
     CountDownLatch doneLatch = new CountDownLatch(threadCount);
-    AtomicInteger errorCount = new AtomicInteger(0);
+    List<Exception> exceptions = Collections.synchronizedList(new ArrayList<>());
     Set<Integer> commandCounts = ConcurrentHashMap.newKeySet();
-    List<List<String>> allCommandNames = new ArrayList<>();
+    List<List<String>> allCommandNames = Collections.synchronizedList(new ArrayList<>());
 
     for (int i = 0; i < threadCount; i++) {
       executor.submit(() -> {
@@ -65,12 +65,9 @@ class CommandServiceTest {
               .map(ICommand::getName)
               .collect(Collectors.toList());
 
-          synchronized (allCommandNames) {
-            allCommandNames.add(names);
-          }
+          allCommandNames.add(names);
         } catch (Exception e) {
-          errorCount.incrementAndGet();
-          e.printStackTrace();
+          exceptions.add(e);
         } finally {
           doneLatch.countDown();
         }
@@ -83,9 +80,12 @@ class CommandServiceTest {
     // Wait for all threads to complete
     assertTrue(doneLatch.await(30, TimeUnit.SECONDS), "Threads should complete within timeout");
     executor.shutdown();
+    assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS),
+        "Executor should terminate within timeout");
 
     // Verify no errors occurred
-    assertEquals(0, errorCount.get(), "No exceptions should occur during concurrent access");
+    assertEquals(0, exceptions.size(),
+        "No exceptions should occur during concurrent access. Exceptions: " + exceptions);
 
     // Verify consistent command count across all calls
     assertEquals(1, commandCounts.size(),

--- a/cli-processor/src/test/java/dev/metaschema/cli/processor/command/CommandServiceTest.java
+++ b/cli-processor/src/test/java/dev/metaschema/cli/processor/command/CommandServiceTest.java
@@ -1,0 +1,137 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package dev.metaschema.cli.processor.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+/**
+ * Tests for {@link CommandService}.
+ */
+class CommandServiceTest {
+
+  /**
+   * Tests that getCommands() is thread-safe when called concurrently.
+   * <p>
+   * This test verifies that concurrent access to getCommands() does not cause:
+   * <ul>
+   * <li>NoSuchElementException from ServiceLoader iteration</li>
+   * <li>Duplicate commands in the result</li>
+   * <li>Inconsistent results across calls</li>
+   * </ul>
+   */
+  @RepeatedTest(5)
+  void testGetCommandsThreadSafety() throws InterruptedException {
+    int threadCount = 10;
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    CountDownLatch startLatch = new CountDownLatch(1);
+    CountDownLatch doneLatch = new CountDownLatch(threadCount);
+    AtomicInteger errorCount = new AtomicInteger(0);
+    Set<Integer> commandCounts = ConcurrentHashMap.newKeySet();
+    List<List<String>> allCommandNames = new ArrayList<>();
+
+    for (int i = 0; i < threadCount; i++) {
+      executor.submit(() -> {
+        try {
+          // Wait for all threads to be ready
+          startLatch.await();
+
+          // Call getCommands() concurrently
+          List<ICommand> commands = CommandService.getInstance().getCommands();
+          assertNotNull(commands);
+
+          commandCounts.add(commands.size());
+
+          List<String> names = commands.stream()
+              .map(ICommand::getName)
+              .collect(Collectors.toList());
+
+          synchronized (allCommandNames) {
+            allCommandNames.add(names);
+          }
+        } catch (Exception e) {
+          errorCount.incrementAndGet();
+          e.printStackTrace();
+        } finally {
+          doneLatch.countDown();
+        }
+      });
+    }
+
+    // Start all threads simultaneously
+    startLatch.countDown();
+
+    // Wait for all threads to complete
+    assertTrue(doneLatch.await(30, TimeUnit.SECONDS), "Threads should complete within timeout");
+    executor.shutdown();
+
+    // Verify no errors occurred
+    assertEquals(0, errorCount.get(), "No exceptions should occur during concurrent access");
+
+    // Verify consistent command count across all calls
+    assertEquals(1, commandCounts.size(),
+        "All calls should return the same number of commands, but got: " + commandCounts);
+
+    // Verify no duplicates in any result
+    for (List<String> names : allCommandNames) {
+      Set<String> uniqueNames = Set.copyOf(names);
+      assertEquals(names.size(), uniqueNames.size(),
+          "Should have no duplicate command names, but found duplicates in: " + names);
+    }
+  }
+
+  /**
+   * Tests that getCommands() returns consistent results (same instances).
+   */
+  @Test
+  void testGetCommandsReturnsCachedInstances() {
+    List<ICommand> commands1 = CommandService.getInstance().getCommands();
+    List<ICommand> commands2 = CommandService.getInstance().getCommands();
+
+    assertNotNull(commands1);
+    assertNotNull(commands2);
+    assertEquals(commands1.size(), commands2.size());
+
+    // Commands should be the same instances (cached)
+    for (int i = 0; i < commands1.size(); i++) {
+      assertTrue(commands1.get(i) == commands2.get(i),
+          "Commands should be cached and return same instances");
+    }
+  }
+
+  /**
+   * Tests that the service discovers the shell-completion command via SPI.
+   */
+  @Test
+  void testDiscoversSpiCommands() {
+    List<ICommand> commands = CommandService.getInstance().getCommands();
+
+    assertFalse(commands.isEmpty(), "Should discover at least one command via SPI");
+
+    List<String> names = commands.stream()
+        .map(ICommand::getName)
+        .collect(Collectors.toList());
+
+    assertTrue(names.contains("shell-completion"),
+        "Should discover shell-completion command. Found: " + names);
+  }
+}


### PR DESCRIPTION
## Summary

- Cache loaded commands using `Lazy` to ensure thread-safe access and consistent results across concurrent calls
- Fix issues when multiple threads call `getCommands()` simultaneously, which previously caused `NoSuchElementException` and duplicate command entries due to `ServiceLoader`'s non-thread-safe iteration

## Changes

- Use `Lazy<List<ICommand>>` to cache commands on first load
- Commands are loaded once and reused for all subsequent calls
- Thread-safety is handled by `Lazy`'s internal synchronization
- Added `CommandServiceTest.java` with tests for thread-safety, caching, and SPI discovery

## Test plan

- [x] All existing cli-processor tests pass (95 tests)
- [x] New `CommandServiceTest` validates thread-safe concurrent access
- [x] Verified fix resolves oscal-cli parallel test failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Command loading now uses a lazy, cached mechanism to provide a stable, thread-safe list of commands and avoid repeated discovery overhead.

* **Tests**
  * Added comprehensive tests covering concurrent access, caching behavior, and SPI-based command discovery to ensure reliable command loading.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->