### PR TITLE
Add METAPATH_ATOMIZE_NO_DATA_AS_EMPTY evaluation feature

### DIFF
--- a/core/src/main/java/dev/metaschema/core/metapath/DynamicContext.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/DynamicContext.java
@@ -341,6 +341,37 @@ public class DynamicContext {
   }
 
   /**
+   * Used to make atomization of node items that have no associated typed value
+   * yield a {@code null} atomic value instead of raising
+   * {@link dev.metaschema.core.metapath.function.InvalidTypeFunctionException}.
+   * <p>
+   * Intended for callers that traverse an
+   * {@link dev.metaschema.core.metapath.item.node.IModuleNodeItem} graph and want
+   * downstream function calls to degrade gracefully when they receive a no-data
+   * flag rather than an instance value.
+   *
+   * @return this dynamic context
+   */
+  @NonNull
+  public DynamicContext enableAtomizeNoDataAsEmpty() {
+    this.sharedState.configuration.enableFeature(MetapathEvaluationFeature.METAPATH_ATOMIZE_NO_DATA_AS_EMPTY);
+    return this;
+  }
+
+  /**
+   * Used to restore the default behavior of raising
+   * {@link dev.metaschema.core.metapath.function.InvalidTypeFunctionException}
+   * when a node item that has no typed value is atomized.
+   *
+   * @return this dynamic context
+   */
+  @NonNull
+  public DynamicContext disableAtomizeNoDataAsEmpty() {
+    this.sharedState.configuration.disableFeature(MetapathEvaluationFeature.METAPATH_ATOMIZE_NO_DATA_AS_EMPTY);
+    return this;
+  }
+
+  /**
    * Get the Metapath evaluation configuration.
    *
    * @return the configuration

--- a/core/src/main/java/dev/metaschema/core/metapath/MetapathEvaluationFeature.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/MetapathEvaluationFeature.java
@@ -25,6 +25,25 @@ public final class MetapathEvaluationFeature<V>
   public static final MetapathEvaluationFeature<Boolean> METAPATH_EVALUATE_PREDICATES
       = new MetapathEvaluationFeature<>("evaluate-predicates", Boolean.class, true);
 
+  /**
+   * If enabled, atomization of a node item that has no associated typed value
+   * (for example, a flag or field node reached while walking a module definition
+   * rather than an instance document) yields a {@code null} atomic value instead
+   * of raising
+   * {@link dev.metaschema.core.metapath.function.InvalidTypeFunctionException}
+   * with code
+   * {@link dev.metaschema.core.metapath.function.InvalidTypeFunctionException#NODE_HAS_NO_TYPED_VALUE}.
+   * <p>
+   * This is intended for visitors and tools that traverse an
+   * {@link dev.metaschema.core.metapath.item.node.IModuleNodeItem} graph and need
+   * downstream function calls (for example {@code fn:resolve-uri} or
+   * {@code fn:doc}) to degrade gracefully when they receive a no-data flag rather
+   * than an instance value.
+   */
+  @NonNull
+  public static final MetapathEvaluationFeature<Boolean> METAPATH_ATOMIZE_NO_DATA_AS_EMPTY
+      = new MetapathEvaluationFeature<>("atomize-no-data-as-empty", Boolean.class, false);
+
   private MetapathEvaluationFeature(
       @NonNull String name,
       @NonNull Class<V> valueClass,

--- a/core/src/main/java/dev/metaschema/core/metapath/function/impl/AbstractFunction.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/function/impl/AbstractFunction.java
@@ -13,10 +13,12 @@ import java.util.stream.Stream;
 
 import dev.metaschema.core.metapath.ContextAbsentDynamicMetapathException;
 import dev.metaschema.core.metapath.DynamicContext;
+import dev.metaschema.core.metapath.MetapathEvaluationFeature;
 import dev.metaschema.core.metapath.MetapathException;
 import dev.metaschema.core.metapath.function.CalledContext;
 import dev.metaschema.core.metapath.function.IArgument;
 import dev.metaschema.core.metapath.function.IFunction;
+import dev.metaschema.core.metapath.function.InvalidTypeFunctionException;
 import dev.metaschema.core.metapath.item.IItem;
 import dev.metaschema.core.metapath.item.IItemVisitor;
 import dev.metaschema.core.metapath.item.ISequence;
@@ -28,6 +30,7 @@ import dev.metaschema.core.metapath.type.ISequenceType;
 import dev.metaschema.core.metapath.type.InvalidTypeMetapathException;
 import dev.metaschema.core.qname.IEnhancedQName;
 import dev.metaschema.core.util.CollectionUtil;
+import dev.metaschema.core.util.ObjectUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
@@ -194,7 +197,11 @@ public abstract class AbstractFunction implements IFunction {
     Stream<? extends IItem> stream = sequence.safeStream();
 
     if (IAnyAtomicItem.class.isAssignableFrom(requiredSequenceTypeClass)) {
-      Stream<? extends IAnyAtomicItem> atomicStream = stream.flatMap(IItem::atomize);
+      boolean tolerateNoData = dynamicContext.getConfiguration()
+          .isFeatureEnabled(MetapathEvaluationFeature.METAPATH_ATOMIZE_NO_DATA_AS_EMPTY);
+      Stream<? extends IAnyAtomicItem> atomicStream = tolerateNoData
+          ? stream.flatMap(AbstractFunction::atomizeTolerantOfNoData)
+          : stream.flatMap(IItem::atomize);
 
       // if (IUntypedAtomicItem.class.isInstance(item)) {
       // // TODO: apply cast to atomic type
@@ -220,6 +227,29 @@ public abstract class AbstractFunction implements IFunction {
     assert stream != null;
 
     return ISequence.of(stream);
+  }
+
+  /**
+   * Atomize the provided item, translating a
+   * {@link InvalidTypeFunctionException#NODE_HAS_NO_TYPED_VALUE} or
+   * {@link InvalidTypeFunctionException#DATA_ITEM_IS_FUNCTION} into an empty
+   * stream. Used at function argument conversion when the
+   * {@link MetapathEvaluationFeature#METAPATH_ATOMIZE_NO_DATA_AS_EMPTY} feature
+   * is enabled so that definition-walk evaluations degrade gracefully instead of
+   * aborting.
+   */
+  @NonNull
+  private static Stream<? extends IAnyAtomicItem> atomizeTolerantOfNoData(@NonNull IItem item) {
+    try {
+      return item.atomize();
+    } catch (InvalidTypeFunctionException ex) {
+      int code = ex.getErrorCode().getCode();
+      if (code == InvalidTypeFunctionException.NODE_HAS_NO_TYPED_VALUE
+          || code == InvalidTypeFunctionException.DATA_ITEM_IS_FUNCTION) {
+        return ObjectUtils.notNull(Stream.empty());
+      }
+      throw ex;
+    }
   }
 
   @Nullable

--- a/core/src/main/java/dev/metaschema/core/metapath/item/node/AllowedValueCollectingNodeItemVisitor.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/item/node/AllowedValueCollectingNodeItemVisitor.java
@@ -64,7 +64,11 @@ public class AllowedValueCollectingNodeItemVisitor
    * constraints.
    * <p>
    * This method creates a new {@link DynamicContext} configured with the module's
-   * default namespace and with predicate evaluation disabled.
+   * default namespace, with predicate evaluation disabled, and with no-data
+   * atomization treated as empty so that expressions that reach instance-only
+   * functions (for example, {@code fn:doc} via
+   * {@code oscal:resolve-reference(@href)}) degrade to empty sequences rather
+   * than raising {@code InvalidTypeFunctionException} while walking a module.
    *
    * @param module
    *          the Metaschema module to visit
@@ -75,6 +79,7 @@ public class AllowedValueCollectingNodeItemVisitor
             .defaultModelNamespace(module.getXmlNamespace())
             .build());
     context.disablePredicateEvaluation();
+    context.enableAtomizeNoDataAsEmpty();
 
     visit(INodeItemFactory.instance().newModuleNodeItem(module), context);
   }

--- a/core/src/test/java/dev/metaschema/core/metapath/function/impl/AtomizeNoDataAsEmptyTest.java
+++ b/core/src/test/java/dev/metaschema/core/metapath/function/impl/AtomizeNoDataAsEmptyTest.java
@@ -1,0 +1,173 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package dev.metaschema.core.metapath.function.impl;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import dev.metaschema.core.metapath.DynamicContext;
+import dev.metaschema.core.metapath.IMetapathExpression;
+import dev.metaschema.core.metapath.MetapathEvaluationFeature;
+import dev.metaschema.core.metapath.StaticContext;
+import dev.metaschema.core.metapath.function.InvalidTypeFunctionException;
+import dev.metaschema.core.metapath.item.node.IAssemblyNodeItem;
+import dev.metaschema.core.metapath.item.node.IModelNodeItem;
+import dev.metaschema.core.metapath.item.node.IModuleNodeItem;
+import dev.metaschema.core.metapath.item.node.INodeItemFactory;
+import dev.metaschema.core.metapath.type.InvalidTypeMetapathException;
+import dev.metaschema.core.model.IModule;
+import dev.metaschema.core.model.ISource;
+import dev.metaschema.core.testsupport.MockedModelTestSupport;
+import dev.metaschema.core.testsupport.builder.IModuleBuilder;
+
+/**
+ * Targeted tests for the {@code METAPATH_ATOMIZE_NO_DATA_AS_EMPTY} evaluation
+ * feature. These exercise the function argument conversion layer directly,
+ * independent of any visitor, so a regression that narrows or broadens the
+ * caught exception surface in
+ * {@link dev.metaschema.core.metapath.function.impl.AbstractFunction#convertSequence}
+ * is caught here.
+ */
+class AtomizeNoDataAsEmptyTest {
+
+  private static final String TEST_NAMESPACE = "http://example.com/ns/atomize-no-data-test";
+
+  private static IModule buildSingleFlagModule() {
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create(TEST_NAMESPACE));
+
+    return IModuleBuilder.builder()
+        .namespace(TEST_NAMESPACE)
+        .shortName("no-data-test")
+        .version("1.0.0")
+        .source(source)
+        .assembly(mocking.assembly()
+            .name("root")
+            .rootName("root")
+            .flags(List.of(mocking.flag().name("href"))))
+        .toModule();
+  }
+
+  private static IAssemblyNodeItem rootAssemblyNode(IModule module) {
+    IModuleNodeItem moduleNode = INodeItemFactory.instance().newModuleNodeItem(module);
+    List<? extends IModelNodeItem<?, ?>> children = moduleNode.modelItems().collect(Collectors.toList());
+    return (IAssemblyNodeItem) children.iterator().next();
+  }
+
+  private static DynamicContext newContext(IModule module) {
+    DynamicContext context = new DynamicContext(
+        StaticContext.builder()
+            .defaultModelNamespace(module.getXmlNamespace())
+            .build());
+    context.disablePredicateEvaluation();
+    return context;
+  }
+
+  @Test
+  void featureDefaultsToDisabled() {
+    DynamicContext context = new DynamicContext(StaticContext.instance());
+    assertFalse(context.getConfiguration()
+        .isFeatureEnabled(MetapathEvaluationFeature.METAPATH_ATOMIZE_NO_DATA_AS_EMPTY),
+        "METAPATH_ATOMIZE_NO_DATA_AS_EMPTY must default to disabled on a fresh DynamicContext");
+  }
+
+  @Test
+  void enableAndDisableRoundTripToggleFeatureState() {
+    DynamicContext context = new DynamicContext(StaticContext.instance());
+    context.enableAtomizeNoDataAsEmpty();
+    assertTrue(context.getConfiguration()
+        .isFeatureEnabled(MetapathEvaluationFeature.METAPATH_ATOMIZE_NO_DATA_AS_EMPTY),
+        "enableAtomizeNoDataAsEmpty must set the feature to enabled");
+
+    context.disableAtomizeNoDataAsEmpty();
+    assertFalse(context.getConfiguration()
+        .isFeatureEnabled(MetapathEvaluationFeature.METAPATH_ATOMIZE_NO_DATA_AS_EMPTY),
+        "disableAtomizeNoDataAsEmpty must restore the disabled state");
+  }
+
+  @Test
+  void withoutFeatureFlagFunctionArgAtomizationOnNoDataFlagThrows() {
+    IModule module = buildSingleFlagModule();
+    IAssemblyNodeItem rootNode = rootAssemblyNode(module);
+    DynamicContext context = newContext(module);
+
+    IMetapathExpression expr = IMetapathExpression.compile("upper-case(@href)", context.getStaticContext());
+    assertThrows(InvalidTypeFunctionException.class,
+        () -> expr.evaluate(rootNode, context),
+        "With the feature disabled, atomizing a no-data flag inside a function argument must raise FOTY");
+  }
+
+  @Test
+  void withFeatureFlagFunctionArgAtomizationOnNoDataFlagDoesNotThrow() {
+    IModule module = buildSingleFlagModule();
+    IAssemblyNodeItem rootNode = rootAssemblyNode(module);
+    DynamicContext context = newContext(module);
+    context.enableAtomizeNoDataAsEmpty();
+
+    // The feature controls argument-atomization behavior only: function-arg
+    // conversion yields an empty sequence for the no-data @href instead of
+    // raising FOTY. The function body then handles the empty input according
+    // to its own semantics (for upper-case, per the XPath spec, empty input
+    // returns the zero-length string). The contract being exercised here is
+    // that no FOTY error propagates out of evaluation.
+    IMetapathExpression expr = IMetapathExpression.compile("upper-case(@href)", context.getStaticContext());
+    assertDoesNotThrow(() -> expr.evaluate(rootNode, context),
+        "With the feature enabled, atomizing a no-data flag inside a function argument"
+            + " must not raise FOTY");
+  }
+
+  @Test
+  void featureFlagDoesNotSwallowUnrelatedTypeErrors() {
+    IModule module = buildSingleFlagModule();
+    IAssemblyNodeItem rootNode = rootAssemblyNode(module);
+    DynamicContext context = newContext(module);
+    context.enableAtomizeNoDataAsEmpty();
+
+    // Concatenating two strings with '+' requires numeric operands; the atomic
+    // string items cannot be promoted, so a type error must still be raised
+    // even when no-data-atomization tolerance is enabled.
+    IMetapathExpression expr = IMetapathExpression.compile("'a' + 'b'", context.getStaticContext());
+    assertThrows(InvalidTypeMetapathException.class,
+        () -> expr.evaluate(rootNode, context),
+        "The feature must only tolerate NODE_HAS_NO_TYPED_VALUE / DATA_ITEM_IS_FUNCTION,"
+            + " not generic type errors");
+  }
+
+  @Test
+  void featureFlagPropagatesIntoRecurseDepthRecursion() {
+    IModule module = buildSingleFlagModule();
+    IAssemblyNodeItem rootNode = rootAssemblyNode(module);
+    // Deliberately create a context WITHOUT disabling predicate evaluation
+    // because recurse-depth below relies on predicate evaluation to prove the
+    // inner expression actually ran.
+    DynamicContext context = new DynamicContext(
+        StaticContext.builder()
+            .defaultModelNamespace(module.getXmlNamespace())
+            .build());
+    context.enableAtomizeNoDataAsEmpty();
+
+    // recurse-depth compiles its string argument and evaluates it against the
+    // same DynamicContext. The inner expression filters the current context
+    // item by a predicate containing a function call on a no-data flag. If
+    // the feature did not propagate, the upper-case argument atomization
+    // would raise FOTY during recursion and tear the whole expression down.
+    // With the feature propagated, upper-case(@href) yields the empty string,
+    // the predicate is false, and recurse-depth terminates.
+    IMetapathExpression expr = IMetapathExpression.compile(
+        "recurse-depth('.[upper-case(@href)]')",
+        context.getStaticContext());
+    assertDoesNotThrow(() -> expr.evaluate(rootNode, context),
+        "The feature must propagate into recurse-depth's inner expression evaluation");
+  }
+}

