### PR TITLE
test: expand CLITest coverage for list-allowed-values command

### DIFF
--- a/metaschema-cli/src/test/java/dev/metaschema/cli/CLITest.java
+++ b/metaschema-cli/src/test/java/dev/metaschema/cli/CLITest.java
@@ -166,6 +166,11 @@ public class CLITest {
                 "src/test/resources/content/schema-validation-module.xml"
             },
             ExitCode.OK, NO_EXCEPTION_CLASS));
+        // list-allowed-values with no module argument should fail fast with
+        // INVALID_ARGUMENTS (missing required positional arg)
+        add(Arguments.of(
+            new String[] { "list-allowed-values" },
+            ExitCode.INVALID_ARGUMENTS, NO_EXCEPTION_CLASS));
         add(Arguments.of(
             new String[] { "validate",
                 "../databind/src/test/resources/metaschema/fields_with_flags/metaschema.xml"
@@ -367,6 +372,113 @@ public class CLITest {
         .contains("target: optional")
         .contains("yes")
         .contains("allow-other: false");
+  }
+
+  @Test
+  void testListAllowedValuesIncludesIdentifierWhenPresent() throws Exception {
+    Path outputFile = Paths.get("target/test-list-allowed-values-identifier.yaml");
+    Files.deleteIfExists(outputFile);
+    String[] cliArgs = { "list-allowed-values",
+        "src/test/resources/content/list-allowed-values-module.xml",
+        outputFile.toString(),
+        "--show-stack-trace"
+    };
+    evaluateResult(CLI.runCli(NULL_STREAM, cliArgs), ExitCode.OK, cliArgs);
+
+    String content = Files.readString(outputFile);
+    // Field-level allowed-values constraint (with id) on 'color'
+    assertThat(content)
+        .as("Field-level constraint with identifier should be emitted")
+        .contains("/root/color:")
+        .contains("identifier: color-values")
+        .contains("red")
+        .contains("green")
+        .contains("blue");
+    // Flag-level constraint carries its identifier, allow-other preserved from XML
+    assertThat(content)
+        .as("Flag-targeted constraint identifier and allow-other should be preserved")
+        .contains("identifier: status-phase")
+        .contains("allow-other: true");
+  }
+
+  @Test
+  void testListAllowedValuesGroupsMultipleConstraintsUnderSameTarget() throws Exception {
+    Path outputFile = Paths.get("target/test-list-allowed-values-grouping.yaml");
+    Files.deleteIfExists(outputFile);
+    String[] cliArgs = { "list-allowed-values",
+        "src/test/resources/content/list-allowed-values-module.xml",
+        outputFile.toString(),
+        "--show-stack-trace"
+    };
+    evaluateResult(CLI.runCli(NULL_STREAM, cliArgs), ExitCode.OK, cliArgs);
+
+    String content = Files.readString(outputFile);
+    // Two allowed-values constraints target @status; both should appear under the
+    // same
+    // location key rather than producing two separate /root/@status entries.
+    long statusKeyCount = content.lines()
+        .filter(line -> line.trim().equals("/root/@status:"))
+        .count();
+    assertEquals(1, statusKeyCount,
+        "Constraints sharing a target must group under a single location key");
+    // Values from both constraints ('init', 'run' from first; 'done' from second)
+    // should
+    // all surface in the combined output for that target.
+    assertThat(content)
+        .contains("init")
+        .contains("run")
+        .contains("done");
+  }
+
+  @Test
+  void testListAllowedValuesOverwriteRequiredForExistingFile() throws Exception {
+    Path outputFile = Paths.get("target/test-list-allowed-values-overwrite.yaml");
+    // Pre-create the destination so the first run lands on an existing file
+    Files.writeString(outputFile, "pre-existing content\n");
+
+    String[] argsWithoutOverwrite = { "list-allowed-values",
+        "src/test/resources/content/schema-validation-module.xml",
+        outputFile.toString(),
+        "--show-stack-trace"
+    };
+    ExitStatus withoutOverwrite = CLI.runCli(NULL_STREAM, argsWithoutOverwrite);
+    assertEquals(ExitCode.INVALID_ARGUMENTS, withoutOverwrite.getExitCode(),
+        "Writing to an existing file without --overwrite must fail with INVALID_ARGUMENTS");
+    // Pre-existing content must not have been mutated by the failed run
+    assertEquals("pre-existing content\n", Files.readString(outputFile),
+        "Failed run must not have modified the destination file");
+
+    String[] argsWithOverwrite = { "list-allowed-values",
+        "src/test/resources/content/schema-validation-module.xml",
+        outputFile.toString(),
+        "--overwrite",
+        "--show-stack-trace"
+    };
+    evaluateResult(CLI.runCli(NULL_STREAM, argsWithOverwrite), ExitCode.OK, argsWithOverwrite);
+    // With --overwrite the file should now contain YAML rather than the
+    // pre-existing text
+    assertThat(Files.readString(outputFile))
+        .doesNotContain("pre-existing content")
+        .contains("locations:");
+  }
+
+  @Test
+  void testListAllowedValuesConsoleOutputYaml() {
+    try (LogCaptor captor = LogCaptor.forClass(
+        dev.metaschema.cli.commands.ListAllowedValuesCommand.class)) {
+      String[] cliArgs = { "list-allowed-values",
+          "src/test/resources/content/schema-validation-module.xml",
+          "--show-stack-trace"
+      };
+      evaluateResult(CLI.runCli(NULL_STREAM, cliArgs), ExitCode.OK, cliArgs);
+
+      // When no destination file is given, YAML output goes to the logger at INFO
+      // level
+      assertThat(captor.getInfoLogs().toString())
+          .contains("locations:")
+          .contains("/root/optional:")
+          .contains("type: allowed-values");
+    }
   }
 
   @Test

--- a/metaschema-cli/src/test/resources/content/list-allowed-values-module.xml
+++ b/metaschema-cli/src/test/resources/content/list-allowed-values-module.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../../../core/metaschema/schema/xml/metaschema.xsd" type="application/xml" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<METASCHEMA xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0">
+    <schema-name>List-allowed-values test module</schema-name>
+    <schema-version>0</schema-version>
+    <short-name>list-av-test</short-name>
+    <namespace>http://metaschema.dev/ns/metaschema/test/list-allowed-values</namespace>
+    <json-base-uri>http://metaschema.dev/ns/metaschema/test/list-allowed-values</json-base-uri>
+    <define-assembly name="root">
+        <formal-name>Root Assembly</formal-name>
+        <description>Root assembly that exercises identifier, grouping, and field-level constraint paths in list-allowed-values output.</description>
+        <root-name>root</root-name>
+        <define-flag name="status" as-type="string"/>
+        <model>
+            <define-field name="color" min-occurs="1" max-occurs="1">
+                <constraint>
+                    <allowed-values id="color-values" target=".">
+                        <enum value="red">Red</enum>
+                        <enum value="green">Green</enum>
+                        <enum value="blue">Blue</enum>
+                    </allowed-values>
+                </constraint>
+            </define-field>
+        </model>
+        <constraint>
+            <!-- Two allowed-values constraints on the same target (the status flag)
+                 exercises the grouping path that collapses them under one key. -->
+            <allowed-values id="status-phase" target="@status" allow-other="yes">
+                <enum value="init">Initialization phase</enum>
+                <enum value="run">Run phase</enum>
+            </allowed-values>
+            <allowed-values target="@status">
+                <enum value="done">Done phase</enum>
+            </allowed-values>
+        </constraint>
+    </define-assembly>
+</METASCHEMA>


### PR DESCRIPTION
## Summary

Follow-up to #684. #684 covered the \`AllowedValueCollectingNodeItemVisitor\`. This PR does the same for the \`ListAllowedValuesCommand\` wrapper, which was previously only covered by exit-code checks plus one output-shape assertion on \`schema-validation-module.xml\` (a fixture with a single anonymous flag-level constraint).

### New tests in \`CLITest\`

| Test | Covers |
|------|--------|
| \`testListAllowedValuesIncludesIdentifierWhenPresent\` | Constraint \`id\` is emitted for both field-level and flag-level constraints, and \`allow-other=\"yes\"\` flows through to YAML \`allow-other: true\`. |
| \`testListAllowedValuesGroupsMultipleConstraintsUnderSameTarget\` | Two constraints sharing the same target (\`@status\`) collapse under one location key — exercises the \`Collectors.groupingBy\` path in \`generateAllowedValuesList\`. |
| \`testListAllowedValuesOverwriteRequiredForExistingFile\` | Writing to an existing destination without \`--overwrite\` returns \`INVALID_ARGUMENTS\` and leaves the pre-existing content intact; \`--overwrite\` replaces it with YAML. |
| \`testListAllowedValuesConsoleOutputYaml\` | When no destination file is given, YAML is routed through \`LOGGER.info\` (exercises the \`StringWriter\` branch in \`executeCommand\`). |

Plus one parameterized entry: \`list-allowed-values\` with no module argument → \`INVALID_ARGUMENTS\` (regression guard on required-arg enforcement).

### New fixture

\`metaschema-cli/src/test/resources/content/list-allowed-values-module.xml\` contains:
- A field-level \`<allowed-values>\` with an \`id\` on \`color\`, values red/green/blue.
- Two flag-level \`<allowed-values>\` on \`@status\` (one with \`id=\"status-phase\"\` and \`allow-other=\"yes\"\`, one anonymous) to exercise identifier, grouping, and \`allow-other\` paths in a single fixture.

### Intentional scope

The \`-c\` (external constraints) option is not exercised — adding that would require either a non-trivial external-constraints fixture (none of the existing ones are allowed-values) or a new plumbing test, which is better off in its own PR.

## Test Plan

- [x] \`mvn -pl metaschema-cli test -Dtest=CLITest\` — 40/40 pass
- [x] \`mvn -pl metaschema-cli pmd:check\` — 0 blocking (priority 1/2) violations introduced
- [ ] Full CI build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test coverage for the `list-allowed-values` command, including validation of argument handling, YAML output formatting with identifiers, constraint grouping behavior, file overwrite semantics, and console output.

*Note: This release contains no user-facing feature changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->