### PR TITLE
Bind let variables lazily in AllowedValueCollectingNodeItemVisitor

### DIFF
--- a/core/src/main/java/dev/metaschema/core/metapath/item/node/AllowedValueCollectingNodeItemVisitor.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/item/node/AllowedValueCollectingNodeItemVisitor.java
@@ -10,18 +10,26 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import dev.metaschema.core.metapath.DynamicContext;
+import dev.metaschema.core.metapath.IExpression;
+import dev.metaschema.core.metapath.IMetapathExpression;
 import dev.metaschema.core.metapath.MetapathException;
 import dev.metaschema.core.metapath.StaticContext;
+import dev.metaschema.core.metapath.cst.AbstractExpressionVisitor;
+import dev.metaschema.core.metapath.cst.VariableReference;
 import dev.metaschema.core.metapath.item.ISequence;
 import dev.metaschema.core.model.IModule;
 import dev.metaschema.core.model.constraint.IAllowedValuesConstraint;
 import dev.metaschema.core.model.constraint.ILet;
+import dev.metaschema.core.qname.IEnhancedQName;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -46,6 +54,18 @@ public class AllowedValueCollectingNodeItemVisitor
 
   @NonNull
   private final Map<IDefinitionNodeItem<?, ?>, NodeItemRecord> nodeItemAnalysis = new LinkedHashMap<>();
+
+  /**
+   * The set of let variable names that are referenced, transitively, by any
+   * allowed-values constraint target expression in the walked module. A let is
+   * only evaluated at walk time if its name appears in this set. Lets that are
+   * never read by an allowed-values constraint are skipped entirely to avoid
+   * evaluating expressions that inherently require instance-level data (for
+   * example, those calling {@code fn:doc} or {@code oscal:resolve-reference} on a
+   * flag whose typed value only exists in an instance document).
+   */
+  @NonNull
+  private Set<IEnhancedQName> referencedVariables = Collections.emptySet();
 
   /**
    * Get the collected allowed-values constraint locations found during
@@ -89,7 +109,89 @@ public class AllowedValueCollectingNodeItemVisitor
    *          the dynamic context to use for constraint evaluation
    */
   public void visit(@NonNull IModuleNodeItem module, @NonNull DynamicContext context) {
+    this.referencedVariables = computeReferencedVariables(module);
     visitMetaschema(module, context);
+  }
+
+  /**
+   * Walk the module graph once to determine which let variable names are needed
+   * by an allowed-values constraint target expression. The set is expanded
+   * transitively so that, if a let's value expression references another let,
+   * both are considered needed.
+   *
+   * @param module
+   *          the module graph to scan
+   * @return the set of needed variable names
+   */
+  @NonNull
+  private static Set<IEnhancedQName> computeReferencedVariables(@NonNull IModuleNodeItem module) {
+    Set<IEnhancedQName> needed = new HashSet<>();
+    Map<IEnhancedQName, IMetapathExpression> allLets = new HashMap<>();
+
+    ReferenceCollectingVisitor scanner = new ReferenceCollectingVisitor(needed, allLets);
+    scanner.visitMetaschema(module, null);
+
+    // Transitive closure: if a needed let's value expression references another
+    // variable, that variable is also needed.
+    boolean changed = true;
+    while (changed) {
+      changed = false;
+      Set<IEnhancedQName> toAdd = new HashSet<>();
+      for (IEnhancedQName name : needed) {
+        IMetapathExpression expr = allLets.get(name);
+        if (expr != null) {
+          Set<IEnhancedQName> found = new HashSet<>();
+          collectVariableReferences(expr, found);
+          for (IEnhancedQName ref : found) {
+            if (!needed.contains(ref)) {
+              toAdd.add(ref);
+            }
+          }
+        }
+      }
+      if (!toAdd.isEmpty()) {
+        needed.addAll(toAdd);
+        changed = true;
+      }
+    }
+    return needed;
+  }
+
+  /**
+   * Walk the AST of the provided compiled Metapath expression and append every
+   * variable reference name into {@code sink}. Expressions that cannot be
+   * compiled on demand (for lazy expressions) are treated as referencing no
+   * variables, which conservatively lets them fail at evaluation time with the
+   * existing diagnostic path instead of silently skipping the constraint.
+   */
+  private static void collectVariableReferences(
+      @NonNull IMetapathExpression expression,
+      @NonNull Set<IEnhancedQName> sink) {
+    try {
+      ((IExpression) expression).accept(
+          new AbstractExpressionVisitor<Void, Set<IEnhancedQName>>() {
+            @Override
+            protected Void aggregateResult(Void existing, Void next, Set<IEnhancedQName> ctx) {
+              return null;
+            }
+
+            @Override
+            protected Void defaultResult() {
+              return null;
+            }
+
+            @Override
+            public Void visitVariableReference(VariableReference expr, Set<IEnhancedQName> ctx) {
+              ctx.add(expr.getName());
+              return null;
+            }
+          },
+          sink);
+    } catch (MetapathException ex) {
+      // Compilation failed. Leave the variable set unchanged; the downstream
+      // evaluation code path will surface the underlying problem with a
+      // standard diagnostic.
+    }
   }
 
   @SuppressWarnings("PMD.AvoidCatchingGenericException")
