### PR TITLE
fix: skip unevaluable let and target expressions in allowed-values visitor

### DIFF
--- a/core/src/main/java/dev/metaschema/core/metapath/item/node/AllowedValueCollectingNodeItemVisitor.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/item/node/AllowedValueCollectingNodeItemVisitor.java
@@ -5,6 +5,9 @@
 
 package dev.metaschema.core.metapath.item.node;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -13,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 
 import dev.metaschema.core.metapath.DynamicContext;
+import dev.metaschema.core.metapath.MetapathException;
 import dev.metaschema.core.metapath.StaticContext;
 import dev.metaschema.core.metapath.item.ISequence;
 import dev.metaschema.core.model.IModule;
@@ -38,6 +42,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  */
 public class AllowedValueCollectingNodeItemVisitor
     extends AbstractRecursionPreventingNodeItemVisitor<DynamicContext, Void> {
+  private static final Logger LOGGER = LogManager.getLogger(AllowedValueCollectingNodeItemVisitor.class);
 
   @NonNull
   private final Map<IDefinitionNodeItem<?, ?>, NodeItemRecord> nodeItemAnalysis = new LinkedHashMap<>();
@@ -93,11 +98,18 @@ public class AllowedValueCollectingNodeItemVisitor
       @NonNull DynamicContext context) {
     itemLocation.getDefinition().getAllowedValuesConstraints().stream()
         .forEachOrdered(allowedValues -> {
-          ISequence<?> result = allowedValues.getTarget().evaluate(itemLocation, context);
-          result.stream().forEachOrdered(target -> {
-            assert target != null;
-            handleAllowedValues(allowedValues, itemLocation, (IDefinitionNodeItem<?, ?>) target);
-          });
+          try {
+            ISequence<?> result = allowedValues.getTarget().evaluate(itemLocation, context);
+            result.stream().forEachOrdered(target -> {
+              assert target != null;
+              handleAllowedValues(allowedValues, itemLocation, (IDefinitionNodeItem<?, ?>) target);
+            });
+          } catch (MetapathException ex) {
+            LOGGER.atWarn().log(
+                "Skipping allowed-values constraint target '{}' at '{}' because it cannot be evaluated"
+                    + " against the module definition: {}",
+                allowedValues.getTarget().getPath(), itemLocation.getMetapath(), ex.getLocalizedMessage());
+          }
         });
   }
 
@@ -144,9 +156,20 @@ public class AllowedValueCollectingNodeItemVisitor
     assert context != null;
     DynamicContext subContext = context;
     for (ILet let : item.getDefinition().getLetExpressions().values()) {
-      ISequence<?> result = let.getValueExpression().evaluate(item,
-          subContext).reusable();
-      subContext = subContext.bindVariableValue(let.getName(), result);
+      try {
+        ISequence<?> result = let.getValueExpression().evaluate(item,
+            subContext).reusable();
+        subContext = subContext.bindVariableValue(let.getName(), result);
+      } catch (MetapathException ex) {
+        // Let expressions may reference runtime-only data (e.g. atomization of a
+        // flag whose typed value is only available on an instance document) that
+        // cannot be evaluated while walking the module definition. Skip binding
+        // the variable; dependent expressions will be skipped downstream.
+        LOGGER.atWarn().log(
+            "Skipping let expression '${}' at '{}' because it cannot be evaluated against"
+                + " the module definition: {}",
+            let.getName(), item.getMetapath(), ex.getLocalizedMessage());
+      }
     }
     return subContext;
   }

--- a/core/src/test/java/dev/metaschema/core/metapath/item/node/AllowedValueCollectingNodeItemVisitorTest.java
+++ b/core/src/test/java/dev/metaschema/core/metapath/item/node/AllowedValueCollectingNodeItemVisitorTest.java
@@ -379,4 +379,59 @@ class AllowedValueCollectingNodeItemVisitorTest {
     assertEquals(1, locations.size(),
         "The allowed-values constraint that does not reference the failing let must still be collected");
   }
+
+  @Test
+  void testVisitorSkipsAllowedValuesTargetThatReferencesUnboundLetVariable() {
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create(TEST_NAMESPACE));
+
+    IModule module = IModuleBuilder.builder()
+        .namespace(TEST_NAMESPACE)
+        .shortName("target-eval-test")
+        .version("1.0.0")
+        .source(source)
+        .assembly(mocking.assembly()
+            .name("root")
+            .rootName("root")
+            .flags(List.of(
+                mocking.flag().name("href"),
+                mocking.flag().name("status"))))
+        .toModule();
+
+    IAssemblyDefinition rootDef = module.getAssemblyDefinitions().iterator().next();
+    // The let's value expression atomizes a flag with no typed value, so the
+    // variable will never be bound.
+    rootDef.getConstraintSupport().addLetExpression(
+        ILet.of(
+            IEnhancedQName.of("resolved"),
+            IMetapathExpression.compile("@href + 1"),
+            source,
+            null));
+    // This constraint's target references the (unbound) $resolved variable. The
+    // visitor must catch the resulting evaluation error and move on instead of
+    // aborting the walk.
+    rootDef.getConstraintSupport().addConstraint(
+        IAllowedValuesConstraint.builder()
+            .source(source)
+            .target(IMetapathExpression.compile("$resolved"))
+            .allowedValue(IAllowedValue.of("skipped", MarkupLine.fromMarkdown("Skipped"), null))
+            .build());
+    // An independent constraint with a simple target should still be collected.
+    rootDef.getConstraintSupport().addConstraint(
+        IAllowedValuesConstraint.builder()
+            .source(source)
+            .target(IMetapathExpression.compile("@status"))
+            .allowedValue(IAllowedValue.of("active", MarkupLine.fromMarkdown("Active"), null))
+            .build());
+
+    AllowedValueCollectingNodeItemVisitor visitor = new AllowedValueCollectingNodeItemVisitor();
+    assertDoesNotThrow(() -> visitor.visit(module),
+        "Visitor must not abort when an allowed-values target references an unbound let variable");
+
+    Collection<NodeItemRecord> locations = visitor.getAllowedValueLocations();
+    assertEquals(1, locations.size(),
+        "Only the independent allowed-values constraint should be collected");
+    assertEquals("status", locations.iterator().next().getItem().getDefinition().getName(),
+        "The surviving constraint should be the one targeting @status");
+  }
 }