--- a/core/src/test/java/dev/metaschema/core/metapath/item/node/AllowedValueCollectingNodeItemVisitorTest.java
+++ b/core/src/test/java/dev/metaschema/core/metapath/item/node/AllowedValueCollectingNodeItemVisitorTest.java
@@ -12,10 +12,19 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import java.net.URI;
 import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
 
 import dev.metaschema.core.datatype.markup.MarkupLine;
@@ -34,9 +43,34 @@ import dev.metaschema.core.qname.IEnhancedQName;
 import dev.metaschema.core.testsupport.MockedModelTestSupport;
 import dev.metaschema.core.testsupport.builder.IModuleBuilder;
 
+@Execution(value = ExecutionMode.SAME_THREAD, reason = "Log capturing needs to be single threaded")
 class AllowedValueCollectingNodeItemVisitorTest {
 
   private static final String TEST_NAMESPACE = "http://example.com/ns/allowed-values-test";
+
+  private CapturingAppender capturingAppender;
+  private Logger visitorLogger;
+
+  @BeforeEach
+  void attachLogCapture() {
+    capturingAppender = new CapturingAppender();
+    capturingAppender.start();
+    visitorLogger = (Logger) LogManager.getLogger(AllowedValueCollectingNodeItemVisitor.class);
+    visitorLogger.addAppender(capturingAppender);
+  }
+
+  @AfterEach
+  void detachLogCapture() {
+    if (visitorLogger != null && capturingAppender != null) {
+      visitorLogger.removeAppender(capturingAppender);
+      capturingAppender.stop();
+    }
+  }
+
+  private boolean capturedAnyMessageContaining(String substring) {
+    return capturingAppender.getEvents().stream()
+        .anyMatch(event -> event.getMessage().getFormattedMessage().contains(substring));
+  }
 
   @Test
   void testVisitorFindsAllowedValuesConstraints() {
@@ -433,5 +467,72 @@ class AllowedValueCollectingNodeItemVisitorTest {
         "Only the independent allowed-values constraint should be collected");
     assertEquals("status", locations.iterator().next().getItem().getDefinition().getName(),
         "The surviving constraint should be the one targeting @status");
+  }
+
+  @Test
+  void testVisitorToleratesNoDataAtomizationInFunctionArgument() {
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create(TEST_NAMESPACE));
+
+    IModule module = IModuleBuilder.builder()
+        .namespace(TEST_NAMESPACE)
+        .shortName("no-data-func-test")
+        .version("1.0.0")
+        .source(source)
+        .assembly(mocking.assembly()
+            .name("root")
+            .rootName("root")
+            .flags(List.of(mocking.flag().name("href"))))
+        .toModule();
+
+    IAssemblyDefinition rootDef = module.getAssemblyDefinitions().iterator().next();
+    // Mirrors the shape of the OSCAL external constraint lets that pass a
+    // no-data flag node through a function expecting an atomic type. With
+    // METAPATH_ATOMIZE_NO_DATA_AS_EMPTY enabled by the visitor, argument
+    // atomization yields an empty sequence instead of raising FOTY, so the
+    // chain collapses to an empty result and the let binds to an empty
+    // sequence without warning.
+    rootDef.getConstraintSupport().addLetExpression(
+        ILet.of(
+            IEnhancedQName.of("resolved"),
+            IMetapathExpression.compile("upper-case(@href)"),
+            source,
+            null));
+    rootDef.getConstraintSupport().addConstraint(
+        IAllowedValuesConstraint.builder()
+            .source(source)
+            .target(IMetapathExpression.compile("@href"))
+            .allowedValue(IAllowedValue.of("http://example.com/a", MarkupLine.fromMarkdown("A"), null))
+            .build());
+
+    AllowedValueCollectingNodeItemVisitor visitor = new AllowedValueCollectingNodeItemVisitor();
+    visitor.visit(module);
+
+    assertFalse(capturedAnyMessageContaining("Skipping let expression"),
+        "A let whose function-argument atomization would raise FOTY on a no-data flag"
+            + " must not produce a warning when the visitor enables"
+            + " METAPATH_ATOMIZE_NO_DATA_AS_EMPTY");
+    assertEquals(1, visitor.getAllowedValueLocations().size(),
+        "The allowed-values constraint targeting @href must still be collected");
+  }
+
+  private static final class CapturingAppender
+      extends AbstractAppender {
+    private final List<LogEvent> events = new LinkedList<>();
+
+    CapturingAppender() {
+      super("AvVisitorLogCapture", null, null, false, null);
+    }
+
+    List<LogEvent> getEvents() {
+      return events;
+    }
+
+    @Override
+    public void append(LogEvent event) {
+      synchronized (this) {
+        events.add(event.toImmutable());
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Adds a new `MetapathEvaluationFeature<Boolean>` named `METAPATH_ATOMIZE_NO_DATA_AS_EMPTY` (default off). When enabled on a `DynamicContext`, function argument conversion in `AbstractFunction.convertSequence` catches `InvalidTypeFunctionException` with code `NODE_HAS_NO_TYPED_VALUE` or `DATA_ITEM_IS_FUNCTION` and yields an empty atomic stream instead of propagating the error.

`AllowedValueCollectingNodeItemVisitor` enables the feature on the `DynamicContext` it constructs, alongside the existing `disablePredicateEvaluation()` call.

## Motivation

`list-allowed-values` walks an `IModuleNodeItem` graph, not an instance document. OSCAL external constraints declare lets whose value expressions pass a flag node through `oscal:resolve-reference(@href)` and similar functions that, in instance mode, atomize the flag to a URI. At module walk the flag has no typed value, so atomization raises `FOTY` before the function body runs. The visitor catches the exception and logs it at WARN, producing six warnings on every run.

With this change, the chain `oscal:resolve-reference(@href)` → `fn:resolve-uri(...)` → `fn:doc(...)` → `/component-definition` naturally collapses to an empty sequence, the let binds to empty, and no warning is emitted. Behavior outside of callers that opt in is unchanged.

## Design

Granular behavioral settings that callers compose, matching the existing `METAPATH_EVALUATE_PREDICATES` pattern:

- `MetapathEvaluationFeature.METAPATH_ATOMIZE_NO_DATA_AS_EMPTY` (default `false`).
- `DynamicContext.enableAtomizeNoDataAsEmpty()` / `disableAtomizeNoDataAsEmpty()`.
- `AbstractFunction.convertSequence` checks the feature during function argument atomization and swallows the two relevant `FOTY` codes into an empty stream when on.

Surgical at the argument-conversion call site; no signature change to `IItem.toAtomicItem()` or atomization in other paths.

## Follow-on

The broader model-return-type design for `fn:doc` / `oscal:resolve-reference` / `oscal:resolve-profile` (so `recurse-depth` can resolve an expression to the actual component-definition assembly definition at walk time) remains in #706. This change stops the warning noise today without blocking that work.

## Test plan

- [x] New `testVisitorToleratesNoDataAtomizationInFunctionArgument` asserts no `Skipping let expression` warning fires for a let whose value is a function call (`upper-case(@href)`) on a no-data flag.
- [x] All existing `AllowedValueCollectingNodeItemVisitorTest` tests continue to pass.
- [x] `mvn -pl core -am -o test` passes (pre-existing `CommonmarkConformanceTest` SAX issue reproduces on unmodified `develop`; unrelated).

## Note

Supersedes #707, which attempted lazy let binding via reference scanning. That approach had a scope-correctness bug: metaschema lets are scoped per `<constraints>` block, so two definitions can independently declare lets with the same qualified name. A flat referenced-variables set treats all same-named lets as equivalent, which breaks when an OSCAL author adds an AV that references a name used by multiple definition-level lets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable toggles to let atomization of node items without typed values degrade to empty results instead of throwing, and to toggle this behavior at runtime.

* **Tests**
  * Added and expanded tests to verify toggles, propagation into nested evaluations, and that unrelated type errors still surface.
  * Improved log-capture in a visitor test to assert no unwanted warnings during traversal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->