@@ -156,6 +258,15 @@ public class AllowedValueCollectingNodeItemVisitor
     assert context != null;
     DynamicContext subContext = context;
     for (ILet let : item.getDefinition().getLetExpressions().values()) {
+      if (!referencedVariables.contains(let.getName())) {
+        // No allowed-values constraint (direct or transitive through another
+        // let) references this variable. Skip binding so expressions that
+        // cannot be evaluated against a module definition -- for example those
+        // calling fn:doc, oscal:resolve-reference, or oscal:resolve-profile --
+        // do not raise diagnostics when they would have no effect on the
+        // collected allowed-values anyway.
+        continue;
+      }
       try {
         ISequence<?> result = let.getValueExpression().evaluate(item,
             subContext).reusable();
@@ -172,6 +283,64 @@ public class AllowedValueCollectingNodeItemVisitor
       }
     }
     return subContext;
+  }
+
+  /**
+   * A node-item visitor used as a one-time pre-pass to populate the set of let
+   * variable names that are referenced by any allowed-values constraint target
+   * expression in the module, along with the full table of let value expressions
+   * for later transitive expansion.
+   */
+  private static final class ReferenceCollectingVisitor
+      extends AbstractRecursionPreventingNodeItemVisitor<Void, Void> {
+    @NonNull
+    private final Set<IEnhancedQName> referenced;
+    @NonNull
+    private final Map<IEnhancedQName, IMetapathExpression> letExpressions;
+
+    ReferenceCollectingVisitor(
+        @NonNull Set<IEnhancedQName> referenced,
+        @NonNull Map<IEnhancedQName, IMetapathExpression> letExpressions) {
+      this.referenced = referenced;
+      this.letExpressions = letExpressions;
+    }
+
+    private void collectFromDefinition(@NonNull IDefinitionNodeItem<?, ?> item) {
+      for (ILet let : item.getDefinition().getLetExpressions().values()) {
+        letExpressions.putIfAbsent(let.getName(), let.getValueExpression());
+      }
+      for (IAllowedValuesConstraint constraint : item.getDefinition().getAllowedValuesConstraints()) {
+        collectVariableReferences(constraint.getTarget(), referenced);
+      }
+    }
+
+    @Override
+    public Void visitFlag(IFlagNodeItem item, Void context) {
+      collectFromDefinition(item);
+      return super.visitFlag(item, context);
+    }
+
+    @Override
+    public Void visitField(IFieldNodeItem item, Void context) {
+      collectFromDefinition(item);
+      return super.visitField(item, context);
+    }
+
+    @Override
+    public Void visitAssembly(IAssemblyNodeItem item, Void context) {
+      collectFromDefinition(item);
+      return super.visitAssembly(item, context);
+    }
+
+    @Override
+    public Void visitAssembly(IAssemblyInstanceGroupedNodeItem item, Void context) {
+      return visitAssembly((IAssemblyNodeItem) item, context);
+    }
+
+    @Override
+    protected Void defaultResult() {
+      return null;
+    }
   }
 
   @Override

--- a/core/src/main/java/dev/metaschema/core/metapath/item/node/AllowedValueCollectingNodeItemVisitor.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/item/node/AllowedValueCollectingNodeItemVisitor.java
@@ -8,8 +8,10 @@ package dev.metaschema.core.metapath.item.node;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -131,27 +133,23 @@ public class AllowedValueCollectingNodeItemVisitor
     ReferenceCollectingVisitor scanner = new ReferenceCollectingVisitor(needed, allLets);
     scanner.visitMetaschema(module, null);
 
