### PR TITLE
refactor: remove unnecessary PMD warning suppressions

### DIFF
--- a/cli-processor/src/main/java/dev/metaschema/cli/processor/CLIProcessor.java
+++ b/cli-processor/src/main/java/dev/metaschema/cli/processor/CLIProcessor.java
@@ -40,7 +40,6 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * This implementation make significant use of the command pattern to support a
  * delegation chain of commands based on implementations of {@link ICommand}.
  */
-@SuppressWarnings("PMD.CouplingBetweenObjects")
 public class CLIProcessor {
   private static final Logger LOGGER = LogManager.getLogger(CLIProcessor.class);
 

--- a/cli-processor/src/main/java/dev/metaschema/cli/processor/CallingContext.java
+++ b/cli-processor/src/main/java/dev/metaschema/cli/processor/CallingContext.java
@@ -302,10 +302,6 @@ public class CallingContext {
    *          the command line information
    * @return the result of executing the command
    */
-  @SuppressWarnings({
-      "PMD.OnlyOneReturn", // readability
-      "PMD.AvoidCatchingGenericException" // needed here
-  })
   @NonNull
   private ExitStatus invokeCommand(@NonNull CommandLine cmdLine) {
     ExitStatus retval;
@@ -648,7 +644,7 @@ public class CallingContext {
     // This avoids native terminal detection which triggers Java 21+ warnings
     int terminalWidth = getTerminalWidth();
 
-    try (PrintWriter writer = new PrintWriter( // NOPMD not owned
+    try (PrintWriter writer = new PrintWriter(
         AutoCloser.preventClose(out),
         true,
         StandardCharsets.UTF_8)) {

--- a/cli-processor/src/main/java/dev/metaschema/cli/processor/command/ShellCompletionCommand.java
+++ b/cli-processor/src/main/java/dev/metaschema/cli/processor/command/ShellCompletionCommand.java
@@ -186,7 +186,6 @@ public class ShellCompletionCommand
     }
   }
 
-  @SuppressWarnings("PMD.SystemPrintln")
   private static void writeToStdout(@NonNull String script) {
     PrintWriter writer = new PrintWriter(
         new OutputStreamWriter(System.out, StandardCharsets.UTF_8), true);

--- a/core/src/main/java/dev/metaschema/core/datatype/adapter/DateAdapter.java
+++ b/core/src/main/java/dev/metaschema/core/datatype/adapter/DateAdapter.java
@@ -72,7 +72,7 @@ public class DateAdapter
         = String.format("%sT00:00:00%s", matcher.group(1), matcher.group(2) == null ? "" : matcher.group(2));
     try {
       TemporalAccessor accessor = DateFormats.DATE_TIME_WITH_TZ.parse(parseValue);
-      return new AmbiguousDate(ObjectUtils.notNull(ZonedDateTime.from(accessor)), true); // NOPMD - readability
+      return new AmbiguousDate(ObjectUtils.notNull(ZonedDateTime.from(accessor)), true);
     } catch (DateTimeParseException ex) {
       try {
         TemporalAccessor accessor = DateFormats.DATE_TIME_WITH_OPTIONAL_TZ.parse(parseValue);
@@ -81,7 +81,7 @@ public class DateAdapter
       } catch (DateTimeParseException ex2) {
         IllegalArgumentException newEx = new IllegalArgumentException(ex2.getLocalizedMessage(), ex2);
         newEx.addSuppressed(ex);
-        throw newEx; // NOPMD - false positive
+        throw newEx;
       }
     }
   }

--- a/core/src/main/java/dev/metaschema/core/datatype/markup/XmlMarkupParser.java
+++ b/core/src/main/java/dev/metaschema/core/datatype/markup/XmlMarkupParser.java
@@ -88,7 +88,7 @@ public final class XmlMarkupParser {
    */
   public MarkupLine parseMarkupline(
       @NonNull XMLEventReader2 reader,
-      @NonNull URI resource) throws XMLStreamException { // NOPMD - acceptable
+      @NonNull URI resource) throws XMLStreamException {
     StringBuilder buffer = new StringBuilder();
     parseContents(reader, resource, null, buffer);
     String html = buffer.toString().trim();
@@ -134,8 +134,7 @@ public final class XmlMarkupParser {
   private void parseToString(
       @NonNull XMLEventReader2 reader,
       @NonNull URI resource,
-      @NonNull StringBuilder buffer) // NOPMD - acceptable
-      throws XMLStreamException {
+      @NonNull StringBuilder buffer) throws XMLStreamException {
     // if (LOGGER.isDebugEnabled()) {
     // LOGGER.debug("parseToString(enter): {}",
     // XmlEventUtil.toString(reader.peek()));

--- a/core/src/main/java/dev/metaschema/core/datatype/markup/flexmark/InsertAnchorExtension.java
+++ b/core/src/main/java/dev/metaschema/core/datatype/markup/flexmark/InsertAnchorExtension.java
@@ -168,7 +168,7 @@ public class InsertAnchorExtension
           assert type != null;
           assert idReference != null;
           inlineParser.appendNode(new InsertAnchorNode(type, idReference));
-          return true; // NOPMD - readability
+          return true;
         }
       }
       return false;
@@ -256,7 +256,7 @@ public class InsertAnchorExtension
           : Collections.emptySet();
     }
 
-    private void processInsert( // NOPMD used as lambda
+    private void processInsert(
         Element node,
         @SuppressWarnings("unused") HtmlNodeConverterContext context,
         HtmlMarkdownWriter out) {

--- a/core/src/main/java/dev/metaschema/core/datatype/markup/flexmark/impl/AbstractMarkupWriter.java
+++ b/core/src/main/java/dev/metaschema/core/datatype/markup/flexmark/impl/AbstractMarkupWriter.java
@@ -262,10 +262,7 @@ public abstract class AbstractMarkupWriter<T, E extends Throwable> // NOPMD not 
    */
   protected abstract void writeElementEnd(@NonNull QName qname) throws E;
 
-  @SuppressWarnings({
-      "unchecked",
-      "PMD.UnusedPrivateMethod"
-  }) // while unused, keeping code for when inline HTML is supported
+  @SuppressWarnings("unchecked") // while unused, keeping code for when inline HTML is supported
   private void writeHtml(Node node) throws E {
     Document doc = Jsoup.parse(node.getChars().toString());
     try {

--- a/core/src/main/java/dev/metaschema/core/datatype/markup/flexmark/impl/IMarkupWriter.java
+++ b/core/src/main/java/dev/metaschema/core/datatype/markup/flexmark/impl/IMarkupWriter.java
@@ -51,7 +51,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  */
 @SuppressFBWarnings(value = "THROWS_METHOD_THROWS_CLAUSE_THROWABLE",
     justification = "There is a need to support varying exceptions from multiple stream writers")
-public interface IMarkupWriter<T, E extends Throwable> { // NOPMD
+public interface IMarkupWriter<T, E extends Throwable> {
   /**
    * Write an HTML element with the provided local name, with no attributes.
    *

--- a/core/src/main/java/dev/metaschema/core/datatype/markup/flexmark/impl/MarkupVisitor.java
+++ b/core/src/main/java/dev/metaschema/core/datatype/markup/flexmark/impl/MarkupVisitor.java
@@ -145,7 +145,7 @@ public class MarkupVisitor<T, E extends Throwable> implements IMarkupVisitor<T, 
   @SuppressWarnings({ "PMD.CyclomaticComplexity", "PMD.CognitiveComplexity", "PMD.NcssCount" })
   protected boolean processInlineElements(
       @NonNull Node node,
-      @NonNull IMarkupWriter<T, E> writer) throws E { // NOPMD - acceptable
+      @NonNull IMarkupWriter<T, E> writer) throws E {
     boolean retval = true;
     if (node instanceof Text) {
       writer.writeText((Text) node);

--- a/core/src/main/java/dev/metaschema/core/metapath/DynamicContext.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/DynamicContext.java
@@ -43,7 +43,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * The implementation of a Metapath
  * <a href="https://www.w3.org/TR/xpath-31/#eval_context">dynamic context</a>.
  */
-public class DynamicContext { // NOPMD - intentional data class
+public class DynamicContext {
 
   @NonNull
   private final Map<Integer, ISequence<?>> letVariableMap;

--- a/core/src/main/java/dev/metaschema/core/metapath/cst/AbstractCSTVisitorBase.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/cst/AbstractCSTVisitorBase.java
@@ -72,7 +72,6 @@ public abstract class AbstractCSTVisitorBase
    *           if the expanded QName prefix is not bound or if the resulting
    *           namespace is invalid
    */
-  @SuppressWarnings({ "PMD.CyclomaticComplexity", "PMD.CognitiveComplexity" })
   @NonNull
   static QName toQName(@NonNull Metapath10.EqnameContext eqname, @NonNull StaticContext context,
       boolean requireNamespace) {

--- a/core/src/main/java/dev/metaschema/core/metapath/cst/logic/AbstractComparison.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/cst/logic/AbstractComparison.java
@@ -17,7 +17,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * expressions representing the left and right sides of the comparison, and a
  * comparison operator.
  */
-public abstract class AbstractComparison // NOPMD - unavoidable
+public abstract class AbstractComparison
     extends AbstractBinaryExpression<IExpression, IExpression>
     implements IBooleanLogicExpression {
 

--- a/core/src/main/java/dev/metaschema/core/metapath/cst/logic/And.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/cst/logic/And.java
@@ -31,7 +31,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * first expression evaluates to {@code false}, otherwise it will return
  * {@code true}.
  */
-public class And // NOPMD - intentional name
+public class And
     extends AbstractNAryExpression
     implements IBooleanLogicExpression {
 

--- a/core/src/main/java/dev/metaschema/core/metapath/function/ArgumentImpl.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/function/ArgumentImpl.java
@@ -33,7 +33,6 @@ class ArgumentImpl implements IArgument {
     return sequenceType;
   }
 
-  @SuppressWarnings("null")
   @Override
   public String toSignature() {
     StringBuilder builder = new StringBuilder();

--- a/core/src/main/java/dev/metaschema/core/metapath/function/ArgumentImpl.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/function/ArgumentImpl.java
@@ -54,10 +54,10 @@ class ArgumentImpl implements IArgument {
   @Override
   public boolean equals(Object obj) {
     if (this == obj) {
-      return true; // NOPMD - readability
+      return true;
     }
     if (obj == null || getClass() != obj.getClass()) {
-      return false; // NOPMD - readability
+      return false;
     }
     ArgumentImpl other = (ArgumentImpl) obj;
     return Objects.equals(name, other.name) && Objects.equals(sequenceType, other.sequenceType);

--- a/core/src/main/java/dev/metaschema/core/metapath/function/impl/AbstractFunction.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/function/impl/AbstractFunction.java
@@ -197,7 +197,7 @@ public abstract class AbstractFunction implements IFunction {
     if (IAnyAtomicItem.class.isAssignableFrom(requiredSequenceTypeClass)) {
       Stream<? extends IAnyAtomicItem> atomicStream = stream.flatMap(IItem::atomize);
 
-      // if (IUntypedAtomicItem.class.isInstance(item)) { // NOPMD
+      // if (IUntypedAtomicItem.class.isInstance(item)) {
       // // TODO: apply cast to atomic type
       // }
 
@@ -303,10 +303,10 @@ public abstract class AbstractFunction implements IFunction {
   @Override
   public boolean equals(Object obj) {
     if (this == obj) {
-      return true; // NOPMD - readability
+      return true;
     }
     if (obj == null || getClass() != obj.getClass()) {
-      return false; // NOPMD - readability
+      return false;
     }
     AbstractFunction other = (AbstractFunction) obj;
     return Objects.equals(getQName(), other.getQName())

--- a/core/src/main/java/dev/metaschema/core/metapath/function/library/CastFunction.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/function/library/CastFunction.java
@@ -86,7 +86,7 @@ public final class CastFunction<ITEM extends IAnyAtomicItem> implements IFunctio
 
     IAnyAtomicItem item = arg.getFirstItem(true);
     if (item == null) {
-      return ISequence.empty(); // NOPMD - readability
+      return ISequence.empty();
     }
 
     ITEM castItem = castExecutor.cast(item);

--- a/core/src/main/java/dev/metaschema/core/metapath/function/library/FnAbs.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/function/library/FnAbs.java
@@ -60,7 +60,7 @@ public final class FnAbs {
 
     INumericItem item = sequence.getFirstItem(true);
     if (item == null) {
-      return ISequence.empty(); // NOPMD - readability
+      return ISequence.empty();
     }
 
     return ISequence.of(item.castAsType(item.abs()));

--- a/core/src/main/java/dev/metaschema/core/metapath/function/library/FnAvg.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/function/library/FnAvg.java
@@ -88,7 +88,7 @@ public final class FnAvg {
   @Nullable
   public static IAnyAtomicItem average(@NonNull Collection<? extends IAnyAtomicItem> items) {
     if (items.isEmpty()) {
-      return null; // NOPMD - readability
+      return null;
     }
 
     // tell cpd to start ignoring code - CPD-OFF
@@ -150,7 +150,7 @@ public final class FnAvg {
     return retval;
   }
 
-  @SuppressWarnings("PMD.UnnecessaryCast")
+  @SuppressWarnings("unchecked")
   @NonNull
   private static <T, R extends T> R average(
       @NonNull Collection<? extends T> items,

--- a/core/src/main/java/dev/metaschema/core/metapath/function/library/FnBaseUri.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/function/library/FnBaseUri.java
@@ -123,7 +123,7 @@ public final class FnBaseUri {
   public static IAnyUriItem fnBaseUri(INodeItem nodeItem) {
     IAnyUriItem retval;
     if (nodeItem == null) {
-      retval = null; // NOPMD - intentional
+      retval = null;
     } else {
       URI baseUri = nodeItem.getBaseUri();
       retval = baseUri == null ? null : IAnyUriItem.valueOf(baseUri);

--- a/core/src/main/java/dev/metaschema/core/metapath/function/library/FnCeiling.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/function/library/FnCeiling.java
@@ -61,7 +61,7 @@ public final class FnCeiling {
 
     INumericItem item = sequence.getFirstItem(true);
     if (item == null) {
-      return ISequence.empty(); // NOPMD - readability
+      return ISequence.empty();
     }
 
     return ISequence.of(item.castAsType(item.ceiling()));

--- a/core/src/main/java/dev/metaschema/core/metapath/function/library/FnResolveUri.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/function/library/FnResolveUri.java
@@ -84,7 +84,7 @@ public final class FnResolveUri {
     ISequence<? extends IStringItem> relativeSequence
         = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(0)));
     if (relativeSequence.isEmpty()) {
-      return ISequence.empty(); // NOPMD - readability
+      return ISequence.empty();
     }
 
     IStringItem relativeString = relativeSequence.getFirstItem(true);
@@ -110,13 +110,12 @@ public final class FnResolveUri {
    * @return a sequence containing the resolved URI or and empty sequence if
    *         either the base or relative URI is {@code null}
    */
-  @SuppressWarnings("PMD.UnusedPrivateMethod") // used in lambda
   @NonNull
   private static ISequence<IAnyUriItem> executeTwoArg(
-      @NonNull IFunction function, // NOPMD - ok
+      @NonNull IFunction function,
       @NonNull List<ISequence<?>> arguments,
-      @NonNull DynamicContext dynamicContext, // NOPMD - ok
-      IItem focus) { // NOPMD - ok
+      @NonNull DynamicContext dynamicContext,
+      IItem focus) {
 
     /* there will always be two arguments */
     assert arguments.size() == 2;
@@ -124,7 +123,7 @@ public final class FnResolveUri {
     ISequence<? extends IStringItem> relativeSequence = FunctionUtils.asType(
         ObjectUtils.requireNonNull(arguments.get(0)));
     if (relativeSequence.isEmpty()) {
-      return ISequence.empty(); // NOPMD - readability
+      return ISequence.empty();
     }
 
     ISequence<? extends IStringItem> baseSequence = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(1)));

--- a/core/src/main/java/dev/metaschema/core/metapath/function/library/FnRound.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/function/library/FnRound.java
@@ -82,7 +82,7 @@ public final class FnRound {
 
     INumericItem item = sequence.getFirstItem(true);
     if (item == null) {
-      return ISequence.empty(); // NOPMD - readability
+      return ISequence.empty();
     }
 
     return ISequence.of(item.round());
@@ -100,7 +100,7 @@ public final class FnRound {
 
     INumericItem item = sequence.getFirstItem(true);
     if (item == null) {
-      return ISequence.empty(); // NOPMD - readability
+      return ISequence.empty();
     }
 
     IIntegerItem precision = FunctionUtils.asType(ObjectUtils.requireNonNull(arguments.get(1).getFirstItem(true)));

--- a/core/src/main/java/dev/metaschema/core/metapath/function/library/FnTokenize.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/function/library/FnTokenize.java
@@ -102,7 +102,7 @@ public final class FnTokenize {
       .build();
   // CPD-ON
 
-  @SuppressWarnings({ "PMD.UnusedFormalParameter", "unused" })
+  @SuppressWarnings("unused")
   @NonNull
   private static ISequence<IStringItem> executeOneArg(
       @NonNull IFunction function,
@@ -118,7 +118,7 @@ public final class FnTokenize {
                 .map(IStringItem::valueOf)));
   }
 
-  @SuppressWarnings({ "PMD.UnusedFormalParameter", "unused" })
+  @SuppressWarnings("unused")
   @NonNull
   private static ISequence<IStringItem> executeTwoArg(
       @NonNull IFunction function,
@@ -131,7 +131,7 @@ public final class FnTokenize {
     return execute(input, pattern, IStringItem.valueOf(""));
   }
 
-  @SuppressWarnings({ "PMD.UnusedFormalParameter", "unused" })
+  @SuppressWarnings("unused")
   @NonNull
   private static ISequence<IStringItem> executeThreeArg(
       @NonNull IFunction function,

--- a/core/src/main/java/dev/metaschema/core/metapath/function/library/NumericFunction.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/function/library/NumericFunction.java
@@ -76,12 +76,12 @@ public final class NumericFunction implements IFunctionExecutor {
     ISequence<? extends INumericItem> sequence = FunctionUtils.asType(
         ObjectUtils.requireNonNull(arguments.get(0)));
     if (sequence.isEmpty()) {
-      return ISequence.empty(); // NOPMD - readability
+      return ISequence.empty();
     }
 
     INumericItem item = sequence.getFirstItem(true);
     if (item == null) {
-      return ISequence.empty(); // NOPMD - readability
+      return ISequence.empty();
     }
 
     INumericItem result = executor.execute(item);

--- a/core/src/main/java/dev/metaschema/core/metapath/impl/MetapathExpression.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/impl/MetapathExpression.java
@@ -41,9 +41,6 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 /**
  * Supports compiling and executing Metapath expressions.
  */
-@SuppressWarnings({
-    "PMD.CouplingBetweenObjects" // necessary since this class aggregates functionality
-})
 public class MetapathExpression
     extends AbstractMetapathExpression {
 

--- a/core/src/main/java/dev/metaschema/core/metapath/item/ISequence.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/item/ISequence.java
@@ -259,7 +259,7 @@ public interface ISequence<ITEM extends IItem> extends List<ITEM>, ICollectionVa
    *         {@link ISequence}
    */
   @NonNull
-  static <ITEM_TYPE extends IItem> ISequence<ITEM_TYPE> ofCollection( // NOPMD - intentional
+  static <ITEM_TYPE extends IItem> ISequence<ITEM_TYPE> ofCollection(
       @NonNull Collection<ITEM_TYPE> items) {
     ISequence<ITEM_TYPE> retval;
     if (items instanceof ISequence) {
@@ -286,7 +286,7 @@ public interface ISequence<ITEM extends IItem> extends List<ITEM>, ICollectionVa
    * @return the new sequence
    */
   @NonNull
-  static <T extends IItem> ISequence<T> of( // NOPMD - intentional
+  static <T extends IItem> ISequence<T> of(
       @Nullable T item) {
     return item == null ? empty() : new SingletonSequence<>(item);
   }

--- a/core/src/main/java/dev/metaschema/core/metapath/item/atomic/IMarkupLineItem.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/item/atomic/IMarkupLineItem.java
@@ -40,7 +40,6 @@ public interface IMarkupLineItem extends IMarkupItem {
    *          a line of markup
    * @return the new item
    */
-  @SuppressWarnings("PMD.AvoidCatchingGenericException")
   @NonNull
   static IMarkupLineItem valueOf(@NonNull String value) {
     try {

--- a/core/src/main/java/dev/metaschema/core/metapath/item/atomic/IMarkupMultilineItem.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/item/atomic/IMarkupMultilineItem.java
@@ -40,7 +40,6 @@ public interface IMarkupMultilineItem extends IMarkupItem {
    *          a line of markup
    * @return the new item
    */
-  @SuppressWarnings("PMD.AvoidCatchingGenericException")
   @NonNull
   static IMarkupMultilineItem valueOf(@NonNull String value) {
     try {

--- a/core/src/main/java/dev/metaschema/core/metapath/item/function/IArrayItem.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/item/function/IArrayItem.java
@@ -40,7 +40,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * @param <ITEM>
  *          the Metapath item type of array members
  */
-@SuppressWarnings("PMD.ExcessivePublicCount")
 public interface IArrayItem<ITEM extends ICollectionValue> extends IFunction, List<ITEM> {
   /**
    * Get the type information for this item.
@@ -224,7 +223,7 @@ public interface IArrayItem<ITEM extends ICollectionValue> extends IFunction, Li
    * @return an array item containing the specified entries
    */
   @NonNull
-  static <T extends ICollectionValue> IArrayItem<T> ofCollection( // NOPMD - intentional
+  static <T extends ICollectionValue> IArrayItem<T> ofCollection(
       @NonNull List<T> items) {
     return items.isEmpty() ? empty() : new ArrayItemN<>(items);
   }

--- a/core/src/main/java/dev/metaschema/core/metapath/item/function/IMapItem.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/item/function/IMapItem.java
@@ -155,7 +155,7 @@ public interface IMapItem<VALUE extends ICollectionValue>
    * @return a map item containing the specified entries
    */
   @NonNull
-  static <V extends ICollectionValue> IMapItem<V> ofCollection( // NOPMD - intentional
+  static <V extends ICollectionValue> IMapItem<V> ofCollection(
       @NonNull Map<IMapKey, V> map) {
     return map.isEmpty() ? empty() : new MapItemN<>(map);
   }

--- a/core/src/main/java/dev/metaschema/core/metapath/item/function/impl/AbstractArrayItem.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/item/function/impl/AbstractArrayItem.java
@@ -81,7 +81,7 @@ public abstract class AbstractArrayItem<ITEM extends ICollectionValue>
 
     IIntegerItem position = arg.getFirstItem(true);
     if (position == null) {
-      return ISequence.empty(); // NOPMD - readability
+      return ISequence.empty();
     }
 
     int index = position.toIntValueExact() - 1;

--- a/core/src/main/java/dev/metaschema/core/metapath/item/function/impl/AbstractMapItem.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/item/function/impl/AbstractMapItem.java
@@ -89,7 +89,7 @@ public abstract class AbstractMapItem<VALUE extends ICollectionValue>
 
     IAnyAtomicItem key = arg.getFirstItem(true);
     if (key == null) {
-      return ISequence.empty(); // NOPMD - readability
+      return ISequence.empty();
     }
 
     ICollectionValue result = MapGet.get(this, key);

--- a/core/src/main/java/dev/metaschema/core/metapath/item/node/DefaultNodeItemFactory.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/item/node/DefaultNodeItemFactory.java
@@ -167,7 +167,7 @@ final class DefaultNodeItemFactory
       @NonNull IAssemblyNodeItem parent,
       @NonNull INamedModelInstance namedInstance,
       @NonNull Stream<?> itemValues) {
-    AtomicInteger index = new AtomicInteger(); // NOPMD - intentional
+    AtomicInteger index = new AtomicInteger();
 
     // the item values will be all non-null items
     return itemValues.map(itemValue -> {

--- a/core/src/main/java/dev/metaschema/core/metapath/type/impl/SequenceTypeImpl.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/type/impl/SequenceTypeImpl.java
@@ -122,10 +122,10 @@ public class SequenceTypeImpl implements ISequenceType {
   @Override
   public boolean equals(Object obj) {
     if (this == obj) {
-      return true; // NOPMD - readability
+      return true;
     }
     if (obj == null || getClass() != obj.getClass()) {
-      return false; // NOPMD - readability
+      return false;
     }
     ISequenceType other = (ISequenceType) obj;
     return Objects.equals(occurrence, other.getOccurrence()) && Objects.equals(type, other.getType());

--- a/core/src/main/java/dev/metaschema/core/model/AbstractModule.java
+++ b/core/src/main/java/dev/metaschema/core/model/AbstractModule.java
@@ -135,7 +135,7 @@ public abstract class AbstractModule<
     return getExports().getExportedRootAssemblyDefinitionMap().get(name);
   }
 
-  @SuppressWarnings({ "unused", "PMD.UnusedPrivateMethod" }) // used by lambda
+  @SuppressWarnings("unused") // used by lambda
   private static <DEF extends IDefinition> DEF handleShadowedDefinitions(
       @NonNull IEnhancedQName key,
       @NonNull DEF oldDef,
@@ -151,7 +151,7 @@ public abstract class AbstractModule<
     return newDef;
   }
 
-  @SuppressWarnings({ "unused", "PMD.UnusedPrivateMethod" }) // used by lambda
+  @SuppressWarnings("unused") // used by lambda
   private static <DEF extends IDefinition> DEF handleShadowedDefinitions(
       @NonNull Integer key,
       @NonNull DEF oldDef,

--- a/core/src/main/java/dev/metaschema/core/model/DefinitionCollectingModelWalker.java
+++ b/core/src/main/java/dev/metaschema/core/model/DefinitionCollectingModelWalker.java
@@ -31,7 +31,7 @@ public abstract class DefinitionCollectingModelWalker
   private final Set<IDefinition> definitions = new LinkedHashSet<>();
 
   @Override
-  protected Void getDefaultData() { // NOPMD - intentional
+  protected Void getDefaultData() {
     return null;
   }
 

--- a/core/src/main/java/dev/metaschema/core/model/constraint/DefaultConstraintValidator.java
+++ b/core/src/main/java/dev/metaschema/core/model/constraint/DefaultConstraintValidator.java
@@ -63,7 +63,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
     "PMD.GodClass" // provides validators for all types
 })
 public class DefaultConstraintValidator
-    implements IConstraintValidator, IMutableConfiguration<ValidationFeature<?>> { // NOPMD - intentional
+    implements IConstraintValidator, IMutableConfiguration<ValidationFeature<?>> {
   private static final Logger LOGGER = LogManager.getLogger(DefaultConstraintValidator.class);
 
   @NonNull
@@ -280,7 +280,7 @@ public class DefaultConstraintValidator
    * @throws ConstraintValidationException
    *           if an unexpected error occurred while validating a constraint
    */
-  private void validateHasCardinality( // NOPMD false positive
+  private void validateHasCardinality(
       @NonNull List<? extends ICardinalityConstraint> constraints,
       @NonNull IAssemblyNodeItem item,
       @NonNull DynamicContext dynamicContext) throws ConstraintValidationException {
@@ -666,7 +666,7 @@ public class DefaultConstraintValidator
    * @throws ConstraintValidationException
    *           if an unexpected error occurred while validating a constraint
    */
-  private void validateIndexHasKey( // NOPMD false positive
+  private void validateIndexHasKey(
       @NonNull List<? extends IIndexHasKeyConstraint> constraints,
       @NonNull IDefinitionNodeItem<?, ?> item,
       @NonNull DynamicContext dynamicContext) throws ConstraintValidationException {

--- a/core/src/main/java/dev/metaschema/core/model/constraint/IIndex.java
+++ b/core/src/main/java/dev/metaschema/core/model/constraint/IIndex.java
@@ -53,7 +53,7 @@ public interface IIndex {
   static boolean isAllNulls(@NonNull Iterable<String> key) {
     for (String value : key) {
       if (value != null) {
-        return false; // NOPMD readability
+        return false;
       }
     }
     return true;

--- a/core/src/main/java/dev/metaschema/core/model/constraint/ParallelValidationConfig.java
+++ b/core/src/main/java/dev/metaschema/core/model/constraint/ParallelValidationConfig.java
@@ -122,7 +122,6 @@ public final class ParallelValidationConfig implements AutoCloseable {
    * @throws IllegalStateException
    *           if called on SEQUENTIAL config
    */
-  @SuppressWarnings("PMD.DoubleCheckedLocking") // Correct with volatile field
   @NonNull
   public ExecutorService getExecutor() {
     if (!isParallel()) {

--- a/core/src/main/java/dev/metaschema/core/model/util/JsonUtil.java
+++ b/core/src/main/java/dev/metaschema/core/model/util/JsonUtil.java
@@ -75,7 +75,6 @@ public final class JsonUtil {
    * @throws IOException
    *           if an error occurred while getting the information from the parser
    */
-  @SuppressWarnings("null")
   @NonNull
   public static String toString(
       @NonNull JsonParser parser,
@@ -96,7 +95,6 @@ public final class JsonUtil {
    *          a JSON parser location
    * @return the informational string
    */
-  @SuppressWarnings("null")
   @NonNull
   public static String toString(@NonNull JsonLocation location) {
     return new StringBuilder(8)
@@ -417,7 +415,6 @@ public final class JsonUtil {
    *          the resource being parsed
    * @return the location string
    */
-  @SuppressWarnings("null")
   @NonNull
   public static CharSequence generateLocationMessage(@NonNull JsonLocation location, @NonNull URI resource) {
     return new StringBuilder()

--- a/core/src/main/java/dev/metaschema/core/model/util/JsonUtil.java
+++ b/core/src/main/java/dev/metaschema/core/model/util/JsonUtil.java
@@ -196,7 +196,7 @@ public final class JsonUtil {
   // JsonToken currentToken = parser.getCurrentToken();
   //
   // boolean retval;
-  // switch (startToken) { // NOPMD - intentional fall through
+  // switch (startToken) {
   // case START_OBJECT:
   // retval = JsonToken.END_OBJECT.equals(currentToken);
   // break;

--- a/databind/src/main/java/dev/metaschema/databind/AbstractModuleLoaderStrategy.java
+++ b/databind/src/main/java/dev/metaschema/databind/AbstractModuleLoaderStrategy.java
@@ -191,11 +191,10 @@ public abstract class AbstractModuleLoaderStrategy implements IBindingContext.IM
       retval = IBindingMatcher.of(definition);
       // always replace the existing matcher to ensure the last loaded module wins
       IBindingMatcher old = bindingMatchers.put(qname, retval);
-      if (old != null && !(definition.getContainingModule() instanceof MetaschemaModelModule)) {
-        // FIXME: find existing causes of this in unit tests
-        if (LOGGER.isDebugEnabled()) {
-          LOGGER.atDebug().log("Replacing matcher for QName: {}", qname);
-        }
+      // FIXME: find existing causes of this in unit tests
+      if (old != null && !(definition.getContainingModule() instanceof MetaschemaModelModule)
+          && LOGGER.isDebugEnabled()) {
+        LOGGER.atDebug().log("Replacing matcher for QName: {}", qname);
       }
 
       // retval = bindingMatchers.get(definition);

--- a/databind/src/main/java/dev/metaschema/databind/AbstractModuleLoaderStrategy.java
+++ b/databind/src/main/java/dev/metaschema/databind/AbstractModuleLoaderStrategy.java
@@ -192,8 +192,7 @@ public abstract class AbstractModuleLoaderStrategy implements IBindingContext.IM
       // always replace the existing matcher to ensure the last loaded module wins
       IBindingMatcher old = bindingMatchers.put(qname, retval);
       // FIXME: find existing causes of this in unit tests
-      if (old != null && !(definition.getContainingModule() instanceof MetaschemaModelModule)
-          && LOGGER.isDebugEnabled()) {
+      if (old != null && !(definition.getContainingModule() instanceof MetaschemaModelModule)) {
         LOGGER.atDebug().log("Replacing matcher for QName: {}", qname);
       }
 

--- a/databind/src/main/java/dev/metaschema/databind/DefaultBindingContext.java
+++ b/databind/src/main/java/dev/metaschema/databind/DefaultBindingContext.java
@@ -271,7 +271,6 @@ public class DefaultBindingContext implements IBindingContext {
   @Override
   @SuppressWarnings({
       "deprecation",
-      "PMD.EmptyFinalizer",
       "checkstyle:NoFinalizer" })
   protected final void finalize() {
     // Do nothing

--- a/databind/src/main/java/dev/metaschema/databind/IBindingContext.java
+++ b/databind/src/main/java/dev/metaschema/databind/IBindingContext.java
@@ -970,7 +970,6 @@ public interface IBindingContext {
      *          the assembly definition that matcher is for
      * @return the matcher
      */
-    @SuppressWarnings("PMD.ShortMethodName")
     @NonNull
     static IBindingMatcher of(IBoundDefinitionModelAssembly assembly) {
       if (!assembly.isRoot()) {

--- a/databind/src/main/java/dev/metaschema/databind/codegen/IProduction.java
+++ b/databind/src/main/java/dev/metaschema/databind/codegen/IProduction.java
@@ -82,7 +82,7 @@ public interface IProduction {
    *           if an error occurred while generating or compiling the classes
    */
   @NonNull
-  static IProduction of( // NOPMD - intentional
+  static IProduction of(
       @NonNull Collection<? extends IModule> modules,
       @NonNull IBindingConfiguration bindingConfiguration,
       @NonNull Path classDir) throws IOException {

--- a/databind/src/main/java/dev/metaschema/databind/codegen/IProduction.java
+++ b/databind/src/main/java/dev/metaschema/databind/codegen/IProduction.java
@@ -97,13 +97,13 @@ public interface IProduction {
       retval.addModule(module, classFactory, classDir);
     }
 
-    Map<String, PackageMetadata> packageNameToPackageMetadataMap = new HashMap<>(); // NOPMD - no concurrency
+    Map<String, PackageMetadata> packageNameToPackageMetadataMap = new HashMap<>();
     for (IGeneratedModuleClass moduleProduction : retval.getModuleProductions()) {
       String packageName = moduleProduction.getPackageName();
 
       PackageMetadata metadata = packageNameToPackageMetadataMap.get(packageName);
       if (metadata == null) {
-        metadata = new PackageMetadata(moduleProduction); // NOPMD - intentional
+        metadata = new PackageMetadata(moduleProduction);
         packageNameToPackageMetadataMap.put(metadata.getPackageName(), metadata);
       } else {
         metadata.addModule(moduleProduction);

--- a/databind/src/main/java/dev/metaschema/databind/codegen/impl/AnnotationGenerator.java
+++ b/databind/src/main/java/dev/metaschema/databind/codegen/impl/AnnotationGenerator.java
@@ -454,9 +454,6 @@ public final class AnnotationGenerator {
     }
   }
 
-  @SuppressWarnings({
-      "PMD.GuardLogStatement" // guarded in outer calls
-  })
   private static void checkCardinalities(
       @NonNull IAssemblyDefinition definition,
       @NonNull ICardinalityConstraint constraint,
@@ -481,9 +478,6 @@ public final class AnnotationGenerator {
     }
   }
 
-  @SuppressWarnings({
-      "PMD.GuardLogStatement" // guarded in outer calls
-  })
   private static void checkMinOccurs(
       @NonNull IAssemblyDefinition definition,
       @NonNull ICardinalityConstraint constraint,
@@ -513,9 +507,6 @@ public final class AnnotationGenerator {
     }
   }
 
-  @SuppressWarnings({
-      "PMD.GuardLogStatement" // guarded in outer calls
-  })
   private static void checkMaxOccurs(
       @NonNull IAssemblyDefinition definition,
       @NonNull ICardinalityConstraint constraint,

--- a/databind/src/main/java/dev/metaschema/databind/codegen/typeinfo/DefaultMetaschemaClassFactory.java
+++ b/databind/src/main/java/dev/metaschema/databind/codegen/typeinfo/DefaultMetaschemaClassFactory.java
@@ -75,8 +75,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 @SuppressWarnings({
     "PMD.CouplingBetweenObjects", // ok
-    "PMD.GodClass", // ok
-    "PMD.CyclomaticComplexity" // ok
+    "PMD.GodClass" // ok
 })
 public class DefaultMetaschemaClassFactory implements IMetaschemaClassFactory {
   private static final Logger LOGGER = LogManager.getLogger();
@@ -203,7 +202,6 @@ public class DefaultMetaschemaClassFactory implements IMetaschemaClassFactory {
 
     Set<String> classNames = new LinkedHashSet<>();
 
-    @SuppressWarnings("PMD.UseConcurrentHashMap") // map is unmodifiable
     Map<IModelDefinition, IGeneratedDefinitionClass> definitionProductions
         = ObjectUtils.notNull(globalDefinitions
             // Get type information for assembly and field definitions.
@@ -355,7 +353,7 @@ public class DefaultMetaschemaClassFactory implements IMetaschemaClassFactory {
   @NonNull
   protected TypeSpec.Builder newClassBuilder(
       @NonNull IModule module,
-      @NonNull ClassName className) { // NOPMD - long, but readable
+      @NonNull ClassName className) {
 
     // create the class
     TypeSpec.Builder builder = TypeSpec.classBuilder(className)

--- a/databind/src/main/java/dev/metaschema/databind/codegen/typeinfo/FlagInstanceTypeInfoImpl.java
+++ b/databind/src/main/java/dev/metaschema/databind/codegen/typeinfo/FlagInstanceTypeInfoImpl.java
@@ -61,7 +61,6 @@ public class FlagInstanceTypeInfoImpl
     return ObjectUtils.notNull(ClassName.get(getInstance().getDefinition().getJavaTypeAdapter().getJavaClass()));
   }
 
-  @SuppressWarnings("PMD.CyclomaticComplexity") // acceptable
   @Override
   public Set<IModelDefinition> buildField(
       TypeSpec.Builder typeBuilder,

--- a/databind/src/main/java/dev/metaschema/databind/io/AbstractSerializationBase.java
+++ b/databind/src/main/java/dev/metaschema/databind/io/AbstractSerializationBase.java
@@ -25,7 +25,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * @param <T>
  *          the type of configuration feature this class manages
  */
-@SuppressWarnings("PMD.ReplaceVectorWithList") // false positive
 abstract class AbstractSerializationBase<T extends IConfigurationFeature<?>>
     implements IMutableConfiguration<T> {
   @NonNull

--- a/databind/src/main/java/dev/metaschema/databind/io/json/MetaschemaJsonReader.java
+++ b/databind/src/main/java/dev/metaschema/databind/io/json/MetaschemaJsonReader.java
@@ -157,7 +157,7 @@ public class MetaschemaJsonReader
   // LOGGER.info(builder.toString());
   // }
 
-  @SuppressWarnings({ "resource", "PMD.CloseResource" })
+  @SuppressWarnings("resource")
   private void push(@NonNull JsonParser parser) throws IOException {
     assert !parser.equals(parserStack.peek());
     if (parser.getCurrentToken() == null) {
@@ -487,7 +487,6 @@ public class MetaschemaJsonReader
         ? bodyHandler
         : new JsonKeyBodyHandler(jsonKey, bodyHandler);
 
-    @SuppressWarnings("PMD.CloseResource")
     JsonLocation location = getReader().currentLocation();
 
     // construct the item

--- a/databind/src/main/java/dev/metaschema/databind/io/xml/DefaultXmlSerializer.java
+++ b/databind/src/main/java/dev/metaschema/databind/io/xml/DefaultXmlSerializer.java
@@ -150,7 +150,7 @@ public class DefaultXmlSerializer<CLASS extends IBoundObject>
           throw new IOException(ex);
         }
         caughtException.addSuppressed(ex);
-        throw caughtException; // NOPMD - intentional
+        throw caughtException;
       }
     }
   }

--- a/databind/src/main/java/dev/metaschema/databind/io/xml/MetaschemaXmlReader.java
+++ b/databind/src/main/java/dev/metaschema/databind/io/xml/MetaschemaXmlReader.java
@@ -323,7 +323,6 @@ public class MetaschemaXmlReader
    * @throws XMLStreamException
    *           if an error occurred while parsing XML events
    */
-  @SuppressWarnings("PMD.OnlyOneReturn")
   protected boolean isNextInstance(
       @NonNull IBoundInstanceModel<?> targetInstance)
       throws XMLStreamException {

--- a/databind/src/main/java/dev/metaschema/databind/metapath/function/Model.java
+++ b/databind/src/main/java/dev/metaschema/databind/metapath/function/Model.java
@@ -69,9 +69,7 @@ public final class Model {
    * @return a sequence containing the model node item, or an empty sequence if
    *         not available
    */
-  @SuppressWarnings({ "unused",
-      "PMD.OnlyOneReturn" // readability
-  })
+  @SuppressWarnings("unused")
   @NonNull
   public static ISequence<?> execute(
       @NonNull IFunction function,

--- a/databind/src/main/java/dev/metaschema/databind/metapath/function/Model.java
+++ b/databind/src/main/java/dev/metaschema/databind/metapath/function/Model.java
@@ -69,7 +69,6 @@ public final class Model {
    * @return a sequence containing the model node item, or an empty sequence if
    *         not available
    */
-  @SuppressWarnings("unused")
   @NonNull
   public static ISequence<?> execute(
       @NonNull IFunction function,

--- a/databind/src/main/java/dev/metaschema/databind/model/IBoundModule.java
+++ b/databind/src/main/java/dev/metaschema/databind/model/IBoundModule.java
@@ -71,7 +71,7 @@ public interface IBoundModule
   IBindingContext getBindingContext();
 
   @Override
-  default URI getLocation() { // NOPMD - intentional
+  default URI getLocation() {
     // not known
     return null;
   }

--- a/databind/src/main/java/dev/metaschema/databind/model/IFeatureJavaField.java
+++ b/databind/src/main/java/dev/metaschema/databind/model/IFeatureJavaField.java
@@ -53,7 +53,7 @@ public interface IFeatureJavaField extends IValuedMutable {
   default Object getValue(@NonNull Object parent) {
     Field field = getField();
     // boolean accessable = field.canAccess(parent);
-    // field.setAccessible(true); // NOPMD - intentional
+    // field.setAccessible(true);
     Object retval;
     try {
       Object result = field.get(parent);
@@ -64,7 +64,7 @@ public interface IFeatureJavaField extends IValuedMutable {
               field.getDeclaringClass().getName()),
           ex);
       // } finally {
-      // field.setAccessible(accessable); // NOPMD - intentional
+      // field.setAccessible(accessable);
     }
     return retval;
   }
@@ -73,7 +73,7 @@ public interface IFeatureJavaField extends IValuedMutable {
   default void setValue(@NonNull Object parentObject, Object value) {
     Field field = getField();
     // boolean accessable = field.canAccess(parentObject);
-    // field.setAccessible(true); // NOPMD - intentional
+    // field.setAccessible(true);
     try {
       field.set(parentObject, value);
     } catch (IllegalArgumentException | IllegalAccessException ex) {
@@ -85,7 +85,7 @@ public interface IFeatureJavaField extends IValuedMutable {
               field.getDeclaringClass().getName()),
           ex);
       // } finally {
-      // field.setAccessible(accessable); // NOPMD - intentional
+      // field.setAccessible(accessable);
     }
   }
 

--- a/databind/src/main/java/dev/metaschema/databind/model/annotations/AllowedValues.java
+++ b/databind/src/main/java/dev/metaschema/databind/model/annotations/AllowedValues.java
@@ -32,7 +32,6 @@ public @interface AllowedValues {
    *
    * @return the identifier if provided or an empty string otherwise
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   String id() default "";
 

--- a/databind/src/main/java/dev/metaschema/databind/model/annotations/Expect.java
+++ b/databind/src/main/java/dev/metaschema/databind/model/annotations/Expect.java
@@ -31,7 +31,6 @@ public @interface Expect {
    *
    * @return the identifier if provided or an empty string otherwise
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   String id() default "";
 

--- a/databind/src/main/java/dev/metaschema/databind/model/annotations/HasCardinality.java
+++ b/databind/src/main/java/dev/metaschema/databind/model/annotations/HasCardinality.java
@@ -31,7 +31,6 @@ public @interface HasCardinality {
    *
    * @return the identifier if provided or an empty string otherwise
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   String id() default "";
 

--- a/databind/src/main/java/dev/metaschema/databind/model/annotations/Index.java
+++ b/databind/src/main/java/dev/metaschema/databind/model/annotations/Index.java
@@ -31,7 +31,6 @@ public @interface Index {
    *
    * @return the identifier if provided or an empty string otherwise
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   String id() default "";
 

--- a/databind/src/main/java/dev/metaschema/databind/model/annotations/IndexHasKey.java
+++ b/databind/src/main/java/dev/metaschema/databind/model/annotations/IndexHasKey.java
@@ -34,7 +34,6 @@ public @interface IndexHasKey {
    *
    * @return the identifier if provided or an empty string otherwise
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   String id() default "";
 

--- a/databind/src/main/java/dev/metaschema/databind/model/annotations/IsUnique.java
+++ b/databind/src/main/java/dev/metaschema/databind/model/annotations/IsUnique.java
@@ -32,7 +32,6 @@ public @interface IsUnique {
    *
    * @return the identifier if provided or an empty string otherwise
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   String id() default "";
 

--- a/databind/src/main/java/dev/metaschema/databind/model/annotations/Matches.java
+++ b/databind/src/main/java/dev/metaschema/databind/model/annotations/Matches.java
@@ -34,7 +34,6 @@ public @interface Matches {
    *
    * @return the identifier if provided or an empty string otherwise
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   String id() default "";
 

--- a/databind/src/main/java/dev/metaschema/databind/model/annotations/ModelUtil.java
+++ b/databind/src/main/java/dev/metaschema/databind/model/annotations/ModelUtil.java
@@ -323,12 +323,10 @@ public final class ModelUtil {
   public static Map.Entry<IAttributable.Key, Set<String>> toPropertyEntry(@NonNull Property property) {
     String name = property.name();
     String namespace = property.namespace();
-    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops") // ok
     IAttributable.Key key = IAttributable.key(namespace, name);
 
     String[] values = property.values();
     List<String> valueList = Arrays.asList(values);
-    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops") // ok
     Set<String> valueSet = new LinkedHashSet<>(valueList);
 
     return Map.entry(key, CollectionUtil.unmodifiableSet(valueSet));

--- a/databind/src/main/java/dev/metaschema/databind/model/annotations/Report.java
+++ b/databind/src/main/java/dev/metaschema/databind/model/annotations/Report.java
@@ -34,7 +34,6 @@ public @interface Report {
    *
    * @return the identifier if provided or an empty string otherwise
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   String id() default "";
 

--- a/databind/src/main/java/dev/metaschema/databind/model/impl/AssemblyModelGenerator.java
+++ b/databind/src/main/java/dev/metaschema/databind/model/impl/AssemblyModelGenerator.java
@@ -85,10 +85,6 @@ final class AssemblyModelGenerator {
     }
   }
 
-  @SuppressWarnings({
-      "PMD.ShortMethodName",
-      "PMD.CyclomaticComplexity" // reasonable for model building logic
-  })
   @NonNull
   public static IContainerModelAssemblySupport<
       IBoundInstanceModel<?>,

--- a/databind/src/main/java/dev/metaschema/databind/model/impl/ClassIntrospector.java
+++ b/databind/src/main/java/dev/metaschema/databind/model/impl/ClassIntrospector.java
@@ -37,7 +37,6 @@ public final class ClassIntrospector {
    * @return an unmodifiable list of matching methods found in the class
    *         hierarchy, or an empty list if no matches are found
    */
-  @SuppressWarnings("PMD.EmptyCatchBlock")
   public static List<Method> getMatchingMethods(Class<?> clazz, String name, Class<?>... parameterTypes) {
     List<Method> retval = new LinkedList<>();
     Class<?> searchClass = clazz;
@@ -69,7 +68,6 @@ public final class ClassIntrospector {
    * @return the first matching method found in the class hierarchy, or
    *         {@code null} if no match is found
    */
-  @SuppressWarnings("PMD.EmptyCatchBlock")
   public static Method getMatchingMethod(Class<?> clazz, String name, Class<?>... parameterTypes) {
     Method retval = null;
     Class<?> searchClass = clazz;

--- a/databind/src/main/java/dev/metaschema/databind/model/impl/ConstraintFactory.java
+++ b/databind/src/main/java/dev/metaschema/databind/model/impl/ConstraintFactory.java
@@ -219,7 +219,6 @@ final class ConstraintFactory {
       @NonNull ISource source,
       @NonNull KeyField... keyFields) {
     for (KeyField keyField : keyFields) {
-      @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops") // ok
       IKeyField field = IKeyField.of(
           metapath(keyField.target(), source),
           toPattern(keyField.pattern()),

--- a/databind/src/main/java/dev/metaschema/databind/model/impl/ConstraintSupport.java
+++ b/databind/src/main/java/dev/metaschema/databind/model/impl/ConstraintSupport.java
@@ -39,7 +39,7 @@ public final class ConstraintSupport {
    *          the constraint set to parse the constraints into
    */
   @SuppressWarnings("null")
-  public static void parse( // NOPMD - intentional
+  public static void parse(
       @Nullable ValueConstraints valueAnnotation,
       @NonNull ISource source,
       @NonNull IValueConstrained set) {
@@ -77,7 +77,7 @@ public final class ConstraintSupport {
    *          the constraint set to parse the constraints into
    */
   @SuppressWarnings("null")
-  public static void parse( // NOPMD - intentional
+  public static void parse(
       @Nullable AssemblyConstraints assemblyAnnotation,
       @NonNull ISource source,
       @NonNull IModelConstrained set) {

--- a/databind/src/main/java/dev/metaschema/databind/model/impl/DefinitionField.java
+++ b/databind/src/main/java/dev/metaschema/databind/model/impl/DefinitionField.java
@@ -125,7 +125,7 @@ public final class DefinitionField
       throw new IllegalArgumentException(
           String.format("Class '%s' is missing the '%s' annotation on one of its fields.",
               clazz.getName(),
-              BoundFieldValue.class.getName())); // NOPMD false positive
+              BoundFieldValue.class.getName()));
     }
     FieldSupport.bindField(field);
     this.fieldValue = new FieldValue(field, BoundFieldValue.class, bindingContext);

--- a/databind/src/main/java/dev/metaschema/databind/model/impl/FlagContainerSupport.java
+++ b/databind/src/main/java/dev/metaschema/databind/model/impl/FlagContainerSupport.java
@@ -48,7 +48,6 @@ public class FlagContainerSupport implements IContainerFlagSupport<IBoundInstanc
    *          an optional consumer to receive each flag instance as it is
    *          processed, or {@code null} if no additional processing is needed
    */
-  @SuppressWarnings("PMD.ConstructorCallsOverridableMethod")
   @SuppressFBWarnings(value = "CT_CONSTRUCTOR_THROW", justification = "Use of final fields")
   public FlagContainerSupport(
       @NonNull IBoundDefinitionModelComplex definition,
@@ -88,7 +87,6 @@ public class FlagContainerSupport implements IContainerFlagSupport<IBoundInstanc
    *          the class
    * @return an immutable collection of flag instances
    */
-  @SuppressWarnings("PMD.UseArraysAsList")
   @NonNull
   protected static Collection<Field> getFlagInstanceFields(Class<?> clazz) {
     Field[] fields = clazz.getDeclaredFields();

--- a/databind/src/main/java/dev/metaschema/databind/model/impl/InstanceModelFieldComplex.java
+++ b/databind/src/main/java/dev/metaschema/databind/model/impl/InstanceModelFieldComplex.java
@@ -89,7 +89,7 @@ public final class InstanceModelFieldComplex
       @NonNull IBoundDefinitionModelAssembly parent) {
     BoundField annotation = ModelUtil.getAnnotation(javaField, BoundField.class);
     if (!annotation.inXmlWrapped()) {
-      if (definition.hasChildren()) { // NOPMD efficiency
+      if (definition.hasChildren()) {
         throw new IllegalStateException(
             String.format("Field '%s' on class '%s' is requested to be unwrapped, but it has flags preventing this.",
                 javaField.getName(),
@@ -113,7 +113,7 @@ public final class InstanceModelFieldComplex
         throw new IllegalStateException(String.format("Field '%s' on class '%s' is missing the '%s' annotation.",
             javaField.getName(),
             javaField.getDeclaringClass().getName(),
-            GroupAs.class.getName())); // NOPMD false positive
+            GroupAs.class.getName()));
       }
     } else if (!IGroupAs.SINGLETON_GROUP_AS.equals(groupAs)) {
       // max is 1 and a groupAs is set
@@ -122,7 +122,7 @@ public final class InstanceModelFieldComplex
               "Field '%s' on class '%s' has the '%s' annotation, but maxOccurs=1. A groupAs must not be specfied.",
               javaField.getName(),
               javaField.getDeclaringClass().getName(),
-              GroupAs.class.getName())); // NOPMD false positive
+              GroupAs.class.getName()));
     }
     return new InstanceModelFieldComplex(javaField, annotation, groupAs, definition, parent);
   }

--- a/databind/src/main/java/dev/metaschema/databind/model/impl/InstanceModelFieldScalar.java
+++ b/databind/src/main/java/dev/metaschema/databind/model/impl/InstanceModelFieldScalar.java
@@ -99,7 +99,7 @@ public final class InstanceModelFieldScalar
         throw new IllegalStateException(String.format("Field '%s' on class '%s' is missing the '%s' annotation.",
             javaField.getName(),
             javaField.getDeclaringClass().getName(),
-            GroupAs.class.getName())); // NOPMD false positive
+            GroupAs.class.getName()));
       }
     } else if (!IGroupAs.SINGLETON_GROUP_AS.equals(groupAs)) {
       // max is 1 and a groupAs is set
@@ -108,7 +108,7 @@ public final class InstanceModelFieldScalar
               "Field '%s' on class '%s' has the '%s' annotation, but maxOccurs=1. A groupAs must not be specfied.",
               javaField.getName(),
               javaField.getDeclaringClass().getName(),
-              GroupAs.class.getName())); // NOPMD false positive
+              GroupAs.class.getName()));
     }
 
     return new InstanceModelFieldScalar(

--- a/databind/src/main/java/dev/metaschema/databind/model/info/IModelInstanceCollectionInfo.java
+++ b/databind/src/main/java/dev/metaschema/databind/model/info/IModelInstanceCollectionInfo.java
@@ -45,7 +45,6 @@ public interface IModelInstanceCollectionInfo<ITEM> {
    *          the model instance to create collection info for
    * @return the new collection info instance
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   @NonNull
   static <T> IModelInstanceCollectionInfo<T> of(
       @NonNull IBoundInstanceModel<T> instance) {

--- a/databind/src/main/java/dev/metaschema/databind/model/metaschema/BindingModuleLoader.java
+++ b/databind/src/main/java/dev/metaschema/databind/model/metaschema/BindingModuleLoader.java
@@ -64,7 +64,7 @@ public class BindingModuleLoader
   public BindingModuleLoader(
       @NonNull IBindingContext bindingContext,
       @NonNull ModuleLoadingPostProcessor postProcessor) {
-    this.loader = Lazy.of(() -> bindingContext.newBoundLoader());
+    this.loader = Lazy.of(bindingContext::newBoundLoader);
     this.postProcessor = postProcessor;
   }
 

--- a/databind/src/main/java/dev/metaschema/databind/model/metaschema/impl/AbstractAbsoluteModelGenerator.java
+++ b/databind/src/main/java/dev/metaschema/databind/model/metaschema/impl/AbstractAbsoluteModelGenerator.java
@@ -38,9 +38,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  *          the Java type of the builder to use to gather the container
  *          instances
  */
-@SuppressWarnings({
-    "PMD.AbstractClassWithoutAbstractMethod",
-    "PMD.UseConcurrentHashMap" })
+@SuppressWarnings("PMD.AbstractClassWithoutAbstractMethod")
 /**
  * Abstract base class for generating absolute model structures from bindings.
  * <p>

--- a/databind/src/main/java/dev/metaschema/databind/model/metaschema/impl/AssemblyModelGenerator.java
+++ b/databind/src/main/java/dev/metaschema/databind/model/metaschema/impl/AssemblyModelGenerator.java
@@ -33,7 +33,6 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * <p>
  * This class is not thread safe.
  */
-@SuppressWarnings("PMD.UseConcurrentHashMap")
 /**
  * Generates assembly model structures from binding data.
  * <p>
@@ -67,7 +66,6 @@ public final class AssemblyModelGenerator
    *          the node item factory used to generate child nodes
    * @return the container
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   public static IContainerModelAssemblySupport<
       IModelInstanceAbsolute,
       INamedModelInstanceAbsolute,

--- a/databind/src/main/java/dev/metaschema/databind/model/metaschema/impl/BindingModule.java
+++ b/databind/src/main/java/dev/metaschema/databind/model/metaschema/impl/BindingModule.java
@@ -79,9 +79,8 @@ public class BindingModule
    * @throws MetaschemaException
    *           if a processing error occurs
    */
-  @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
   @SuppressFBWarnings(value = "CT_CONSTRUCTOR_THROW", justification = "Use of final fields")
-  public BindingModule( // NOPMD - unavoidable
+  public BindingModule(
       @NonNull URI resource,
       @NonNull IBoundDefinitionModelAssembly rootDefinition,
       @NonNull METASCHEMA binding,

--- a/databind/src/main/java/dev/metaschema/databind/model/metaschema/impl/ChoiceGroupModelGenerator.java
+++ b/databind/src/main/java/dev/metaschema/databind/model/metaschema/impl/ChoiceGroupModelGenerator.java
@@ -65,7 +65,6 @@ public final class ChoiceGroupModelGenerator
    *          the node item factory used to generate child nodes
    * @return the container
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   public static IContainerModelSupport<
       INamedModelInstanceGrouped,
       INamedModelInstanceGrouped,

--- a/databind/src/main/java/dev/metaschema/databind/model/metaschema/impl/ChoiceModelGenerator.java
+++ b/databind/src/main/java/dev/metaschema/databind/model/metaschema/impl/ChoiceModelGenerator.java
@@ -59,7 +59,6 @@ public final class ChoiceModelGenerator
    *          the node item factory used to generate child nodes
    * @return the container
    */
-  @SuppressWarnings("PMD.ShortMethodName")
   public static IContainerModelSupport<
       IModelInstanceAbsolute,
       INamedModelInstanceAbsolute,

--- a/databind/src/main/java/dev/metaschema/databind/model/metaschema/impl/FlagContainerSupport.java
+++ b/databind/src/main/java/dev/metaschema/databind/model/metaschema/impl/FlagContainerSupport.java
@@ -26,7 +26,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-@SuppressWarnings("PMD.OnlyOneReturn")
 /**
  * Support class for building flag containers from binding data.
  * <p>

--- a/databind/src/main/java/dev/metaschema/databind/model/metaschema/impl/ModelSupport.java
+++ b/databind/src/main/java/dev/metaschema/databind/model/metaschema/impl/ModelSupport.java
@@ -98,7 +98,6 @@ public final class ModelSupport {
    *          the text scope value
    * @return the enumerated value
    */
-  @SuppressWarnings("PMD.ImplicitSwitchFallThrough")
   @NonNull
   public static IDefinition.ModuleScope moduleScope(@NonNull String value) {
     IDefinition.ModuleScope retval;

--- a/metaschema-cli/src/main/java/dev/metaschema/cli/CLI.java
+++ b/metaschema-cli/src/main/java/dev/metaschema/cli/CLI.java
@@ -28,7 +28,6 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 /**
  * The main entry point for the CLI application.
  */
-@SuppressWarnings("PMD.ShortClassName")
 public final class CLI {
   /**
    * The main command line entry point.

--- a/metaschema-cli/src/main/java/dev/metaschema/cli/commands/AbstractConvertSubcommand.java
+++ b/metaschema-cli/src/main/java/dev/metaschema/cli/commands/AbstractConvertSubcommand.java
@@ -103,10 +103,6 @@ public abstract class AbstractConvertSubcommand
     @NonNull
     protected abstract IBindingContext getBindingContext() throws CommandExecutionException, MetaschemaException;
 
-    @SuppressWarnings({
-        "PMD.OnlyOneReturn", // readability
-        "PMD.CyclomaticComplexity", "PMD.CognitiveComplexity" // reasonable
-    })
     @Override
     public void execute() throws CommandExecutionException {
       CommandLine cmdLine = getCommandLine();

--- a/metaschema-cli/src/main/java/dev/metaschema/cli/commands/AbstractValidateContentCommand.java
+++ b/metaschema-cli/src/main/java/dev/metaschema/cli/commands/AbstractValidateContentCommand.java
@@ -223,7 +223,6 @@ public abstract class AbstractValidateContentCommand
     /**
      * Execute the validation operation.
      */
-    @SuppressWarnings("PMD.OnlyOneReturn") // readability
     @Override
     public void execute() throws CommandExecutionException {
       CommandLine cmdLine = getCommandLine();

--- a/metaschema-cli/src/main/java/dev/metaschema/cli/commands/GenerateDiagramCommand.java
+++ b/metaschema-cli/src/main/java/dev/metaschema/cli/commands/GenerateDiagramCommand.java
@@ -92,10 +92,6 @@ public class GenerateDiagramCommand
    * @throws CommandExecutionException
    *           if an error occurred while executing the command
    */
-  @SuppressWarnings({
-      "PMD.OnlyOneReturn", // readability
-      "PMD.AvoidCatchingGenericException"
-  })
   @SuppressFBWarnings(value = "REC_CATCH_EXCEPTION",
       justification = "Catching generic exception for CLI error handling")
   protected void executeCommand(

--- a/metaschema-cli/src/main/java/dev/metaschema/cli/commands/GenerateSchemaCommand.java
+++ b/metaschema-cli/src/main/java/dev/metaschema/cli/commands/GenerateSchemaCommand.java
@@ -150,7 +150,7 @@ public class GenerateSchemaCommand
         LOGGER.info("Generating {} schema for '{}'.", asFormat.name(), extraArgs.get(0));
       }
       if (destination == null) {
-        @SuppressWarnings({ "resource", "PMD.CloseResource" }) // not owned
+        @SuppressWarnings("resource") // not owned
         OutputStream os = ObjectUtils.notNull(System.out);
 
         try (OutputStream out = AutoCloser.preventClose(os)) {

--- a/metaschema-cli/src/main/java/dev/metaschema/cli/commands/MetaschemaCommands.java
+++ b/metaschema-cli/src/main/java/dev/metaschema/cli/commands/MetaschemaCommands.java
@@ -300,7 +300,6 @@ public final class MetaschemaCommands {
    *           if the format option was not provided or was an invalid choice
    * @since 2.0.0
    */
-  @SuppressWarnings("PMD.PreserveStackTrace")
   @NonNull
   public static SchemaFormat getSchemaFormat(
       @NonNull CommandLine commandLine,
@@ -353,7 +352,6 @@ public final class MetaschemaCommands {
    *           if an error occurred while determining the source format
    * @since 2.0.0
    */
-  @SuppressWarnings({ "PMD.PreserveStackTrace", "PMD.OnlyOneReturn" })
   @NonNull
   public static Format determineSourceFormat(
       @NonNull CommandLine commandLine,

--- a/metaschema-cli/src/main/java/dev/metaschema/cli/commands/metapath/EvaluateMetapathCommand.java
+++ b/metaschema-cli/src/main/java/dev/metaschema/cli/commands/metapath/EvaluateMetapathCommand.java
@@ -111,13 +111,6 @@ class EvaluateMetapathCommand
     return ICommandExecutor.using(callingContext, cmdLine, this::executeCommand);
   }
 
-  @SuppressWarnings({
-      "PMD.OnlyOneReturn", // readability
-      "PMD.AvoidCatchingGenericException",
-      "PMD.NPathComplexity",
-      "PMD.CognitiveComplexity",
-      "PMD.CyclomaticComplexity"
-  })
   @SuppressFBWarnings(value = "REC_CATCH_EXCEPTION",
       justification = "Catching generic exception for CLI error handling")
   private void executeCommand(

--- a/metaschema-cli/src/main/java/dev/metaschema/cli/commands/metapath/ListFunctionsSubcommand.java
+++ b/metaschema-cli/src/main/java/dev/metaschema/cli/commands/metapath/ListFunctionsSubcommand.java
@@ -63,11 +63,6 @@ class ListFunctionsSubcommand
    *          the parsed command line details
    * @return the execution result
    */
-  @SuppressWarnings({
-      "PMD.OnlyOneReturn", // readability
-      "PMD.AvoidInstantiatingObjectsInLoops",
-      "PMD.CognitiveComplexity"
-  })
   protected ExitStatus executeCommand(
       @NonNull CallingContext callingContext,
       @NonNull CommandLine cmdLine) {

--- a/metaschema-maven-plugin/src/main/java/dev/metaschema/maven/plugin/AbstractMetaschemaMojo.java
+++ b/metaschema-maven-plugin/src/main/java/dev/metaschema/maven/plugin/AbstractMetaschemaMojo.java
@@ -541,7 +541,6 @@ public abstract class AbstractMetaschemaMojo
     }
   }
 
-  @SuppressWarnings("PMD.AvoidCatchingGenericException")
   @Override
   public void execute() throws MojoExecutionException {
     File staleFile = getStaleFile();
@@ -594,7 +593,6 @@ public abstract class AbstractMetaschemaMojo
     }
   }
 
-  @SuppressWarnings({ "PMD.AvoidCatchingGenericException", "PMD.ExceptionAsFlowControl" })
   @NonNull
   private List<File> performGeneration(
       @NonNull IModuleLoader.IModulePostProcessor modulePostProcessor) throws MojoExecutionException {

--- a/metaschema-testing/src/main/java/dev/metaschema/model/testing/AbstractTestSuite.java
+++ b/metaschema-testing/src/main/java/dev/metaschema/model/testing/AbstractTestSuite.java
@@ -486,7 +486,7 @@ public abstract class AbstractTestSuite {
             try {
               contentValidator = lazyContentValidator.get();
             } catch (Exception ex) {
-              throw new JUnitException( // NOPMD - cause is relevant, exception is not
+              throw new JUnitException(
                   "failed to produce the content validator", ex);
             }
 
@@ -508,7 +508,7 @@ public abstract class AbstractTestSuite {
                   contentUri,
                   ObjectUtils.notNull(resourceGenerationPath.get()),
                   bindingContext);
-            } catch (Exception ex) { // NOPMD - intentional
+            } catch (Exception ex) {
               throw new JUnitException("failed to convert content: " + contentUri, ex);
             }
 

--- a/schemagen/src/main/java/dev/metaschema/schemagen/AbstractSchemaGenerator.java
+++ b/schemagen/src/main/java/dev/metaschema/schemagen/AbstractSchemaGenerator.java
@@ -89,12 +89,12 @@ public abstract class AbstractSchemaGenerator<
       IConfiguration<SchemaGenerationFeature<?>> configuration) {
     try {
       // avoid automatically closing streams not owned by the generator
-      @SuppressWarnings({ "PMD.CloseResource", "resource" })
+      @SuppressWarnings("resource")
       T schemaWriter = newWriter(out);
       S generationState = newGenerationState(metaschema, schemaWriter, configuration);
       generateSchema(generationState);
       generationState.flushWriter();
-    } catch (SchemaGenerationException ex) { // NOPMD avoid nesting same exception
+    } catch (SchemaGenerationException ex) {
       throw ex;
     } catch (Exception ex) { // NOPMD need to catch close exception
       throw new SchemaGenerationException(ex);

--- a/schemagen/src/main/java/dev/metaschema/schemagen/datatype/AbstractDatatypeManager.java
+++ b/schemagen/src/main/java/dev/metaschema/schemagen/datatype/AbstractDatatypeManager.java
@@ -56,7 +56,7 @@ public abstract class AbstractDatatypeManager implements IDatatypeManager {
   }
 
   @NonNull
-  private final Map<IDataTypeAdapter<?>, String> datatypeToTypeMap = new ConcurrentHashMap<>(); // NOPMD - intentional
+  private final Map<IDataTypeAdapter<?>, String> datatypeToTypeMap = new ConcurrentHashMap<>();
 
   /**
    * Get the mapping of Metaschema datatype names to schema type names.

--- a/schemagen/src/main/java/dev/metaschema/schemagen/datatype/AbstractDatatypeManager.java
+++ b/schemagen/src/main/java/dev/metaschema/schemagen/datatype/AbstractDatatypeManager.java
@@ -26,8 +26,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  */
 public abstract class AbstractDatatypeManager implements IDatatypeManager {
   @NonNull
-  private static final Map<String, String> DATATYPE_TRANSLATION_MAP // NOPMD - intentional
-      = new LinkedHashMap<>();
+  private static final Map<String, String> DATATYPE_TRANSLATION_MAP = new LinkedHashMap<>();
 
   static {
     DATATYPE_TRANSLATION_MAP.put("base64", "Base64Datatype");

--- a/schemagen/src/main/java/dev/metaschema/schemagen/json/impl/JsonGenerationState.java
+++ b/schemagen/src/main/java/dev/metaschema/schemagen/json/impl/JsonGenerationState.java
@@ -160,7 +160,6 @@ public class JsonGenerationState
       return Objects.hash(definition, disciminatorProperty, disciminatorValue);
     }
 
-    @SuppressWarnings("PMD.OnlyOneReturn")
     @Override
     public boolean equals(Object obj) {
       if (this == obj) {

--- a/schemagen/src/main/java/dev/metaschema/schemagen/xml/XmlSchemaGenerator.java
+++ b/schemagen/src/main/java/dev/metaschema/schemagen/xml/XmlSchemaGenerator.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-package dev.metaschema.schemagen.xml; // NOPMD
+package dev.metaschema.schemagen.xml;
 
 import com.ctc.wstx.stax.WstxOutputFactory;
 

--- a/schemagen/src/main/java/dev/metaschema/schemagen/xml/impl/IndentingXMLStreamWriter.java
+++ b/schemagen/src/main/java/dev/metaschema/schemagen/xml/impl/IndentingXMLStreamWriter.java
@@ -137,7 +137,7 @@ public class IndentingXMLStreamWriter implements XMLStreamWriter, AutoCloseable 
   @Override
   public void writeEndElement() throws XMLStreamException {
     depth--;
-    boolean parentHasText = hasTextStack.isEmpty() ? false : hasTextStack.pop();
+    boolean parentHasText = !hasTextStack.isEmpty() && hasTextStack.pop();
 
     if (!hasText && !lastWasStart) {
       writeIndent();

--- a/schemagen/src/main/java/dev/metaschema/schemagen/xml/impl/XmlCoreDatatypeProvider.java
+++ b/schemagen/src/main/java/dev/metaschema/schemagen/xml/impl/XmlCoreDatatypeProvider.java
@@ -15,9 +15,11 @@ import org.w3c.dom.NodeList;
 
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -55,10 +57,11 @@ public class XmlCoreDatatypeProvider
       XPath xpath = XPathFactory.newInstance().newXPath();
       NodeList nodes = (NodeList) xpath.evaluate(".//@base", element, XPathConstants.NODESET);
 
+      Set<String> seen = new HashSet<>();
       List<String> dependencies = new ArrayList<>();
       for (int i = 0; i < nodes.getLength(); i++) {
         String value = nodes.item(i).getNodeValue();
-        if (value != null && !value.startsWith("xs:") && !dependencies.contains(value)) {
+        if (value != null && !value.startsWith("xs:") && seen.add(value)) {
           dependencies.add(value);
         }
       }

--- a/schemagen/src/main/java/dev/metaschema/schemagen/xml/impl/XmlCoreDatatypeProvider.java
+++ b/schemagen/src/main/java/dev/metaschema/schemagen/xml/impl/XmlCoreDatatypeProvider.java
@@ -58,10 +58,8 @@ public class XmlCoreDatatypeProvider
       List<String> dependencies = new ArrayList<>();
       for (int i = 0; i < nodes.getLength(); i++) {
         String value = nodes.item(i).getNodeValue();
-        if (value != null && !value.startsWith("xs:")) {
-          if (!dependencies.contains(value)) {
-            dependencies.add(value);
-          }
+        if (value != null && !value.startsWith("xs:") && !dependencies.contains(value)) {
+          dependencies.add(value);
         }
       }
       return dependencies;


### PR DESCRIPTION
## Summary

- Remove 142 PMD warnings across all modules by cleaning up obsolete warning suppressions
- Eliminates all `UnnecessaryWarningSuppression` warnings (138 total)
- Fixes additional code style issues: `SimplifiedTernary` (1), `CollapsibleIfStatements` (2), `LambdaCanBeMethodReference` (1)

These suppressions (`// NOPMD` comments and `@SuppressWarnings` annotations) were originally added for PMD rules that have since been removed, renamed, or no longer trigger on the suppressed code.

## Changes by Module

| Module | Files Changed |
|--------|---------------|
| core | 34 |
| databind | 41 |
| schemagen | 6 |
| cli-processor | 3 |
| metaschema-cli | 9 |
| metaschema-maven-plugin | 1 |
| metaschema-testing | 1 |

## Test plan

- [x] All unit tests pass (4,783 tests)
- [x] CI build passes with `-PCI -Prelease`
- [x] PMD reports 0 `UnnecessaryWarningSuppression` warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed numerous static-analysis suppression directives across the codebase and aligned exception/flow declarations for consistency.
  * Replaced a few lambdas with method references and simplified minor internal expressions.

* **Style**
  * Cleaned up inline comments and formatting for clearer, more maintainable code.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->