### PR TITLE
build: remove unused xmlcalabash dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,6 @@
 		<dependency.stax2-api.version>4.2.2</dependency.stax2-api.version>
 		<dependency.thymeleaf.version>3.1.3.RELEASE</dependency.thymeleaf.version>
 		<dependency.woodstox.version>7.1.1</dependency.woodstox.version>
-		<dependency.xmlcalabash.version>3.0.35</dependency.xmlcalabash.version>
-
 		<dependency.xml-apis.version>2.0.2</dependency.xml-apis.version>
 
 		<plugin.antlr4test.version>1.22</plugin.antlr4test.version>
@@ -231,11 +229,6 @@
 				<groupId>xml-apis</groupId>
 				<artifactId>xml-apis</artifactId>
 				<version>${dependency.xml-apis.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.xmlcalabash</groupId>
-				<artifactId>xmlcalabash</artifactId>
-				<version>${dependency.xmlcalabash.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.vladsch.flexmark</groupId>


### PR DESCRIPTION
## Summary

- Remove `com.xmlcalabash:xmlcalabash` from `<dependencyManagement>` and its version property

The dependency was declared in the parent POM's dependency management but never used as an actual dependency by any module. No Java code imports from it and no XProc pipelines exist in the project. Removing it eliminates unnecessary Dependabot update noise.

## Test plan

- [ ] CI passes (POM-only change, no code affected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused transitive dependency from the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->