### PR TITLE
build(deps): bump plexus-utils to 4.0.3 (CVE-2025-67030)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 		<dependency.mokito.version>5.22.0</dependency.mokito.version>
 		<dependency.moxy.version>4.0.9</dependency.moxy.version>
 		<dependency.oss-maven.version>${project.parent.version}</dependency.oss-maven.version>
-		<dependency.plexus-utils.version>4.0.2</dependency.plexus-utils.version>
+		<dependency.plexus-utils.version>4.0.3</dependency.plexus-utils.version>
 		<dependency.plexus-build-api.version>1.2.0</dependency.plexus-build-api.version>
 		<dependency.stax2-api.version>4.2.2</dependency.stax2-api.version>
 		<dependency.thymeleaf.version>3.1.3.RELEASE</dependency.thymeleaf.version>


### PR DESCRIPTION
## Summary

Bumps \`org.codehaus.plexus:plexus-utils\` from 4.0.2 to 4.0.3 in the parent POM's \`dependencyManagement\`. This is consumed by metaschema-maven-plugin.

Resolves **CVE-2025-67030 (HIGH)** — directory-traversal vulnerability in the \`extractFile\` method of plexus-utils. Upstream-fixed in 4.0.3 (and 3.6.1 on the 3.x line).

Trivy v0.70.0 currently reports 2 HIGH findings for this CVE on develop (parent \`pom.xml\` + \`metaschema-maven-plugin/pom.xml\` inherits the same version). Both are resolved by this bump.

## Test Plan

- [x] \`mvn -pl metaschema-maven-plugin -am install -DskipTests\` — builds clean
- [ ] Full CI build
- [ ] Trivy scan no longer flags CVE-2025-67030

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to improve stability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->