### PR TITLE
build(deps): bump dev.harrel:json-schema to 1.9.1

### DIFF
--- a/databind-modules/pom.xml
+++ b/databind-modules/pom.xml
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>dev.harrel</groupId>
 			<artifactId>json-schema</artifactId>
-			<version>1.9.0</version>
+			<version>1.9.1</version>
 		</dependency>
 	</dependencies>
 

--- a/databind-modules/src/main/java/module-info.java
+++ b/databind-modules/src/main/java/module-info.java
@@ -18,7 +18,7 @@ module dev.metaschema.databind.modules {
   requires static org.eclipse.jdt.annotation;
   requires static com.github.spotbugs.annotations;
 
-  requires json.schema;
+  requires dev.harrel.jsonschema;
 
   exports dev.metaschema.modules.sarif;
 


### PR DESCRIPTION
## Summary

- Bump \`dev.harrel:json-schema\` from 1.9.0 to 1.9.1.
- Update \`databind-modules/module-info.java\` to use the new module name \`dev.harrel.jsonschema\`.

Version 1.9.1 added an \`Automatic-Module-Name\` of \`dev.harrel.jsonschema\` to the JAR manifest. Previously there was no module-info entry, so Java auto-derived the name \`json.schema\` from the JAR filename. The \`requires\` clause must be updated to match the new, explicit module name.

Supersedes #675 (dependabot's original bump, which did not include the \`module-info.java\` update required for compilation under JPMS).

## Test Plan

- [x] \`mvn -pl databind-modules -am install -DskipTests\` — builds clean
- [x] \`mvn -pl databind-modules test\` — 2 tests pass
- [ ] Full CI build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the JSON Schema dependency to a newer patch release to improve stability and compatibility.
  * No user-facing API or behavior changes; existing integrations should continue to work as before.
  * Internal module metadata updated to align with the dependency change; no impact on public functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->