### PR TITLE
Apply module-walk DynamicContext settings in both visit overloads

### DIFF
--- a/core/src/main/java/dev/metaschema/core/metapath/item/node/AllowedValueCollectingNodeItemVisitor.java
+++ b/core/src/main/java/dev/metaschema/core/metapath/item/node/AllowedValueCollectingNodeItemVisitor.java
@@ -64,11 +64,7 @@ public class AllowedValueCollectingNodeItemVisitor
    * constraints.
    * <p>
    * This method creates a new {@link DynamicContext} configured with the module's
-   * default namespace, with predicate evaluation disabled, and with no-data
-   * atomization treated as empty so that expressions that reach instance-only
-   * functions (for example, {@code fn:doc} via
-   * {@code oscal:resolve-reference(@href)}) degrade to empty sequences rather
-   * than raising {@code InvalidTypeFunctionException} while walking a module.
+   * default namespace.
    *
    * @param module
    *          the Metaschema module to visit
@@ -78,8 +74,6 @@ public class AllowedValueCollectingNodeItemVisitor
         StaticContext.builder()
             .defaultModelNamespace(module.getXmlNamespace())
             .build());
-    context.disablePredicateEvaluation();
-    context.enableAtomizeNoDataAsEmpty();
 
     visit(INodeItemFactory.instance().newModuleNodeItem(module), context);
   }
@@ -87,6 +81,15 @@ public class AllowedValueCollectingNodeItemVisitor
   /**
    * Visit all definitions in the provided module node item using the given
    * dynamic context.
+   * <p>
+   * The provided context is configured for module-definition walking: predicate
+   * evaluation is disabled and no-data atomization is treated as empty. These
+   * settings are applied regardless of their state on the incoming context so
+   * that expressions which reach instance-only functions (for example,
+   * {@code fn:doc} via {@code oscal:resolve-reference(@href)}) degrade to empty
+   * sequences rather than raising {@code InvalidTypeFunctionException} and
+   * predicates on definitional targets do not attempt evaluation that requires
+   * instance data.
    *
    * @param module
    *          the module node item to visit
@@ -94,6 +97,8 @@ public class AllowedValueCollectingNodeItemVisitor
    *          the dynamic context to use for constraint evaluation
    */
   public void visit(@NonNull IModuleNodeItem module, @NonNull DynamicContext context) {
+    context.disablePredicateEvaluation();
+    context.enableAtomizeNoDataAsEmpty();
     visitMetaschema(module, context);
   }
 

--- a/core/src/test/java/dev/metaschema/core/metapath/item/node/AllowedValueCollectingNodeItemVisitorTest.java
+++ b/core/src/test/java/dev/metaschema/core/metapath/item/node/AllowedValueCollectingNodeItemVisitorTest.java
@@ -28,7 +28,9 @@ import java.util.LinkedList;
 import java.util.List;
 
 import dev.metaschema.core.datatype.markup.MarkupLine;
+import dev.metaschema.core.metapath.DynamicContext;
 import dev.metaschema.core.metapath.IMetapathExpression;
+import dev.metaschema.core.metapath.StaticContext;
 import dev.metaschema.core.metapath.item.node.AllowedValueCollectingNodeItemVisitor.AllowedValuesRecord;
 import dev.metaschema.core.metapath.item.node.AllowedValueCollectingNodeItemVisitor.NodeItemRecord;
 import dev.metaschema.core.model.IAssemblyDefinition;
@@ -514,6 +516,60 @@ class AllowedValueCollectingNodeItemVisitorTest {
             + " METAPATH_ATOMIZE_NO_DATA_AS_EMPTY");
     assertEquals(1, visitor.getAllowedValueLocations().size(),
         "The allowed-values constraint targeting @href must still be collected");
