### PR TITLE
test: expand coverage for AllowedValueCollectingNodeItemVisitor

### DIFF
--- a/core/src/test/java/dev/metaschema/core/metapath/item/node/AllowedValueCollectingNodeItemVisitorTest.java
+++ b/core/src/test/java/dev/metaschema/core/metapath/item/node/AllowedValueCollectingNodeItemVisitorTest.java
@@ -8,6 +8,7 @@ package dev.metaschema.core.metapath.item.node;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -21,6 +22,7 @@ import dev.metaschema.core.metapath.IMetapathExpression;
 import dev.metaschema.core.metapath.item.node.AllowedValueCollectingNodeItemVisitor.AllowedValuesRecord;
 import dev.metaschema.core.metapath.item.node.AllowedValueCollectingNodeItemVisitor.NodeItemRecord;
 import dev.metaschema.core.model.IAssemblyDefinition;
+import dev.metaschema.core.model.IFieldDefinition;
 import dev.metaschema.core.model.IModule;
 import dev.metaschema.core.model.ISource;
 import dev.metaschema.core.model.constraint.IAllowedValue;
@@ -143,5 +145,192 @@ class AllowedValueCollectingNodeItemVisitorTest {
         .mapToInt(loc -> loc.getAllowedValues().size())
         .sum();
     assertEquals(2, totalConstraints, "Should find exactly two allowed-values constraints");
+  }
+
+  @Test
+  void testVisitorFindsConstraintOnFieldDefinition() {
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create(TEST_NAMESPACE));
+
+    IModule module = IModuleBuilder.builder()
+        .namespace(TEST_NAMESPACE)
+        .shortName("field-av-test")
+        .version("1.0.0")
+        .source(source)
+        .assembly(mocking.assembly()
+            .name("root")
+            .rootName("root")
+            .modelInstances(List.of(
+                mocking.field().namespace(TEST_NAMESPACE).name("category"))))
+        .toModule();
+
+    // Add a constraint directly to the field definition (exercises visitField)
+    IAssemblyDefinition rootDef = module.getAssemblyDefinitions().iterator().next();
+    IFieldDefinition fieldDef = rootDef.getFieldInstances().iterator().next().getDefinition();
+    IValueConstrained constraintSupport = fieldDef.getConstraintSupport();
+    constraintSupport.addConstraint(
+        IAllowedValuesConstraint.builder()
+            .source(source)
+            .target(IMetapathExpression.compile("."))
+            .allowedValue(IAllowedValue.of("alpha", MarkupLine.fromMarkdown("Alpha"), null))
+            .allowedValue(IAllowedValue.of("beta", MarkupLine.fromMarkdown("Beta"), null))
+            .build());
+
+    AllowedValueCollectingNodeItemVisitor visitor = new AllowedValueCollectingNodeItemVisitor();
+    visitor.visit(module);
+
+    Collection<NodeItemRecord> locations = visitor.getAllowedValueLocations();
+    assertFalse(locations.isEmpty(), "Visitor should find constraints declared on a field definition");
+
+    NodeItemRecord record = locations.iterator().next();
+    AllowedValuesRecord avRecord = record.getAllowedValues().get(0);
+    assertEquals(2, avRecord.getAllowedValues().getAllowedValues().size(),
+        "Both allowed values should be present on the field-level constraint");
+    // The target should be the field itself (self reference)
+    assertEquals("category", avRecord.getTarget().getDefinition().getName(),
+        "Target should be the field node item");
+  }
+
+  @Test
+  void testAllowOtherFlagPreserved() {
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create(TEST_NAMESPACE));
+
+    IModule module = IModuleBuilder.builder()
+        .namespace(TEST_NAMESPACE)
+        .shortName("allow-other-test")
+        .version("1.0.0")
+        .source(source)
+        .assembly(mocking.assembly()
+            .name("root")
+            .rootName("root")
+            .flags(List.of(
+                mocking.flag().name("strict"),
+                mocking.flag().name("lax"))))
+        .toModule();
+
+    IAssemblyDefinition rootDef = module.getAssemblyDefinitions().iterator().next();
+    IValueConstrained constraintSupport = rootDef.getConstraintSupport();
+    // Explicit allow-other=false (strict)
+    constraintSupport.addConstraint(
+        IAllowedValuesConstraint.builder()
+            .source(source)
+            .target(IMetapathExpression.compile("@strict"))
+            .allowedValue(IAllowedValue.of("x", MarkupLine.fromMarkdown("X"), null))
+            .allowsOther(false)
+            .build());
+    // Explicit allow-other=true (lax)
+    constraintSupport.addConstraint(
+        IAllowedValuesConstraint.builder()
+            .source(source)
+            .target(IMetapathExpression.compile("@lax"))
+            .allowedValue(IAllowedValue.of("y", MarkupLine.fromMarkdown("Y"), null))
+            .allowsOther(true)
+            .build());
+
+    AllowedValueCollectingNodeItemVisitor visitor = new AllowedValueCollectingNodeItemVisitor();
+    visitor.visit(module);
+
+    List<AllowedValuesRecord> allRecords = visitor.getAllowedValueLocations().stream()
+        .flatMap(loc -> loc.getAllowedValues().stream())
+        .collect(java.util.stream.Collectors.toList());
+    assertEquals(2, allRecords.size(), "Both constraints should be captured");
+
+    boolean foundStrict = false;
+    boolean foundLax = false;
+    for (AllowedValuesRecord record : allRecords) {
+      String targetName = record.getTarget().getDefinition().getName();
+      if ("strict".equals(targetName)) {
+        foundStrict = true;
+        assertFalse(record.getAllowedValues().isAllowedOther(),
+            "allow-other=false should be preserved on the strict constraint");
+      } else if ("lax".equals(targetName)) {
+        foundLax = true;
+        assertTrue(record.getAllowedValues().isAllowedOther(),
+            "allow-other=true should be preserved on the lax constraint");
+      }
+    }
+    assertTrue(foundStrict, "Expected a record for the 'strict' flag");
+    assertTrue(foundLax, "Expected a record for the 'lax' flag");
+  }
+
+  @Test
+  void testNodeItemRecordAllowedValuesIsUnmodifiable() {
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create(TEST_NAMESPACE));
+
+    IModule module = IModuleBuilder.builder()
+        .namespace(TEST_NAMESPACE)
+        .shortName("unmodifiable-test")
+        .version("1.0.0")
+        .source(source)
+        .assembly(mocking.assembly()
+            .name("root")
+            .rootName("root")
+            .flags(List.of(mocking.flag().name("flag"))))
+        .toModule();
+
+    IAssemblyDefinition rootDef = module.getAssemblyDefinitions().iterator().next();
+    rootDef.getConstraintSupport().addConstraint(
+        IAllowedValuesConstraint.builder()
+            .source(source)
+            .target(IMetapathExpression.compile("@flag"))
+            .allowedValue(IAllowedValue.of("v", MarkupLine.fromMarkdown("V"), null))
+            .build());
+
+    AllowedValueCollectingNodeItemVisitor visitor = new AllowedValueCollectingNodeItemVisitor();
+    visitor.visit(module);
+
+    NodeItemRecord record = visitor.getAllowedValueLocations().iterator().next();
+    List<AllowedValuesRecord> view = record.getAllowedValues();
+    // Callers must not be able to mutate the list returned by the getter
+    assertThrows(UnsupportedOperationException.class, () -> view.clear(),
+        "NodeItemRecord.getAllowedValues() must return an unmodifiable view");
+  }
+
+  @Test
+  void testAllowedValuesRecordCarriesConstraintIdentity() {
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create(TEST_NAMESPACE));
+
+    IModule module = IModuleBuilder.builder()
+        .namespace(TEST_NAMESPACE)
+        .shortName("identity-test")
+        .version("1.0.0")
+        .source(source)
+        .assembly(mocking.assembly()
+            .name("root")
+            .rootName("root")
+            .flags(List.of(mocking.flag().name("phase"))))
+        .toModule();
+
+    IAssemblyDefinition rootDef = module.getAssemblyDefinitions().iterator().next();
+    IAllowedValuesConstraint constraint = IAllowedValuesConstraint.builder()
+        .identifier("phase-values")
+        .source(source)
+        .target(IMetapathExpression.compile("@phase"))
+        .allowedValue(IAllowedValue.of("init", MarkupLine.fromMarkdown("Initialize"), null))
+        .allowedValue(IAllowedValue.of("done", MarkupLine.fromMarkdown("Complete"), null))
+        .build();
+    rootDef.getConstraintSupport().addConstraint(constraint);
+
+    AllowedValueCollectingNodeItemVisitor visitor = new AllowedValueCollectingNodeItemVisitor();
+    visitor.visit(module);
+
+    AllowedValuesRecord record = visitor.getAllowedValueLocations().iterator().next()
+        .getAllowedValues().get(0);
+
+    // The visitor must surface the exact constraint instance, its id, and the
+    // declaration location
+    assertEquals(constraint, record.getAllowedValues(),
+        "Record should reference the same constraint instance that was added");
+    assertEquals("phase-values", record.getAllowedValues().getId(),
+        "Constraint identifier should be preserved");
+    assertEquals("root", record.getLocation().getDefinition().getName(),
+        "Location should be the assembly where the constraint is declared");
+    assertTrue(record.getAllowedValues().getAllowedValues().containsKey("init"),
+        "Allowed value keys should be preserved");
+    assertTrue(record.getAllowedValues().getAllowedValues().containsKey("done"),
+        "Allowed value keys should be preserved");
   }
 }


