### PR TITLE
test: fix FnDocumentAvailableTest URL returning 404

### DIFF
--- a/core/src/test/java/dev/metaschema/core/metapath/function/library/FnDocumentAvailableTest.java
+++ b/core/src/test/java/dev/metaschema/core/metapath/function/library/FnDocumentAvailableTest.java
@@ -19,8 +19,11 @@ class FnDocumentAvailableTest {
    */
   @Test
   void issue208Test() {
+    // URL pinned to a release tag of this project so the resource remains
+    // available long-term. The previously-referenced fedramp-automation
+    // content was removed upstream, causing this test to fail with HTTP 404.
     IAnyUriItem uri = IAnyUriItem.valueOf(
-        "https://raw.githubusercontent.com/GSA/fedramp-automation/8301e380c88532ebbb22aca55521701750eb0b83/src/content/awesome-cloud/xml/AwesomeCloudSSP1.xml");
+        "https://raw.githubusercontent.com/metaschema-framework/metaschema-java/v3.0.0.M3/README.md");
 
     assertTrue(FnDocumentAvailable.fnDocAvailable(uri, new DynamicContext()).toBoolean());
   }


### PR DESCRIPTION
## Summary

- `FnDocumentAvailableTest.issue208Test` has been failing on all PR CI runs because the referenced fedramp-automation URL returns HTTP 404 — the upstream content was removed.
- Replace with a URL pinned to this project's own \`v3.0.0.M3\` release tag (\`README.md\`), which is stable and under project control.

## Test Plan

- [x] \`mvn -pl core test -Dtest=FnDocumentAvailableTest\` — passes locally
- [ ] CI passes on PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test input resources and external references used for document availability validation tests, improving accuracy and consistency with current project dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->