-    // Transitive closure: if a needed let's value expression references another
-    // variable, that variable is also needed.
-    boolean changed = true;
-    while (changed) {
-      changed = false;
-      Set<IEnhancedQName> toAdd = new HashSet<>();
-      for (IEnhancedQName name : needed) {
-        IMetapathExpression expr = allLets.get(name);
-        if (expr != null) {
-          Set<IEnhancedQName> found = new HashSet<>();
-          collectVariableReferences(expr, found);
-          for (IEnhancedQName ref : found) {
-            if (!needed.contains(ref)) {
-              toAdd.add(ref);
-            }
-          }
-        }
+    // Transitive closure via a worklist. Each variable name whose let value
+    // expression still needs to be scanned is queued once. When scanning
+    // reveals new variable references, only those not already in the needed
+    // set are enqueued. This visits each let value expression at most once.
+    Deque<IEnhancedQName> worklist = new ArrayDeque<>(needed);
+    while (!worklist.isEmpty()) {
+      IEnhancedQName name = worklist.poll();
+      IMetapathExpression expr = allLets.get(name);
+      if (expr == null) {
+        continue;
       }
-      if (!toAdd.isEmpty()) {
-        needed.addAll(toAdd);
-        changed = true;
+      Set<IEnhancedQName> found = new HashSet<>();
+      collectVariableReferences(expr, found);
+      for (IEnhancedQName ref : found) {
+        if (needed.add(ref)) {
+          worklist.add(ref);
+        }
       }
     }
     return needed;

--- a/core/src/test/java/dev/metaschema/core/metapath/item/node/AllowedValueCollectingNodeItemVisitorTest.java
+++ b/core/src/test/java/dev/metaschema/core/metapath/item/node/AllowedValueCollectingNodeItemVisitorTest.java
@@ -12,10 +12,19 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import java.net.URI;
 import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
 
 import dev.metaschema.core.datatype.markup.MarkupLine;
@@ -34,9 +43,34 @@ import dev.metaschema.core.qname.IEnhancedQName;
 import dev.metaschema.core.testsupport.MockedModelTestSupport;
 import dev.metaschema.core.testsupport.builder.IModuleBuilder;
 
+@Execution(value = ExecutionMode.SAME_THREAD, reason = "Log capturing needs to be single threaded")
 class AllowedValueCollectingNodeItemVisitorTest {
 
   private static final String TEST_NAMESPACE = "http://example.com/ns/allowed-values-test";
+
+  private CapturingAppender capturingAppender;
+  private Logger visitorLogger;
+
+  @BeforeEach
+  void attachLogCapture() {
+    capturingAppender = new CapturingAppender();
+    capturingAppender.start();
+    visitorLogger = (Logger) LogManager.getLogger(AllowedValueCollectingNodeItemVisitor.class);
+    visitorLogger.addAppender(capturingAppender);
+  }
+
+  @AfterEach
+  void detachLogCapture() {
+    if (visitorLogger != null && capturingAppender != null) {
+      visitorLogger.removeAppender(capturingAppender);
+      capturingAppender.stop();
+    }
+  }
+
+  private boolean capturedAnyMessageContaining(String substring) {
+    return capturingAppender.getEvents().stream()
+        .anyMatch(event -> event.getMessage().getFormattedMessage().contains(substring));
+  }
 
   @Test
   void testVisitorFindsAllowedValuesConstraints() {
@@ -378,6 +412,113 @@ class AllowedValueCollectingNodeItemVisitorTest {
     Collection<NodeItemRecord> locations = visitor.getAllowedValueLocations();
     assertEquals(1, locations.size(),
         "The allowed-values constraint that does not reference the failing let must still be collected");
+  }
+
+  @Test
+  void testVisitorDoesNotEvaluateLetNotReferencedByAnyAllowedValues() {
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create(TEST_NAMESPACE));
+
+    IModule module = IModuleBuilder.builder()
+        .namespace(TEST_NAMESPACE)
+        .shortName("lazy-let-test")
+        .version("1.0.0")
+        .source(source)
+        .assembly(mocking.assembly()
+            .name("root")
+            .rootName("root")
+            .flags(List.of(mocking.flag().name("href"))))
+        .toModule();
+
+    IAssemblyDefinition rootDef = module.getAssemblyDefinitions().iterator().next();
+    // This let's value expression would raise InvalidTypeFunctionException at
+    // definition walk because it atomizes a no-data flag. The let's variable
+    // ($unused) is not referenced by any allowed-values target or value, so the
+    // visitor must not attempt to evaluate it, and must not emit any
+    // "Skipping let expression" warning for it.
+    rootDef.getConstraintSupport().addLetExpression(
+        ILet.of(
+            IEnhancedQName.of("unused"),
+            IMetapathExpression.compile("@href + 1"),
+            source,
+            null));
+    rootDef.getConstraintSupport().addConstraint(
+        IAllowedValuesConstraint.builder()
+            .source(source)
+            .target(IMetapathExpression.compile("@href"))
+            .allowedValue(IAllowedValue.of("http://example.com/a", MarkupLine.fromMarkdown("A"), null))
+            .build());
+
+    AllowedValueCollectingNodeItemVisitor visitor = new AllowedValueCollectingNodeItemVisitor();
+    visitor.visit(module);
+
+    assertFalse(capturedAnyMessageContaining("Skipping let expression"),
+        "No let-evaluation warning must be emitted when the let's variable is not referenced"
+            + " by any allowed-values constraint");
+    assertEquals(1, visitor.getAllowedValueLocations().size(),
+        "The independent allowed-values constraint must still be collected");
+  }
+
+  @Test
+  void testVisitorEvaluatesLetReferencedByAllowedValuesTarget() {
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create(TEST_NAMESPACE));
+
+    IModule module = IModuleBuilder.builder()
+        .namespace(TEST_NAMESPACE)
+        .shortName("referenced-let-test")
+        .version("1.0.0")
+        .source(source)
+        .assembly(mocking.assembly()
+            .name("root")
+            .rootName("root")
+            .flags(List.of(mocking.flag().name("href"))))
+        .toModule();
+
+    IAssemblyDefinition rootDef = module.getAssemblyDefinitions().iterator().next();
+    // The let's value expression would fail at definition walk. Because an
+    // allowed-values target references $resolved, the visitor MUST still
+    // attempt to evaluate the let and surface the evaluation warning so
+    // authors see that their referenced let is broken.
+    rootDef.getConstraintSupport().addLetExpression(
+        ILet.of(
+            IEnhancedQName.of("resolved"),
+            IMetapathExpression.compile("@href + 1"),
+            source,
+            null));
+    rootDef.getConstraintSupport().addConstraint(
+        IAllowedValuesConstraint.builder()
+            .source(source)
+            .target(IMetapathExpression.compile("$resolved"))
+            .allowedValue(IAllowedValue.of("anything", MarkupLine.fromMarkdown("Anything"), null))
+            .build());
+
+    AllowedValueCollectingNodeItemVisitor visitor = new AllowedValueCollectingNodeItemVisitor();
+    visitor.visit(module);
+
+    assertTrue(capturedAnyMessageContaining("Skipping let expression"),
+        "A let-evaluation warning must still be emitted when the let's variable is referenced"
+            + " by an allowed-values constraint that relies on it");
+  }
+
+  private static final class CapturingAppender
+      extends AbstractAppender {
+    private final List<LogEvent> events = new LinkedList<>();
+
+    CapturingAppender() {
+      super("LetEvalCapture", null, null, false, null);
+    }
+
+    List<LogEvent> getEvents() {
+      return events;
+    }
+
+    @Override
+    public void append(LogEvent event) {
+      synchronized (this) {
+        events.add(event.toImmutable());
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary

Pre-scans allowed-values constraint target expressions across the module to determine which `let` variable names are actually consumed (expanded transitively through other lets). Lets whose variable name is never referenced are skipped instead of being eagerly evaluated.

## Motivation

`list-allowed-values` walks an `IModuleNodeItem` graph, not an instance document. Several OSCAL external constraints declare lets whose value expressions atomize flags (for example, `oscal:resolve-reference(@href)`), which can only produce a value on an instance. At module walk these evaluations raise `FOTY0013` (`InvalidTypeFunctionException`), which the visitor catches and logs at WARN.

Every run of `oscal-cli list-allowed-values` emitted six such warnings even though none of those lets are consumed by an allowed-values constraint — they are only consumed by `<index>` and `<expect>` constraints, which are irrelevant to this visitor.

## Change

- Added `computeReferencedVariables(IModuleNodeItem)` which walks the module once and returns the set of variable names referenced by any allowed-values constraint target expression, expanded transitively through needed let value expressions.
- `handleLetStatements` skips binding for lets whose name is not in that set.
- Behavior for referenced lets is unchanged: eager evaluation, caught exceptions logged at WARN. If a downstream allowed-values target references an unbound variable, the existing target-level WARN still fires.

## Follow-on

The underlying root cause is that `fn:doc`, `oscal:resolve-reference`, and `oscal:resolve-profile` do not declare a model-level return type, so `recurse-depth` has no way to resolve these expressions against the module graph at walk time. Tracked in #706.

## Test plan

- [x] New: `testVisitorDoesNotEvaluateLetNotReferencedByAnyAllowedValues` asserts no `Skipping let expression` warning is emitted when the let's variable is not referenced.
- [x] New: `testVisitorEvaluatesLetReferencedByAllowedValuesTarget` asserts the warning IS emitted when the let is referenced by an allowed-values target.
- [x] Existing `AllowedValueCollectingNodeItemVisitorTest` tests continue to pass.
- [x] `mvn -pl core -am -o test` passes (pre-existing `CommonmarkConformanceTest` SAX issue is unrelated and reproduces on unmodified `develop`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved allowed-values evaluation by precomputing which let variables are actually referenced and initializing only those, reducing unnecessary work while preserving existing diagnostics; compilation failures during analysis are tolerated so downstream behavior remains unchanged.

* **Tests**
  * Added tests covering lazy let behavior and log-based assertions to verify whether "Skipping let expression" warnings are emitted appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->