### PR DESCRIPTION
## Summary

Expands \`AllowedValueCollectingNodeItemVisitorTest\` from 3 happy-path tests to 7 by adding coverage for behaviors that were shipped in #666 but not exercised by a test.

### New tests

| Test | Covers |
|------|--------|
| \`testVisitorFindsConstraintOnFieldDefinition\` | The \`visitField\` path (previously only \`visitAssembly\` + flag targets ran). Attaches a constraint directly to a field definition and verifies the visitor surfaces it. |
| \`testAllowOtherFlagPreserved\` | \`IAllowedValuesConstraint.isAllowedOther()\` flows through the collected \`AllowedValuesRecord\` for both \`allowsOther(true)\` and \`allowsOther(false)\`. |
| \`testNodeItemRecordAllowedValuesIsUnmodifiable\` | The defensive unmodifiable-list contract added during #666's review — previously relied on by convention but not verified by any test. |
| \`testAllowedValuesRecordCarriesConstraintIdentity\` | The record surfaces the exact constraint instance, its identifier, its declaration location (the assembly where it was declared), and its allowed-value keys. |

### Intentional scope

Scope is limited to visitor-level behavior. The command-level output-shape verification for \`ListAllowedValuesCommand\` (YAML structure, file output via \`-o\`, \`-c\` constraints option, \`--overwrite\`, error paths) is larger and deserves its own PR — the existing \`CLITest\` entries only assert exit code.

## Test Plan

- [x] \`mvn -pl core test -Dtest=AllowedValueCollectingNodeItemVisitorTest\` — 7/7 pass
- [x] \`mvn -pl core test\` — 4665 tests pass, 0 failures
- [x] \`mvn -pl core pmd:check\` — 0 blocking (priority 1/2) violations introduced
- [ ] Full CI build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for constraint handling and validation across field and assembly levels.
  * Added tests verifying immutability of constraint value collections and preservation of constraint metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->