--- a/core/src/test/java/dev/metaschema/core/metapath/item/node/AllowedValueCollectingNodeItemVisitorTest.java
+++ b/core/src/test/java/dev/metaschema/core/metapath/item/node/AllowedValueCollectingNodeItemVisitorTest.java
@@ -5,6 +5,7 @@
 
 package dev.metaschema.core.metapath.item.node;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -27,7 +28,9 @@ import dev.metaschema.core.model.IModule;
 import dev.metaschema.core.model.ISource;
 import dev.metaschema.core.model.constraint.IAllowedValue;
 import dev.metaschema.core.model.constraint.IAllowedValuesConstraint;
+import dev.metaschema.core.model.constraint.ILet;
 import dev.metaschema.core.model.constraint.IValueConstrained;
+import dev.metaschema.core.qname.IEnhancedQName;
 import dev.metaschema.core.testsupport.MockedModelTestSupport;
 import dev.metaschema.core.testsupport.builder.IModuleBuilder;
 
@@ -332,5 +335,48 @@ class AllowedValueCollectingNodeItemVisitorTest {
         "Allowed value keys should be preserved");
     assertTrue(record.getAllowedValues().getAllowedValues().containsKey("done"),
         "Allowed value keys should be preserved");
+  }
+
+  @Test
+  void testVisitorSkipsLetExpressionThatCannotBeEvaluatedAtDefinition() {
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create(TEST_NAMESPACE));
+
+    IModule module = IModuleBuilder.builder()
+        .namespace(TEST_NAMESPACE)
+        .shortName("let-eval-test")
+        .version("1.0.0")
+        .source(source)
+        .assembly(mocking.assembly()
+            .name("root")
+            .rootName("root")
+            .flags(List.of(mocking.flag().name("href"))))
+        .toModule();
+
+    IAssemblyDefinition rootDef = module.getAssemblyDefinitions().iterator().next();
+    // A let whose value expression atomizes a flag node item. At definition-walk
+    // time the flag has no typed value, so this evaluation would raise
+    // InvalidTypeFunctionException (FOTY). The visitor must tolerate this and
+    // continue collecting allowed-values constraints.
+    rootDef.getConstraintSupport().addLetExpression(
+        ILet.of(
+            IEnhancedQName.of("resolved"),
+            IMetapathExpression.compile("@href + 1"),
+            source,
+            null));
+    rootDef.getConstraintSupport().addConstraint(
+        IAllowedValuesConstraint.builder()
+            .source(source)
+            .target(IMetapathExpression.compile("@href"))
+            .allowedValue(IAllowedValue.of("http://example.com/a", MarkupLine.fromMarkdown("A"), null))
+            .build());
+
+    AllowedValueCollectingNodeItemVisitor visitor = new AllowedValueCollectingNodeItemVisitor();
+    assertDoesNotThrow(() -> visitor.visit(module),
+        "Visitor must not abort when a let expression cannot be evaluated on a definition node");
+
+    Collection<NodeItemRecord> locations = visitor.getAllowedValueLocations();
+    assertEquals(1, locations.size(),
+        "The allowed-values constraint that does not reference the failing let must still be collected");
   }
 }


### PR DESCRIPTION
## Summary
- `AllowedValueCollectingNodeItemVisitor` walks the module definition, not instance data. Let expressions that atomize a flag node item (e.g. arithmetic on a flag whose typed value only exists against a real document) raise `InvalidTypeFunctionException` (FOTY0013), which aborts the whole walk.
- The same happens for allowed-values constraint targets that reference an unbound let variable.
- Catch `MetapathException` around both the let-variable binding and the allowed-values target evaluation, log a warning, and continue.
- Without this, `metaschema-cli list-allowed-values` fails against modules like OSCAL's component-definition that declare such lets.

## Test plan
- [x] New unit test `testVisitorSkipsLetExpressionThatCannotBeEvaluatedAtDefinition` — asserts the visit does not throw and the independent allowed-values constraint is still collected when a sibling let is unevaluable at the definition level
- [x] Confirmed RED against unfixed code (FOTY0013 from `handleLetStatements`), GREEN after the fix
- [x] Full `AllowedValueCollectingNodeItemVisitorTest` suite passes (8 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness: metapath evaluation errors during definition walks and allowed-values processing are now caught, skipped, and logged so processing continues without aborting.

* **Tests**
  * Added tests confirming evaluation failures do not stop traversal and only applicable allowed-values are collected; processing continues for other constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->