### PR TITLE
ci: fix scheduled-build permissions and expose workflow_dispatch inputs

### DIFF
--- a/.github/workflows/scheduled-build.yml
+++ b/.github/workflows/scheduled-build.yml
@@ -4,6 +4,22 @@ on:
     # Nightly build at 2:00 AM UTC
     - cron: '0 2 * * *'
   workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to checkout (branch, tag, or SHA)'
+        required: false
+        default: 'develop'
+        type: string
+      skip_code_scans:
+        description: 'Skip CodeQL and Trivy security scans'
+        required: false
+        default: true
+        type: boolean
+      skip_linkcheck:
+        description: 'Skip website link checker'
+        required: false
+        default: true
+        type: boolean
 jobs:
   nightly:
     permissions:
@@ -15,7 +31,7 @@ jobs:
       id-token: write
     uses: ./.github/workflows/build.yml
     with:
-      ref: develop
-      skip_code_scans: true
-      skip_linkcheck: true
+      ref: ${{ inputs.ref || 'develop' }}
+      skip_code_scans: ${{ github.event_name == 'schedule' || inputs.skip_code_scans }}
+      skip_linkcheck: ${{ github.event_name == 'schedule' || inputs.skip_linkcheck }}
     secrets: inherit

--- a/.github/workflows/scheduled-build.yml
+++ b/.github/workflows/scheduled-build.yml
@@ -6,6 +6,13 @@ on:
   workflow_dispatch:
 jobs:
   nightly:
+    permissions:
+      actions: read
+      contents: write
+      security-events: write
+      packages: write
+      attestations: write
+      id-token: write
     uses: ./.github/workflows/build.yml
     with:
       ref: develop


### PR DESCRIPTION
## Summary

Fixes the Scheduled Build workflow, which currently fails with a permission-validation error, and adds the ability to override its inputs when triggering it manually.

### 1. Declare permissions on the caller job

`scheduled-build.yml` calls `build.yml` as a reusable workflow but declared no permissions at the caller level, so GitHub rejected it:

> The nested job 'build-code' is requesting 'actions: read, security-events: write', but is only allowed 'actions: none, security-events: none'.
> The nested job 'build-container' is requesting 'attestations: write, packages: write, id-token: write', but is only allowed 'attestations: none, packages: read, id-token: none'.

The fix grants the union of permissions that the nested jobs in `build.yml` request (build-code, build-container, build-website). This is required even though `skip_code_scans: true` skips the CodeQL/Trivy steps at runtime, because GitHub validates job-level permission declarations statically against the caller.

### 2. Expose inputs to workflow_dispatch

`ref`, `skip_code_scans`, and `skip_linkcheck` are now declared as workflow_dispatch inputs with defaults matching the previous hardcoded values. Scheduled runs continue to behave identically; manual runs can override.

The boolean inputs use `github.event_name == 'schedule' || inputs.X` rather than a simple `|| true` fallback so that a user-supplied `false` at dispatch is honored (a plain `||` fallback would clobber a user-supplied `false` because `false` is falsy in expressions).

## Test plan

- [ ] Confirm the workflow file parses (no more invalid-workflow error)
- [ ] Trigger via workflow_dispatch with defaults — should behave like the nightly schedule
- [ ] Trigger via workflow_dispatch with `skip_code_scans: false` — should run CodeQL and Trivy
- [ ] Trigger via workflow_dispatch with `ref: main` — should check out main instead of develop
- [ ] Wait for the next nightly schedule (or manually trigger) and confirm it completes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Scheduled build workflow now supports manual triggering with configurable parameters for branch selection and scan preferences.
  * Updated build job permissions to enable security event logging and package attestations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/metaschema-framework/metaschema-java/pull/722)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->