+  }
+
+  @Test
+  void testTwoArgVisitOverloadEnablesModuleWalkFeaturesOnCallerContext() {
+    MockedModelTestSupport mocking = new MockedModelTestSupport();
+    ISource source = ISource.externalSource(URI.create(TEST_NAMESPACE));
+
+    IModule module = IModuleBuilder.builder()
+        .namespace(TEST_NAMESPACE)
+        .shortName("two-arg-overload-test")
+        .version("1.0.0")
+        .source(source)
+        .assembly(mocking.assembly()
+            .name("root")
+            .rootName("root")
+            .flags(List.of(mocking.flag().name("href"))))
+        .toModule();
+
+    IAssemblyDefinition rootDef = module.getAssemblyDefinitions().iterator().next();
+    rootDef.getConstraintSupport().addLetExpression(
+        ILet.of(
+            IEnhancedQName.of("resolved"),
+            IMetapathExpression.compile("upper-case(@href)"),
+            source,
+            null));
+    rootDef.getConstraintSupport().addConstraint(
+        IAllowedValuesConstraint.builder()
+            .source(source)
+            .target(IMetapathExpression.compile("@href"))
+            .allowedValue(IAllowedValue.of("http://example.com/a", MarkupLine.fromMarkdown("A"), null))
+            .build());
+
+    // Callers of the two-arg overload (including the existing oscal-cli and
+    // metaschema-cli list-allowed-values commands) supply their own
+    // DynamicContext. The visitor must enable the module-walk features on
+    // that context itself so callers do not need to remember to do it, and
+    // do not observe FOTY warnings on OSCAL-style lets.
+    DynamicContext callerContext = new DynamicContext(
+        StaticContext.builder()
+            .defaultModelNamespace(module.getXmlNamespace())
+            .build());
+
+    AllowedValueCollectingNodeItemVisitor visitor = new AllowedValueCollectingNodeItemVisitor();
+    visitor.visit(INodeItemFactory.instance().newModuleNodeItem(module), callerContext);
+
+    assertFalse(capturedAnyMessageContaining("Skipping let expression"),
+        "The two-arg visit overload must enable METAPATH_ATOMIZE_NO_DATA_AS_EMPTY"
+            + " on the caller-supplied context so no FOTY warning is produced");
+    assertTrue(callerContext.getConfiguration()
+        .isFeatureEnabled(dev.metaschema.core.metapath.MetapathEvaluationFeature.METAPATH_ATOMIZE_NO_DATA_AS_EMPTY),
+        "The two-arg visit overload must enable METAPATH_ATOMIZE_NO_DATA_AS_EMPTY on the caller-supplied context");
+    assertFalse(callerContext.getConfiguration()
+        .isFeatureEnabled(dev.metaschema.core.metapath.MetapathEvaluationFeature.METAPATH_EVALUATE_PREDICATES),
+        "The two-arg visit overload must disable METAPATH_EVALUATE_PREDICATES on the caller-supplied context");
   }
 
   private static final class CapturingAppender

--- a/core/src/test/java/dev/metaschema/core/metapath/item/node/AllowedValueCollectingNodeItemVisitorTest.java
+++ b/core/src/test/java/dev/metaschema/core/metapath/item/node/AllowedValueCollectingNodeItemVisitorTest.java
@@ -557,6 +557,11 @@ class AllowedValueCollectingNodeItemVisitorTest {
         StaticContext.builder()
             .defaultModelNamespace(module.getXmlNamespace())
             .build());
+    // Explicitly set the feature flags to the opposite of their expected
+    // post-visit state. This proves that the two-arg overload actually flips
+    // them rather than relying on DynamicContext construction defaults.
+    callerContext.enablePredicateEvaluation();
+    callerContext.disableAtomizeNoDataAsEmpty();
 
     AllowedValueCollectingNodeItemVisitor visitor = new AllowedValueCollectingNodeItemVisitor();
     visitor.visit(INodeItemFactory.instance().newModuleNodeItem(module), callerContext);


### PR DESCRIPTION
## Summary

After #708 landed, the six FOTY warnings still surfaced on every run of `oscal-cli list-allowed-values` because the tool invokes `AllowedValueCollectingNodeItemVisitor.visit(IModuleNodeItem, DynamicContext)` with a caller-built context. That overload did not enable the new `METAPATH_ATOMIZE_NO_DATA_AS_EMPTY` feature; only the convenience `visit(IModule)` overload did.

This change moves `disablePredicateEvaluation()` and `enableAtomizeNoDataAsEmpty()` into the shared two-argument overload. Both overloads now guarantee the visitor's required evaluation context, so callers that build their own `DynamicContext` (metaschema-cli's and oscal-cli's `ListAllowedValuesCommand`) do not need to be updated or remember the configuration invariants.

## Test plan

- [x] New `testTwoArgVisitOverloadEnablesModuleWalkFeaturesOnCallerContext` constructs a bare `DynamicContext`, calls the two-argument overload, and asserts (a) no `Skipping let expression` warning is emitted when the let uses a function on a no-data flag, (b) the feature flag is set on the caller context, and (c) predicate evaluation is disabled on the caller context.
- [x] All existing `AllowedValueCollectingNodeItemVisitorTest` tests continue to pass (11 total).
- [x] `mvn -pl core -am -o test` passes (pre-existing unrelated `CommonmarkConformanceTest` SAX issue reproduces on unmodified `develop`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure module-definition walking forces the correct evaluation flags on the runtime context so allowed-values constraint checks behave consistently and avoid spurious warnings or invalid-type issues.
* **Tests**
  * Added a unit test that validates the visitor enforces those context flags when callers supply their own runtime context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->