### PR TITLE
ci: pin Trivy binary version to v0.70.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,6 +213,10 @@ jobs:
         severity: 'CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN'
         # Exclude submodules (have their own security scanning) and Maven plugin IT target dirs
         skip-dirs: 'core/metaschema,databind-modules/modules,metaschema-maven-plugin/target'
+        # Pin Trivy binary version. The default (auto-detected latest) currently
+        # resolves to v0.69.1, which has no published Linux-64bit binary, causing
+        # the install to fail silently with exit code 1.
+        version: 'v0.70.0'
     - name: Trivy Summary
       if: ${{ !inputs.skip_code_scans }}
       run: |


### PR DESCRIPTION
## Summary

Pin the Trivy binary version to \`v0.70.0\` to fix flaky CI failures on the \"Run Trivy security scanner\" step.

### Root cause

\`aquasecurity/trivy-action\` delegates binary installation to \`aquasecurity/setup-trivy\`. When no \`version\` input is provided, setup-trivy auto-detects the latest Trivy tag. It currently resolves \`v0.69.1\`, but **no \`trivy_0.69.1_Linux-64bit.tar.gz\` was ever published** — the download URL returns HTTP 404. The installer fails silently with exit code 1, blocking CI on most PRs (e.g. #672, #679).

### Fix

Explicitly set \`version: v0.70.0\`, which has published binaries. Dependabot will continue to surface action updates and can bump this pin in lockstep when appropriate.

## Test Plan

- [ ] CI's Trivy step installs successfully and produces \`trivy-results.sarif\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow configuration to specify a fixed version for security scanning, ensuring consistent and reproducible builds across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->